### PR TITLE
Add mailing address to automated alert mailings.

### DIFF
--- a/www/includes/easyparliament/templates/emails/alert_gone.txt
+++ b/www/includes/easyparliament/templates/emails/alert_gone.txt
@@ -19,6 +19,12 @@ alerts you no longer want. Simply visit this URL:
 Best wishes,
 TheyWorkForYou
 
+mySociety Ltd,
+483 Green Lanes,
+London,
+N13 4BS,
+United Kingdom
+
 -------------------------------------------------------------------
 TheyWorkForYou email alerts need love and support to look
 after. Please consider donating to mySociety to help us

--- a/www/includes/easyparliament/templates/emails/alert_mailout.txt
+++ b/www/includes/easyparliament/templates/emails/alert_mailout.txt
@@ -9,6 +9,12 @@ or 'return' on your keyboard.
 Best wishes,
 TheyWorkForYou
 
+mySociety Ltd,
+483 Green Lanes,
+London,
+N13 4BS,
+United Kingdom
+
 -------------------------------------------------------------------
 TheyWorkForYou email alerts need love and support to look
 after. Please consider donating to mySociety to help us


### PR DESCRIPTION
Closes #640

As per discussion on #640, add our physical mailing address to automated
outgoing alert emails (ie those which just happen, and are not explicitly
initiated by a user).
