### PR TITLE
Fix hansard_gid template for PHP5.4 compatibility.

### DIFF
--- a/www/includes/easyparliament/templates/html/hansard_gid.php
+++ b/www/includes/easyparliament/templates/html/hansard_gid.php
@@ -196,8 +196,8 @@ if (isset ($data['rows'])) {
 			
 			context_link($row);
 			$action_links = array( 'Link to this: <a href="' . $row['commentsurl'] . '" class="link">Individually</a> | <a href="' . $row['listurl'] . '">In context</a>' );
-			$sidebarhtml = generate_commentteaser(&$row, $data['info']['major'], $action_links);
 			
+			$sidebarhtml = generate_commentteaser($row, $data['info']['major'], $action_links);
 			$PAGE->stripe_end(array(
 				array (
 					'type' => 'html',
@@ -440,7 +440,7 @@ if (isset ($data['rows'])) {
 # Do the logic for this in the function; plus why shouldn't
 # you be able to comment on speeches with unknown speakers?
 #			if (($hansardmajors[$data['info']['major']]['type'] == 'debate') && isset($row['speaker']) && count($row['speaker']) > 0) {
-			$sidebarhtml .= generate_commentteaser(&$row, $data['info']['major'], $action_links);
+			$sidebarhtml .= generate_commentteaser($row, $data['info']['major'], $action_links);
 #			}
 			
 			if (isset($row['mentions'])) {


### PR DESCRIPTION
- Closes #364

PHP5.4 removes the ability to pass by reference at call time. Warnings have been generated for a while, but 5.4 is the first version to make it a fatal error.

The generate_commentteaser() function declaration already handles referencing, hence no change is required to the function declaration itself.

See http://stackoverflow.com/questions/8971261/php-5-4-call-time-pass-by-reference-easy-fix-available.
