### PR TITLE
Convert non-ASCII characters in speaker names to HTML entities

### DIFF
--- a/scripts/xml2db.pl
+++ b/scripts/xml2db.pl
@@ -31,6 +31,7 @@ my $parldata = mySociety::Config::get('RAWDATA');
 my $lastupdatedir = mySociety::Config::get('INCLUDESPATH') . "../../../xml2db/";
 
 use DBI; 
+use HTML::Entities;
 use XML::Twig;
 use File::Find;
 use Getopt::Long;
@@ -2050,7 +2051,9 @@ sub do_load_speech
                 if ($speaker eq "unknown")
                 {
                         $speaker = 0;
-                        $pretext = '<p class="unknownspeaker">' . $speech->att('speakername') . ':</p> ';
+                        my $encoded = HTML::Entities::encode_entities(
+                                $speech->att('speakername'));
+                        $pretext = '<p class="unknownspeaker">' . $encoded . ':</p> ';
                 }
         }
         else


### PR DESCRIPTION
In the latest Scottish Parliament data there are speaker names that
contain curly apostrophes, em dashes and other non-ASCII characters.
This commit makes sure that they are converted to HTML entities in the
output.  (This isn't required for the text of speeches since they are
emitted with Twig's sprint, which uses the output filter.)
