### PR TITLE
Add link to specific vote on a divisions page

### DIFF
--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -590,6 +590,13 @@
     }
 }
 
+.policy-vote--major,
+.policy-vote--minor {
+    &:target {
+        background-color: #ffc;
+    }
+}
+
 .policy-vote--minor {
     padding-left: 1.5em;
     line-height: 1.3em !important; // override .vote-descriptions .policy-votes > li
@@ -601,6 +608,14 @@
 
     .policy-vote__text {
         color: #666;
+    }
+}
+
+.policy-vote__permalink {
+    float: right;
+    color: #b5af9d; // desaturated taupe colour
+    @media (min-width: $medium-screen) {
+        margin-right: -9em;
     }
 }
 

--- a/www/includes/easyparliament/templates/html/mp/divisions.php
+++ b/www/includes/easyparliament/templates/html/mp/divisions.php
@@ -107,6 +107,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                                     ?>
                                     <?php foreach ($policy['divisions'] as $division) { ?>
                                         <li id="<?= $division['division_id'] ?>" class="<?= $division['strong'] || $show_all ? 'policy-vote--major' : 'policy-vote--minor' ?>">
+                                            <a class="policy-vote__permalink" href="<?= $page_url ?>#<?= $division['division_id'] ?>" title="Link to this vote">#</a>
                                             <span class="policy-vote__date">On <?= strftime('%e %b %Y', strtotime($division['date'])) ?>:</span>
                                             <span class="policy-vote__text"><?= $full_name ?><?= $division['text'] ?></span>
                                             <?php if ( $division['url'] ) { ?>


### PR DESCRIPTION
In case someone wants to highlight a specific vote on a page add a link
to the end of each description. Also, add some JS tweaks to highlight the vote and make sure it's visible.

I'm not sure if this is possibly adding too much visual clutter:

![screen shot 2015-04-09 at 17 34 34](https://cloud.githubusercontent.com/assets/5310/7071694/cf27ad1c-dede-11e4-8c85-ace1576aaa95.png)


<!---
@huboard:{"order":160.75,"milestone_order":810,"custom_state":""}
-->
