### PR TITLE
Replace mailman signup forms with Mailchimp signup forms

### DIFF
--- a/www/docs/js/bar.js
+++ b/www/docs/js/bar.js
@@ -63,7 +63,7 @@ function barSetup(){
 
     var oNewsletterForm = document.createElement('li');
     oNewsletterForm.className = "bordernodivider";
-    oNewsletterForm.innerHTML = '<form method="post" action="http://mysociety.us9.list-manage.com/subscribe/post?u=53d0d2026dea615ed488a8834&id=287dc28511"><input type="email" placeholder="Your email address" class="textbox nodivider" name="EMAIL" id="txtBarEmail"/><div style="position: absolute; left: -5000px;"><input type="text" name="b_53d0d2026dea615ed488a8834_287dc28511" tabindex="-1" value="" /></div><input type="submit" value="Subscribe" name="subscribe"/></form>';
+    oNewsletterForm.innerHTML = '  <form method="post" action="//mysociety.us9.list-manage.com/subscribe/post?u=53d0d2026dea615ed488a8834&id=287dc28511"><input type="email" placeholder="Your email address" class="textbox nodivider" name="EMAIL" id="txtBarEmail"/><div style="position: absolute; left: -5000px;"><input type="text" name="b_53d0d2026dea615ed488a8834_287dc28511" tabindex="-1" value="" /></div><input type="submit" value="Subscribe" name="subscribe"/></form>';
     oMenu.appendChild(oNewsletterForm);
 
     // add class to first menu item

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -1159,7 +1159,7 @@ window.fbAsyncInit = function () {
                   If you find it useful, please <a href="http://www.mysociety.org/donate/">donate</a> to keep it running.
                       </p>
                       <h5>Sign up to our newsletter</h5>
-                      <form method="post" action="http://mysociety.us9.list-manage.com/subscribe/post?u=53d0d2026dea615ed488a8834&id=287dc28511">
+                        <form method="post" action="//mysociety.us9.list-manage.com/subscribe/post?u=53d0d2026dea615ed488a8834&id=287dc28511">
                           <input type="email" placeholder="Your email address" name="EMAIL"/>
                           <label style="position: absolute; left: -5000px;">
                               Leave this box empty: <input type="text" name="b_53d0d2026dea615ed488a8834_287dc28511" tabindex="-1" value="" />

--- a/www/includes/easyparliament/sidebars/mysociety_news.php
+++ b/www/includes/easyparliament/sidebars/mysociety_news.php
@@ -2,7 +2,7 @@
 $this->block_start(array('id'=>'help', 'title'=>"mySociety news updates"));
 ?>
 
-<form method="post" action="http://mysociety.us9.list-manage.com/subscribe/post?u=53d0d2026dea615ed488a8834&id=287dc28511">
+  <form method="post" action="//mysociety.us9.list-manage.com/subscribe/post?u=53d0d2026dea615ed488a8834&id=287dc28511">
 <label for="txtEmail">mySociety, which runs TheyWorkForYou, has a monthly
 news email list, full of titbits and stories. Enter your email address below to
 subscribe:</label>

--- a/www/includes/easyparliament/templates/html/footer.php
+++ b/www/includes/easyparliament/templates/html/footer.php
@@ -22,7 +22,7 @@
                         <div class="row">
                             <div class="footer_follow__column columns">
                               <p>Sign up to our monthly newsletter</p>
-                              <form method="post" action="http://mysociety.us9.list-manage.com/subscribe/post?u=53d0d2026dea615ed488a8834&id=287dc28511">
+                                <form method="post" action="//mysociety.us9.list-manage.com/subscribe/post?u=53d0d2026dea615ed488a8834&id=287dc28511">
                                 <input type="email" placeholder="Your email address" name="EMAIL"/>
                                 <label style="position: absolute; left: -5000px;">
                                   Leave this box empty: <input type="text" name="b_53d0d2026dea615ed488a8834_287dc28511" tabindex="-1" value="" />


### PR DESCRIPTION
Closes #667.

Uses the embedded form code supplied by Mailchimp.

<!---
@huboard:{"order":685.0,"milestone_order":685,"custom_state":""}
-->
