### PR TITLE
Banner for new style pages plus move content into database

### DIFF
--- a/classes/Memcache.php
+++ b/classes/Memcache.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * Memcache wrapper
+ *
+ * @package TheyWorkForYou
+ */
+
+namespace MySociety\TheyWorkForYou;
+
+class Memcache {
+
+    static $memcache;
+
+    public function __construct() {
+        if (!self::$memcache) {
+            self::$memcache = new \Memcache;
+            self::$memcache->connect('localhost', 11211);
+        }
+    }
+
+    public function set($key, $value, $timeout = 3600) {
+        self::$memcache->set(OPTION_TWFY_DB_NAME . ':' . $key, $value, MEMCACHE_COMPRESSED, $timeout);
+    }
+
+    public function get($key) {
+        // see http://php.net/manual/en/memcache.get.php#112056 for explanation of this
+        $was_found = false;
+        $value = self::$memcache->get(OPTION_TWFY_DB_NAME . ':' . $key, $was_found);
+        if ( $was_found === false ) {
+            return false; // mmmmm
+        } else {
+            return $value;
+        }
+    }
+}

--- a/classes/Model/Banner.php
+++ b/classes/Model/Banner.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Banner Model
+ *
+ * @package TheyWorkForYou
+ */
+
+namespace MySociety\TheyWorkForYou\Model;
+
+class Banner {
+
+    /**
+     * DB handle
+     */
+    private $db;
+
+    /*
+     * Memcache handle
+     */
+    private $mem;
+
+    /**
+     * Constructor
+     *
+     * @param Member   $member   The member to get positions for.
+     */
+
+    public function __construct()
+    {
+        $this->db = new \ParlDB;
+        $this->mem = new \MySociety\TheyWorkForYou\Memcache();
+    }
+
+    public function get_text() {
+        $text = NULL;
+        $text = $this->mem->get('banner');
+
+        if ( $text === false ) {
+            $q = $this->db->query("SELECT value FROM editorial WHERE item = 'banner'");
+
+            if ($q->rows) {
+                $text = $q->field(0, 'value');
+                if ( trim($text) == '' ) {
+                    $text = NULL;
+                }
+                $this->mem->set('banner', $text, 86400);
+            }
+        }
+
+        return $text;
+    }
+
+    public function set_text($text) {
+        $q = $this->db->query("UPDATE editorial set value = :banner_text WHERE item = 'banner'",
+            array(
+                ':banner_text' => $text
+            )
+        );
+
+        if ( $q->success() ) {
+            if ( trim($text) == '' ) {
+                $text = NULL;
+            }
+            $this->mem->set('banner', $text, 86400);
+            return true;
+        }
+        return false;
+    }
+}

--- a/classes/Renderer.php
+++ b/classes/Renderer.php
@@ -422,6 +422,10 @@ class Renderer
         $data['footer_links']['international'] = self::get_menu_links(array ('newzealand', 'australia', 'ireland', 'mzalendo'));
         $data['footer_links']['tech'] = self::get_menu_links(array ('code', 'api', 'data', 'pombola', 'devmailinglist', 'irc'));
 
+        # banner text
+        $b = new Model\Banner;
+        $data['banner_text'] = $b->get_text();
+
         # Robots header
         if (DEVSITE) {
             $data['robots'] = 'noindex,nofollow';

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -479,3 +479,12 @@ CREATE TABLE `tokens` (
     PRIMARY KEY (`token`)
 );
 
+-- For things like banners, front page highlighting etc --
+
+CREATE TABLE `editorial` (
+    `item` varchar(50) NOT NULL,
+    `value` text,
+    KEY `item` (`item`)
+);
+
+

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -69,4 +69,19 @@ class PageTest extends FetchPageTestCase
         $this->assertContains('<span class="party SPK">Speaker</span>', $page);
     }
 
+    public function testBanner() {
+        $banner = new MySociety\TheyWorkForYou\Model\Banner;
+
+        $page = $this->fetch_page( array( 'url' => '/' ) );
+        $this->assertNotContains('This is a banner', $page);
+
+        $banner->set_text('This is a banner');
+        $page = $this->fetch_page( array( 'url' => '/' ) );
+        $this->assertContains('This is a banner', $page);
+
+        $banner->set_text('');
+        $page = $this->fetch_page( array( 'url' => '/' ) );
+        $this->assertNotContains('This is a banner', $page);
+    }
+
 }

