### PR TITLE
retain search term over multiple redirects

### DIFF
--- a/classes/SectionView/SectionView.php
+++ b/classes/SectionView/SectionView.php
@@ -97,6 +97,11 @@ class SectionView {
             } else {
                 $URL->insert( array('id'=>$e->getMessage()) );
             }
+            # put the search term back in so highlighting works.
+            # NB: as we don't see the # part of the URL we lose this :(
+            if ( $args['s'] !== '' ) {
+                $URL->insert( array('s'=>$args['s']) );
+            }
             redirect($URL->generate('none'));
         }
 


### PR DESCRIPTION
if the link from the search page, or more realistically an email goes
through more than one level of redirect then the search term is lost
from it. Check if it's present and add it back in to the redirect.

Note that we will always lose and anchor part of the URL in this process
as that's all dealt with purely client side and never supplied to the
server.

Fixes #754