### PR TITLE
Ignore additional structural tags in regmem XML

### DIFF
--- a/scripts/mpinfoin.pl
+++ b/scripts/mpinfoin.pl
@@ -383,8 +383,7 @@ sub loadregmeminfo
                 $htmlcontent .= '<div class="regmemcategory">';
                 $htmlcontent .= $category->att("type") . ". " . $category->att("name");
                 $htmlcontent .= "</div>\n";
-                for (my $item = $category->first_child('item'); $item;
-                        $item = $item->next_sibling('item'))
+                foreach my $item ($category->descendants('item'))
                 {
                         $htmlcontent .= '<div class="regmemitem">';
                         if ($item->att("subcategory"))


### PR DESCRIPTION
This update will parse the regmem XML structure currently output by parlparse, as well as the modified structure proposed in mysociety/parlparse#10.