### PR TITLE
Include links to volunteering information in about page.

### DIFF
--- a/www/includes/easyparliament/staticpages/about.php
+++ b/www/includes/easyparliament/staticpages/about.php
@@ -13,7 +13,7 @@ little wrong with Parliament that a healthy mixture of transparency and public e
 which is itself a project of UK Citizens Online Democracy, a registered charity.
 It was originally built almost entirely by volunteers (see <a href="#history">History</a> below),
 but now mySociety pays Matthew to keep the site running and up-to-date as part of his
-wider work for mySociety. However, things are still added voluntarily by anyone who wishes.
+wider work for mySociety. However, things are still added voluntarily by anyone who wishes. If you want to volunteer to help then you can, just <a href="http://www.mysociety.org/helpus/volunteering-for-theyworkforyou/">take a look at the Volunteering page</a>.
 </p>
 
 <p>The copyright of Hansard remains under
@@ -22,7 +22,7 @@ used under licence.
 
 <p>If you're technically minded, we make all the
 <a href="http://github.com/mysociety/theyworkforyou">TheyWorkForYou source code</a>
-freely available. Do let us know if you want to help!
+freely available. Do <a href="http://www.mysociety.org/helpus/volunteering-for-theyworkforyou/">let us know if you want to help</a>!
 </p>
 
 
@@ -49,7 +49,7 @@ href="https://secure.mysociety.org/donate/">make a donation</a> yourself.)</p>
 <a href="http://www.mysociety.org/">MySociety</a>,  and an accessible re-versioning of the
 <a href="http://www.traintimes.org.uk/">National Rail Timetable</a> website.
 They conceived and developed the original <a href="http://www.upmystreet.com/">UpMyStreet.com</a>
-back in <a href="http://web.archive.org/web/19981202165125/http://www.upmystreet.com/">1998</a>. 
+back in <a href="http://web.archive.org/web/19981202165125/http://www.upmystreet.com/">1998</a>.
 </p>
 
 <p>In early 2006 Tom and Stef decided that the overlap of people and goals with mySociety
@@ -57,7 +57,7 @@ was so substantial that it was best to pass the running over to mySociety, who a
 proper organisation with staff and time.</p>
 
 <p>Matthew added the Northern Ireland Assembly as an early Christmas present in 2006, working
-alone and voluntarily, perhaps as a nudge to the Scots and the Welsh to come forward and 
+alone and voluntarily, perhaps as a nudge to the Scots and the Welsh to come forward and
 work on their own versions. :)</p>
 
 <p>This approach met with success as ace volunteer <a href="http://longair.net/mark/">Mark


### PR DESCRIPTION
- Closes #133

Add link and small amount of text to About page, sending users interested in volunteering to the mySociety "Volunteering for TheyWorkForYou" page.
