### PR TITLE
Implement 7 second engagement timers

### DIFF
--- a/www/includes/easyparliament/newpage.php
+++ b/www/includes/easyparliament/newpage.php
@@ -1159,6 +1159,13 @@ pr()//-->
 
 <script>
   $(document).foundation();
+  $(function() {
+    setTimeout(function() {
+      try {
+        ga('send', 'event', 'engagement', 'timer', '7');
+      } catch(err){}
+    }, 7000);
+  });
 </script>
 </body>
 <?php

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -1199,6 +1199,13 @@ pr()//-->
 
 <script type="text/javascript" charset="utf-8">
     barSetup();
+    $(function() {
+    setTimeout(function() {
+      try {
+        ga('send', 'event', 'engagement', 'timer', '7');
+      } catch(err){}
+    }, 7000);
+  });
 </script>
 
 </body>


### PR DESCRIPTION
In line with GDS, implement timers to record a GA event when a person has been observing a page for 7 seconds.
