### PR TITLE
Issues/745 spwrans meta

### DIFF
--- a/classes/SectionView/SpwransView.php
+++ b/classes/SectionView/SpwransView.php
@@ -123,7 +123,7 @@ class SpwransView extends WransView {
             if( $reference ) {
                 $references[] = "\n<li>$inner.";
             } else {
-                $result .= "\n<li class=\"link-to-hansard\">$description$inner.</span>";
+                $result .= "\n<li class=\"link-to-hansard\">$description$inner</span>";
                 $last_date = $row["date"];
             }
         }

--- a/www/docs/style/sass/pages/_section.scss
+++ b/www/docs/style/sass/pages/_section.scss
@@ -374,28 +374,42 @@ span.hi {
   color: lighten(#9d9195, 10%);
 }
 
-.link-to-hansard span {
-  display: inline;
+.link-to-hansard {
+  margin-bottom: 5px;
   font-size: 14px;
   color: lighten(#9d9195, 10%);
-  @media (min-width: $medium-screen) {
-    display: block;
+
+  span, .debate-speech__meta__link {
+    display: inline;
+
+    @media (min-width: $medium-screen) {
+      display: block;
+    }
+  }
+
+  .question-mention-gap {
+    display: inline; // This should always be inline, no matter what the width
   }
 }
 
 .debate-speech__links {
   margin: 0;
+
   li {
     display: block;
   }
+
   @media (min-width: $medium-screen) {
     padding-left: 70px;
   }
+
   @media (min-width: $large-screen) {
     position: absolute;
     top: 0;
     right: 0;
     padding-left: 0;
+    width: 16em;
+
     li {
       text-align: right;
     }

--- a/www/docs/style/sass/pages/_section.scss
+++ b/www/docs/style/sass/pages/_section.scss
@@ -76,6 +76,8 @@ span.hi {
   padding-top: 20px;
   padding-bottom: 20px;
 
+  @include clearfix;
+
   &:nth-child(even) {
     // IE6,7,8 won't get this zebra-striping, but that's ok
     background-color: transparent;
@@ -122,11 +124,18 @@ span.hi {
   }
 }
 
+.debate-speech__speaker-and-content {
+  @media (min-width: $medium-screen) {
+    width: 60%;
+    float: left;
+  }
+}
+
 .debate-speech__speaker {
   margin-top: 0;
   line-height: 1em;
   margin-bottom: 0.25em;
-  max-width: 33em; //prevent overflow into context links
+
   img {
     float: left;
     margin-right: 10px;
@@ -173,9 +182,7 @@ span.hi {
 
 .debate-speech__content {
   font-size: 14px;
-  max-width: 45em; // keep line lengths readable
   margin-top: 0.66em;
-  min-width: 3.6em; //leave room for the various links on the right that are positioned absolutely on large screebs
   p {
     line-height: 1.4em;
     margin-bottom: 0.8em;
@@ -393,28 +400,22 @@ span.hi {
 }
 
 .debate-speech__links {
-  margin: 0;
+  margin: 1em 0 0 0;
 
   li {
     display: block;
   }
 
   @media (min-width: $medium-screen) {
-    padding-left: 70px;
+    float: right;
+    width: 35%;
+    text-align: right;
+    margin-top: 0;
   }
 
-  @media (min-width: $large-screen) {
-    position: absolute;
-    top: 0;
-    right: 0;
-    padding-left: 0;
-    width: 16em;
-
-    li {
-      text-align: right;
-    }
+  @media (min-width: $medium-screen) {
+    width: 30%;
   }
-
 }
 
 .speech-link-in-context {

--- a/www/includes/easyparliament/templates/html/section/section.php
+++ b/www/includes/easyparliament/templates/html/section/section.php
@@ -161,6 +161,8 @@
         <div class="full-page__row">
             <a name="g<?= gid_to_anchor($speech['gid']) ?>"></a>
 
+            <div class="debate-speech__speaker-and-content">
+
           <?php if(isset($speech['speaker']) && count($speech['speaker']) > 0) { ?>
             <h2 class="debate-speech__speaker">
                 <?php
@@ -297,6 +299,8 @@
             }
 
             ?>
+            </div>
+
             <ul class="debate-speech__meta debate-speech__links">
                 <?php if (!$individual_item) { # XXX ?>
                 <li class="link-to-speech">


### PR DESCRIPTION
~~(Sorry, this branch is on top of https://github.com/mysociety/theyworkforyou/pull/828 – but the `twfy.mysociety` change isn't actually required for the stuff this branch does. Can some Git genius separate it out?)~~

Fixes #745. Tidies up the display of written question metadata:

![screen shot 2015-04-20 at 17 33 14](https://cloud.githubusercontent.com/assets/739624/7235108/e0fbfc8e-e783-11e4-909e-496081a52c18.png)

The `get_question_mentions_html()` function in `SpwransView.php` looked pretty hairy, so I tried not to touch it at all. So I've done what I can in CSS alone. It's less of an eyesore than it was before, but if we wanted to spend more time on it, I'd recommend drastically shortening the output of `get_question_mentions_html()`.