### PR TITLE
Don't set the Cache-Control header on dev sites

### DIFF
--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -307,7 +307,9 @@ try {
     /////////////////////////////////////////////////////////
     // DISPLAY A LIST OF REPRESENTATIVES
 
-    header('Cache-Control: max-age=900');
+    if (!DEVSITE) {
+        header('Cache-Control: max-age=900');
+    }
 
     if (isset($MEMBER) && is_array($MEMBER->person_id())) {
 

--- a/www/docs/regmem/index.php
+++ b/www/docs/regmem/index.php
@@ -11,7 +11,9 @@ while ($file = readdir($dh)) {
 }
 rsort($files);
 
-header('Cache-Control: max-age=3600');
+if (!DEVSITE) {
+   header('Cache-Control: max-age=3600');
+}
 
 $PAGE->page_start();
 ?>

--- a/www/docs/search/index.php
+++ b/www/docs/search/index.php
@@ -8,7 +8,9 @@ include_once INCLUDESPATH."easyparliament/glossary.php";
 // From http://cvs.sourceforge.net/viewcvs.py/publicwhip/publicwhip/website/
 include_once INCLUDESPATH."postcode.inc";
 
-header('Cache-Control: max-age=900');
+if (!DEVSITE) {
+    header('Cache-Control: max-age=900');
+}
 
 if (get_http_var('pid') == 16407) {
     header('Location: /search/?pid=10133');

--- a/www/docs/search/rss/index.php
+++ b/www/docs/search/rss/index.php
@@ -8,7 +8,9 @@ include_once INCLUDESPATH."easyparliament/glossary.php";
 // From http://cvs.sourceforge.net/viewcvs.py/publicwhip/publicwhip/website/
 include_once INCLUDESPATH."postcode.inc";
 
-header('Cache-Control: max-age=86400'); # Once a day
+if (!DEVSITE) {
+    header('Cache-Control: max-age=86400'); # Once a day
+}
 
 if (get_http_var('s') != '' or get_http_var('maj') != '' or get_http_var('pid') != '') {
 

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -191,7 +191,9 @@ class PAGE {
             header('Content-Type: text/html; charset=iso-8859-1');
             if ($this_page == 'overview') {
                 header('Vary: Cookie, X-GeoIP-Country');
-                header('Cache-Control: max-age=600');
+                if (!DEVSITE) {
+                    header('Cache-Control: max-age=600');
+                }
             }
         }
 


### PR DESCRIPTION
Varnish observes the Cache-Control headers on our development server,
which is frustrating when you're actively changing the source and can't
see the changes when you reload the page.

This commit makes sure that TheyWorkForYou only emits Cache-Control
headers when DEVSITE is falsy.
