### PR TITLE
extract test GetConnection out to abstract class and inherit

### DIFF
--- a/tests/AcceptApiTest.php
+++ b/tests/AcceptApiTest.php
@@ -1,23 +1,10 @@
 <?php
 
-include_once 'FetchPageTestCase.php';
 /**
  * Provides acceptance(ish) tests for API functions.
  */
 class AcceptApiTest extends FetchPageTestCase
 {
-
-    /**
-     * Connects to the testing database.
-     */
-    public function getConnection()
-    {
-        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
-        $username = OPTION_TWFY_DB_USER;
-        $password = OPTION_TWFY_DB_PASS;
-        $pdo = new PDO($dsn, $username, $password);
-        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
-    }
 
     /**
      * Loads the api testing fixture.

--- a/tests/AcceptBasicTest.php
+++ b/tests/AcceptBasicTest.php
@@ -1,24 +1,10 @@
 <?php
 
-include_once 'FetchPageTestCase.php';
-
 /**
  * Provides acceptance(ish) tests to ensure key pages are working.
  */
 class AcceptBasicTest extends FetchPageTestCase
 {
-
-    /**
-     * Connects to the testing database.
-     */
-    public function getConnection()
-    {
-        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
-        $username = OPTION_TWFY_DB_USER;
-        $password = OPTION_TWFY_DB_PASS;
-        $pdo = new PDO($dsn, $username, $password);
-        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
-    }
 
     /**
      * Loads the acceptance testing fixture.

--- a/tests/AlertsTest.php
+++ b/tests/AlertsTest.php
@@ -3,20 +3,8 @@
 /**
  * Provides test methods for alerts functionality.
  */
-class AlertsTest extends PHPUnit_Extensions_Database_TestCase
+class AlertsTest extends TWFY_Database_TestCase
 {
-
-    /**
-     * Connects to the testing database.
-     */
-    public function getConnection()
-    {
-        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
-        $username = OPTION_TWFY_DB_USER;
-        $password = OPTION_TWFY_DB_PASS;
-        $pdo = new PDO($dsn, $username, $password);
-        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
-    }
 
     /**
      * Loads the alerts testing fixture.

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -38,5 +38,7 @@ define('TESTING', TRUE);
 
 // Load up the init script (handles the rest of the config, DB connection etc)
 include_once('www/includes/easyparliament/init.php');
+include_once 'TWFY_Database_TestCase.php';
+include_once 'FetchPageTestCase.php';
 
 // Go!

--- a/tests/CommentTest.php
+++ b/tests/CommentTest.php
@@ -3,20 +3,8 @@
 /**
  * Provides test methods for commenting functionality.
  */
-class CommentTest extends PHPUnit_Extensions_Database_TestCase
+class CommentTest extends TWFY_Database_TestCase
 {
-
-    /**
-     * Connects to the testing database.
-     */
-    public function getConnection()
-    {
-        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
-        $username = OPTION_TWFY_DB_USER;
-        $password = OPTION_TWFY_DB_PASS;
-        $pdo = new PDO($dsn, $username, $password);
-        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
-    }
 
     /**
      * Loads the comments testing fixture.

--- a/tests/DivisionsTest.php
+++ b/tests/DivisionsTest.php
@@ -1,24 +1,10 @@
 <?php
 
-include_once 'FetchPageTestCase.php';
-
 /**
  * Provides test methods to ensure pages contain what we want them to in various ways.
  */
 class DivisionsTest extends FetchPageTestCase
 {
-
-    /**
-     * Connects to the testing database.
-     */
-    public function getConnection()
-    {
-        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
-        $username = OPTION_TWFY_DB_USER;
-        $password = OPTION_TWFY_DB_PASS;
-        $pdo = new PDO($dsn, $username, $password);
-        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
-    }
 
     public function getDataSet()
     {

--- a/tests/FetchPageTestCase.php
+++ b/tests/FetchPageTestCase.php
@@ -3,7 +3,7 @@
 /**
  * Provides acceptance(ish) tests for API functions.
  */
-abstract class FetchPageTestCase extends PHPUnit_Extensions_Database_TestCase
+abstract class FetchPageTestCase extends TWFY_Database_TestCase
 {
 
     protected function base_fetch_page($method, $vars = array(), $dir, $page = 'index.php', $ENV = '')

--- a/tests/GlossaryTest.php
+++ b/tests/GlossaryTest.php
@@ -3,20 +3,8 @@
 /**
  * Provides test methods for glossary functionality.
  */
-class GlossaryTest extends PHPUnit_Extensions_Database_TestCase
+class GlossaryTest extends TWFY_Database_TestCase
 {
-
-    /**
-     * Connects to the testing database.
-     */
-    public function getConnection()
-    {
-        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
-        $username = OPTION_TWFY_DB_USER;
-        $password = OPTION_TWFY_DB_PASS;
-        $pdo = new PDO($dsn, $username, $password);
-        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
-    }
 
     /**
      * Loads the glossary testing fixture.

--- a/tests/HansardTest.php
+++ b/tests/HansardTest.php
@@ -3,20 +3,8 @@
 /**
  * Provides test methods for Hansard functionality.
  */
-class HansardTest extends PHPUnit_Extensions_Database_TestCase
+class HansardTest extends TWFY_Database_TestCase
 {
-
-    /**
-     * Connects to the testing database.
-     */
-    public function getConnection()
-    {
-        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
-        $username = OPTION_TWFY_DB_USER;
-        $password = OPTION_TWFY_DB_PASS;
-        $pdo = new PDO($dsn, $username, $password);
-        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
-    }
 
     /**
      * Loads the Hansard testing fixture.

--- a/tests/MemberTest.php
+++ b/tests/MemberTest.php
@@ -3,20 +3,8 @@
 /**
  * Provides test methods for member functionality.
  */
-class MemberTest extends PHPUnit_Extensions_Database_TestCase
+class MemberTest extends TWFY_Database_TestCase
 {
-
-    /**
-     * Connects to the testing database.
-     */
-    public function getConnection()
-    {
-        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
-        $username = OPTION_TWFY_DB_USER;
-        $password = OPTION_TWFY_DB_PASS;
-        $pdo = new PDO($dsn, $username, $password);
-        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
-    }
 
     /**
      * Loads the member testing fixture.

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -1,24 +1,10 @@
 <?php
 
-include_once 'FetchPageTestCase.php';
-
 /**
  * Provides test methods to ensure pages contain what we want them to in various ways.
  */
 class PageTest extends FetchPageTestCase
 {
-
-    /**
-     * Connects to the testing database.
-     */
-    public function getConnection()
-    {
-        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
-        $username = OPTION_TWFY_DB_USER;
-        $password = OPTION_TWFY_DB_PASS;
-        $pdo = new PDO($dsn, $username, $password);
-        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
-    }
 
     /**
      * Loads the member testing fixture.

--- a/tests/PostcodeTest.php
+++ b/tests/PostcodeTest.php
@@ -4,20 +4,8 @@
  * Testing for functions in postcode.inc
  */
 
-class PostcodeTest extends PHPUnit_Extensions_Database_TestCase
+class PostcodeTest extends TWFY_Database_TestCase
 {
-
-    /**
-     * Connects to the testing database.
-     */
-    public function getConnection()
-    {
-        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
-        $username = OPTION_TWFY_DB_USER;
-        $password = OPTION_TWFY_DB_PASS;
-        $pdo = new PDO($dsn, $username, $password);
-        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
-    }
 
     /**
      * Loads the member testing fixture.

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -5,21 +5,12 @@
  * Currently only the highlighting and constituency search.
  */
 
-class SearchTest extends PHPUnit_Extensions_Database_TestCase
+class SearchTest extends TWFY_Database_TestCase
 {
 	public function setUp()
 	{
         parent::setUp();
         include_once('www/includes/easyparliament/searchengine.php');
-    }
-
-    public function getConnection()
-    {
-        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
-        $username = OPTION_TWFY_DB_USER;
-        $password = OPTION_TWFY_DB_PASS;
-        $pdo = new PDO($dsn, $username, $password);
-        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
     }
 
     public function getDataSet()

--- a/tests/SectionTest.php
+++ b/tests/SectionTest.php
@@ -1,24 +1,10 @@
 <?php
 
-include_once 'FetchPageTestCase.php';
-
 /**
  * Provides test methods to ensure pages contain what we want them to in various ways.
  */
 class SectionTest extends FetchPageTestCase
 {
-
-    /**
-     * Connects to the testing database.
-     */
-    public function getConnection()
-    {
-        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
-        $username = OPTION_TWFY_DB_USER;
-        $password = OPTION_TWFY_DB_PASS;
-        $pdo = new PDO($dsn, $username, $password);
-        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
-    }
 
     public function getDataSet()
     {

--- a/tests/TWFY_Database_TestCase.php
+++ b/tests/TWFY_Database_TestCase.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Provides acceptance(ish) tests for API functions.
+ */
+abstract class TWFY_Database_TestCase extends PHPUnit_Extensions_Database_TestCase
+{
+    /**
+     * database handle for database queries in tests
+     */
+    public $db;
+
+    /**
+     * Connects to the testing database.
+     */
+    public function getConnection()
+    {
+        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
+        $username = OPTION_TWFY_DB_USER;
+        $password = OPTION_TWFY_DB_PASS;
+        $pdo = new PDO($dsn, $username, $password);
+        $this->db = $pdo;
+        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
+    }
+
+}

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -3,20 +3,8 @@
 /**
  * Provides test methods for user functionality.
  */
-class UserTest extends PHPUnit_Extensions_Database_TestCase
+class UserTest extends TWFY_Database_TestCase
 {
-
-    /**
-     * Connects to the testing database.
-     */
-    public function getConnection()
-    {
-        $dsn = 'mysql:host=' . OPTION_TWFY_DB_HOST . ' ;dbname=' . OPTION_TWFY_DB_NAME;
-        $username = OPTION_TWFY_DB_USER;
-        $password = OPTION_TWFY_DB_PASS;
-        $pdo = new PDO($dsn, $username, $password);
-        return $this->createDefaultDBConnection($pdo, OPTION_TWFY_DB_NAME);
-    }
 
     /**
      * Loads the user testing fixture.


### PR DESCRIPTION
rather than having the same getConnection method in all the database
tests extract it out to an abstract class and inherit from that.
Also move the includes for it and the FetchPage test class to the
bootstrapper so they don't need to be included in every file.