### PR TITLE
Reinstate photo attribution on MP pages

### DIFF
--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -450,7 +450,12 @@ try {
         $data['user_postcode'] = $THEUSER->postcode;
         $data['houses'] = $MEMBER->houses();
         $data['member_url'] = $MEMBER->url();
-
+        // If there's photo attribution information, copy it into data
+        foreach (['photo_attribution_text', 'photo_attribution_link'] as $key) {
+            if (isset($MEMBER->extra_info[$key])) {
+                $data[$key] = $MEMBER->extra_info[$key];
+            }
+        }
         $data['image'] = person_image($MEMBER);
         $data['member_summary'] = person_summary_description($MEMBER);
         $data['rebellion_rate'] = person_rebellion_rate($MEMBER);

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -81,6 +81,26 @@
             }
         }
 
+        .person-data-attribution {
+          margin: 0.5em 0 0 0;
+          font-size: 0.7em;
+          color: rgba(255,255,255,0.7);
+
+          @media (min-width: $large-screen) {
+            position: absolute;
+            bottom: 0;
+            margin-top: 0;
+          }
+
+          a {
+            color: inherit;
+
+            &:hover, &:focus {
+              color: #fff;
+            }
+          }
+        }
+
         .person-search {
             @media (min-width: $medium-screen) {
                 position: absolute;
@@ -221,6 +241,11 @@
     }
 
     @media (min-width: $large-screen) {
+        &.has-data-attribution .person-header__content {
+          margin-bottom: 2em;
+          margin-top: -1em;
+        }
+
         // Special case for the Queen, bless her
         &.royal {
             .person-header__content .person-name {

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -1,5 +1,5 @@
     <div class="<?= $current_assembly ?>">
-        <div class="person-header <?= $this_page ?>">
+        <div class="person-header <?= $this_page ?> <?= (isset($data['photo_attribution_text'])?'has-data-attribution':'') ?>">
             <div class=" full-page__row">
             <div class="person-header__content page-content__row">
                 <div class="person-name">
@@ -17,6 +17,15 @@
                       <?php } ?>
                     </div>
                 </div>
+              <?php if(isset($data['photo_attribution_text'])) { ?>
+                <div class="person-data-attribution">
+                  <?php if(isset($data['photo_attribution_link'])) { ?>
+                    Profile photo: <a href="<?= $data['photo_attribution_link'] ?>"><?= $data['photo_attribution_text'] ?></a>
+                  <?php } else { ?>
+                    Profile photo: <?= $data['photo_attribution_text'] ?>
+                  <?php } ?>
+                </div>
+              <?php } ?>
                 <div class="person-constituency">
                   <?php if ( $constituency && $this_page != 'peer' && $this_page != 'royal' ) { ?>
                     <span class="constituency"><?= $constituency ?></span>


### PR DESCRIPTION
Closes https://github.com/mysociety/theyworkforyou/issues/594.

![screen shot 2014-07-21 at 12 18 17](https://cloud.githubusercontent.com/assets/739624/3642852/cf82fdfa-10c8-11e4-9744-e55d8a994c78.png)

I couldn't work out how to get the photo attribution text and links for a given member, so I've stubbed it out temporarily:

``` php
// Replace this with some code that actually
// checks for a photo attribution in $MEMBER.
$data['photo_attribution_text'] = 'Crown copyright, used under the Open Government Licence';
$data['photo_attribution_link'] = 'https://www.mysociety.org/horse';
```

This is good to go as soon as a developer has time to get the actual photo attribution text out of the model for a given person.
