### PR TITLE
Escape dollars in replacement strings in email templates

### DIFF
--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Testing for some functions in utility.php
+ */
+
+class UtilityTest extends PHPUnit_Framework_TestCase
+{
+	public function setUp()
+	{
+        parent::setUp();
+        include_once('www/includes/utility.php');
+    }
+
+    /**
+     * Test the escaping of replacement strings for use with
+     * preg_replace.
+     */
+	public function testPregReplacement()
+    {
+        $example = 'try \1 and $0, also backslash \ and dollar $ alone';
+        $this->assertEquals(
+            'try \\\\1 and \$0, also backslash \ and dollar $ alone',
+            preg_replacement_quote($example)
+        );
+    }
+}

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -634,6 +634,14 @@ function gid_to_anchor($gid) {
     return substr( $gid, (strpos($gid, '.') + 1) );
 }
 
+function preg_replacement_quote($s) {
+    // This returns $s but with every $ and \ backslash-escaped.
+    // This is to create a string that can be safely used in a
+    // preg_replace replacement string.  This function was suggested here:
+    // http://www.procata.com/blog/archives/2005/11/13/two-preg_replace-escaping-gotchas/
+    return preg_replace('/(\$|\\\\)(?=\d)/', '\\\\\1', $s);
+}
+
 function send_template_email($data, $merge, $bulk = false, $want_bounces = false) {
     // We should have some email templates in INCLUDESPATH/easyparliament/templates/emails/.
 
@@ -711,7 +719,7 @@ function send_template_email($data, $merge, $bulk = false, $want_bounces = false
 
     foreach ($merge as $key => $val) {
         $search[] = '/{'.$key.'}/';
-        $replace[] = $val;
+        $replace[] = preg_replacement_quote($val);
     }
 
     $emailtext = preg_replace($search, $replace, $emailtext);


### PR DESCRIPTION
Fixes #499, as suggested by Matthew Somerville

I've added a simple test for the utility function; ideally, however, there
should be a test that generating the email text (i.e. the caller of this
code) works correctly.  To do that I'd refactor send_template_email to
separate the generation of the email text from the sending, so that those
can be tested separately.  However, this is just a quick fix on a busy day
when I'm meant to be working on other things...

<!---
@huboard:{"order":228.0,"custom_state":""}
-->