--- a/tests/_fixtures/member.xml
+++ b/tests/_fixtures/member.xml
@@ -349,5 +349,7 @@
 	</table_data>
 	<table_data name="video_timestamps">
 	</table_data>
+	<table_data name="editorial">
+	</table_data>
 </database>
 </mysqldump>

--- a/www/docs/admin/banner.php
+++ b/www/docs/admin/banner.php
@@ -1,0 +1,84 @@
+<?php
+
+include_once '../../includes/easyparliament/init.php';
+
+$this_page = 'admin_banner';
+
+$db = new ParlDB;
+$banner = new MySociety\TheyWorkForYou\Model\Banner;
+
+$PAGE->page_start();
+$PAGE->stripe_start();
+
+$out = '';
+if (get_http_var('action') === 'Save') {
+    $out = update_banner();
+}
+
+$out .= edit_banner_form();
+
+print '<div id="adminbody">';
+print $out;
+?>
+<script>
+    $('#preview').on('click', function bannerPreview() {
+        var text = $('#banner_text').val();
+        if ( text ) {
+            var banner_el = $('#surveyPromoBanner');
+            var fadeDelay = 1000;
+            if ( !banner_el.length ) {
+                fadeDelay = 0;
+                banner_el = $('<div id="surveyPromoBanner" style="clear:both;padding:1em;margin-top:24px;background:#DDD;">&nbsp;</div>');
+                $('body').prepend(banner_el);
+            }
+            banner_el.fadeOut(fadeDelay, function updateBannerText() {
+                banner_el.html($('#banner_text').val());
+                banner_el.fadeIn(1000);
+            });
+        } else {
+            banner_el = $('#surveyPromoBanner').remove();
+        }
+    });
+</script>
+<?php
+print '</div>';
+
+function edit_banner_form() {
+    global $banner;
+    $text = $banner->get_text();
+
+    $out = '<form action="banner.php" method="post">';
+    $out .= '<input name="action" type="hidden" value="Save">';
+    $out .= '<p><label for="banner">Contents (HTML permitted)</label><br>';
+    $out .= '<textarea id="banner_text" name="banner" rows="5" cols="80">' . htmlentities($text) . "</textarea></p>\n";
+    $out .= '<span class="formw"><input type="button" id="preview" value="Preview"> <input name="btnaction" type="submit" value="Save"></span>';
+    $out .= '</form>';
+
+    return $out;
+}
+
+function update_banner() {
+    global $banner;
+    $out = '';
+    $banner_text = get_http_var('banner');
+
+    if ( $banner->set_text($banner_text) ) {
+        $out = "<h4>update successful</h4>";
+        $out = "<p>Banner text is now:</p><p>$banner_text</p>";
+    } else {
+        $out = "<h4>Failed to update banner text</h4>";
+    }
+
+    return $out;
+}
+
+$menu = $PAGE->admin_menu();
+
+$PAGE->stripe_end(array(
+    array(
+        'type'    => 'html',
+        'content' => $menu
+    )
+));
+
+$PAGE->page_end();

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -822,12 +822,8 @@ function person_recent_appearances($member) {
 
     $person_id= $member->person_id();
 
-    global $memcache;
-    if (!$memcache) {
-        $memcache = new Memcache;
-        $memcache->connect('localhost', 11211);
-    }
-    //$recent = $memcache->get(OPTION_TWFY_DB_NAME . ':recent_appear:' . $person_id);
+    $memcache = new MySociety\TheyWorkForYou\Memcache;
+    $recent = $memcache->get('recent_appear:' . $person_id);
     $recent = false;
 
     if (!$recent) {
@@ -845,7 +841,7 @@ function person_recent_appearances($member) {
         );
         $results = $hansard->search($searchstring, $args);
         $recent = serialize($results['rows']);
-        $memcache->set(OPTION_TWFY_DB_NAME . ':recent_appear:' . $person_id, $recent, MEMCACHE_COMPRESSED, 3600);
+        $memcache->set('recent_appear:' . $person_id, $recent);
     }
     $out['appearances'] = unserialize($recent);
     twfy_debug_timestamp();

--- a/www/docs/style/sass/layout/_header.scss
+++ b/www/docs/style/sass/layout/_header.scss
@@ -380,3 +380,15 @@
         }
     }
 }
