### PR TITLE
Reinstate note on MP pages about citing TWFY

### DIFF
--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -297,6 +297,13 @@ you can find it.</p>
                     </div>
                     <?php endif; ?>
 
+                    <div class="panel">
+                        <p>Please feel free to use the data on this page, but if
+                            you do you must cite TheyWorkForYou.com in the body
+                            of your articles as the source of any analysis or
+                            data you get off this site.</p>
+                    </div>
+
                 </div>
             </div>
         </div>

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -125,6 +125,13 @@
 
                     <?php endif; ?>
 
+                    <div class="panel">
+                        <p>Please feel free to use the data on this page, but if
+                            you do you must cite TheyWorkForYou.com in the body
+                            of your articles as the source of any analysis or
+                            data you get off this site.</p>
+                    </div>
+
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Also removed the journalist-specific bit, as this should also apply to all citations (eg academic).
- Closes #448.

<!---
@huboard:{"order":14.03125}
-->
