### PR TITLE
Dot dev dns fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ If you have questions, the best place to ask is the mySociety TheyWorkForYou ema
 
 You will need the latest versions of VirtualBox and Vagrant, then:
 
-* Stick an entry in your `hosts` file to point `theyworkforyou.dev` at `192.168.88.10` (Apache doesn't like IP addresses).
+* Stick an entry in your `hosts` file to point `twfy.mysociety` at `192.168.88.10` (Apache doesn't like IP addresses).
 * Run `vagrant up`.
 * Go make a cup of tea. It may take a while whilst Vagrant and Puppet do their thing.
-* Point your web browser at `http://theyworkforyou.dev` and marvel at modern technology.
+* Point your web browser at `http://twfy.mysociety` and marvel at modern technology.
 
 #### Compiling Static Assets
 

--- a/puphpet/config.yaml
+++ b/puphpet/config.yaml
@@ -92,7 +92,7 @@ apache:
         - rewrite
     vhosts:
         y9hgbpahzaxy:
-            servername: theyworkforyou.dev
+            servername: twfy.mysociety
             docroot: /data/twfy/www/docs
             port: '80'
             directories:

--- a/puphpet/files/exec-once/install.sh
+++ b/puphpet/files/exec-once/install.sh
@@ -15,8 +15,8 @@ sed -i 's/define ("BASEDIR","\/home\/user\/theyworkforyou\/docs");/define ("BASE
 sed -i 's/define ("RAWDATA", "\/home\/twfy\/pwdata\/");/define ("RAWDATA", "\/data\/twfy\/uml-tests\/parldata\/");/g' /data/twfy/conf/general
 sed -i "s/define ('PWMEMBERS', '\/home\/twfy\/parlparse\/members\/');/define ('PWMEMBERS', '\/data\/parlparse\/members\/');/g" /data/twfy/conf/general
 
-sed -i 's/define ("DOMAIN", "www.example.org");/define ("DOMAIN", "theyworkforyou.dev");/g' /data/twfy/conf/general
-sed -i 's/define ("COOKIEDOMAIN", "www.example.org");/define ("COOKIEDOMAIN", "theyworkforyou.dev");/g' /data/twfy/conf/general
+sed -i 's/define ("DOMAIN", "www.example.org");/define ("DOMAIN", "twfy.mysociety");/g' /data/twfy/conf/general
+sed -i 's/define ("COOKIEDOMAIN", "www.example.org");/define ("COOKIEDOMAIN", "twfy.mysociety");/g' /data/twfy/conf/general
 
 mkdir /data/parlparse
 git clone https://github.com/mysociety/parlparse.git /data/parlparse


### PR DESCRIPTION
One for @jacksonj04.

No matter what we tried, `theyworkforyou.dev` wouldn't resolve on my Mac (OS X 10.10.3) so he suggested changing TWFY to not use `.dev`.