+
+.banner {
+    background-color: white;
+    border-top: 1px solid $borders;
+
+    .banner__content {
+        color: rgb(155, 56, 149);
+        font-size: em-calc(25);
+        padding: 0.75em 0.75em;
+        text-align: center;
+    }
+}

--- a/www/includes/easyparliament/member.php
+++ b/www/includes/easyparliament/member.php
@@ -378,12 +378,8 @@ class MEMBER {
     // Grabs extra information (e.g. external links) from the database
     # DISPLAY is whether it's to be displayed on MP page.
     public function load_extra_info($display = false) {
-        global $memcache;
-        if (!$memcache) {
-            $memcache = new Memcache;
-            $memcache->connect('localhost', 11211);
-        }
-        $memcache_key = OPTION_TWFY_DB_NAME . ':extra_info:' . $this->person_id . ($display ? '' : ':plain');
+        $memcache = new MySociety\TheyWorkForYou\Memcache;
+        $memcache_key = 'extra_info:' . $this->person_id . ($display ? '' : ':plain');
         $this->extra_info = $memcache->get($memcache_key);
         if (!DEVSITE && $this->extra_info) {
             return;
@@ -494,7 +490,7 @@ class MEMBER {
             );
         }
 
-        $memcache->set($memcache_key, $this->extra_info, MEMCACHE_COMPRESSED, 3600);
+        $memcache->set($memcache_key, $this->extra_info);
     }
 
     // Functions for accessing things about this Member.

--- a/www/includes/easyparliament/metadata.php
+++ b/www/includes/easyparliament/metadata.php
@@ -181,6 +181,11 @@ $this->page = array (
         'parent'		=> 'admin',
         'url'			=> 'admin/policies.php',
     ),
+    'admin_banner' => array (
+        'title'			=> 'Edit Banner',
+        'parent'		=> 'admin',
+        'url'			=> 'admin/banner.php',
+    ),
 
 // Added by Richard Allan for email alert functions
 

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -281,14 +281,18 @@ class PAGE {
 
     public function page_body() {
         global $this_page;
+        $banner = new MySociety\TheyWorkForYou\Model\Banner;
+        $banner_text = $banner->get_text();
 
         // Start the body, put in the page headings.
         ?>
 <body>
 
+<?php if ( $banner_text ) { ?>
 <div id="surveyPromoBanner" style="clear:both;padding:1em;margin-top:24px;background:#DDD;">
-Find out who your candidates in the 2015 General Election are at <a href="https://yournextmp.com">YourNextMP</a>
+<?= $banner_text ?>
 </div>
+<?php } ?>
 
 
 <div id="fb-root"></div>

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -187,3 +187,10 @@
             </nav>
         </div>
     </header>
+    <div class="banner">
+        <div class="full-page__row">
+            <div class="banner__content">
+                Find out who your candidates in the 2015 General Election are at <a href="https://yournextmp.com">YourNextMP</a>
+            </div>
+        </div>
+    </div>

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -187,10 +187,12 @@
             </nav>
         </div>
     </header>
+    <?php if ( isset($banner_text) ) { ?>
     <div class="banner">
         <div class="full-page__row">
             <div class="banner__content">
-                Find out who your candidates in the 2015 General Election are at <a href="https://yournextmp.com">YourNextMP</a>
+                <?= $banner_text ?>
             </div>
         </div>
     </div>
+    <?php } ?>


### PR DESCRIPTION
This adds a banner to pages with the new design.

It also adds an editorial table, which is a key/value thing at the moment in anticipation of it being used for e.g. controlling things on the front page, and fetches the banner text from that. This allows the banner to now be edited in the admin interface rather than having to edit files and deploy the site.