### PR TITLE
Improve load people

### DIFF
--- a/db/0003-add-moffice-id.sql
+++ b/db/0003-add-moffice-id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE  `moffice` MODIFY moffice_id varchar(100) NOT NULL;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -148,7 +148,7 @@ CREATE TABLE `persondivisionvotes` (
 );
 
 CREATE TABLE `moffice` (
-  `moffice_id` int(11) NOT NULL auto_increment,
+  `moffice_id` varchar(100) NOT NULL,
   `dept` varchar(255) NOT NULL default '',
   `position` varchar(200) NOT NULL default '',
   `from_date` date NOT NULL default '1000-01-01',

--- a/scripts/load-people
+++ b/scripts/load-people
@@ -39,14 +39,13 @@ check_member_ids();
 
 # ---
 
-my ($dbh, $constituencyadd, $memberadd, $memberexist, $membercheck);
+my ($dbh, $memberadd, $memberexist, $membercheck);
 
 sub db_connect {
     #DBI->trace(1);
     my $dsn = 'DBI:mysql:database=' . mySociety::Config::get('TWFY_DB_NAME'). ':host=' . mySociety::Config::get('TWFY_DB_HOST');
     $dbh = DBI->connect($dsn, mySociety::Config::get('TWFY_DB_USER'), mySociety::Config::get('TWFY_DB_PASS'), { RaiseError => 1, PrintError => 0 });
 
-    $constituencyadd = $dbh->prepare("replace into constituency (cons_id, name, main_name, from_date, to_date) values (?, ?, ?, ?, ?)");
     $memberadd = $dbh->prepare("replace into member (member_id, person_id, house, title, first_name, last_name,
         constituency, party, entered_house, left_house, entered_reason, left_reason)
         values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
@@ -60,54 +59,25 @@ sub db_connect {
 my %organizations;
 my %posts;
 
-sub loadmoffices {
-    my @moffices;
-
+sub load_moffices {
+    my $moffreplace = $dbh->prepare("replace into moffice (moffice_id, dept, position, from_date, to_date, person, source) values (?, ?, ?, ?, ?, ?, ?)");
     foreach ('ministers.json', 'ministers-2010.json') {
         my $j = decode_json(read_file($pwmembers . $_));
         foreach (@{$j->{organizations}}) {
             $organizations{$_->{id}} = $_->{name};
         }
         foreach (@{$j->{memberships}}) {
-            push @moffices, loadmoffice($_);
+            (my $person = $_->{person_id}) =~ s#uk.org.publicwhip/person/##;
+            my $pos = $_->{role} || 'Member';
+            my $dept = $organizations{$_->{organization_id}} || die $!;
+            $dept = '' if $dept eq 'House of Commons';
+            $moffreplace->execute($_->{id}, $dept, $pos, $_->{start_date}, $_->{end_date}, $person, '');
         }
     }
-
-    # XXX: Surely the XML should join two consecutive offices together somewhere?!
-    # Also, have to check all previous offices as offices are not consecutive in XML. <sigh>
-    @moffices = sort { $a->[3] cmp $b->[3] } @moffices;
-    for (my $i=0; $i<@moffices; $i++) {
-        for (my $j=0; $j<$i; $j++) {
-            next unless $moffices[$j];
-            if ($moffices[$i][5] eq $moffices[$j][5] && $moffices[$i][1] eq $moffices[$j][1]
-                && $moffices[$i][2] eq $moffices[$j][2] && $moffices[$i][3] eq $moffices[$j][4]) {
-                $moffices[$j][4] = $moffices[$i][4];
-                delete $moffices[$i];
-                last;
-            }
-        }
-    }
-    $dbh->do("delete from moffice");
-    foreach my $row (@moffices) {
-        next unless $row;
-        my $sth = $dbh->do("insert into moffice (dept, position, from_date, to_date, person, source) values (?, ?, ?, ?, ?, ?)", {},
-        $row->[1], $row->[2], $row->[3], $row->[4], $row->[5], $row->[6]);
-    }
-}
-
-sub loadmoffice {
-    my $moff = shift;
-
-    (my $mofficeid = $moff->{id}) =~ s#uk.org.publicwhip/moffice/##;
-    (my $person = $moff->{person_id}) =~ s#uk.org.publicwhip/person/##;
-    my $pos = $moff->{role} || 'Member';
-    my $dept = $organizations{$moff->{organization_id}} || die $!;
-    $dept = '' if $dept eq 'House of Commons';
-
-    return [ $mofficeid, $dept, $pos, $moff->{start_date}, $moff->{end_date}, $person, '' ];
 }
 
 sub load_constituencies {
+    my $constituencyadd = $dbh->prepare("replace into constituency (cons_id, name, main_name, from_date, to_date) values (?, ?, ?, ?, ?)");
     my $j = decode_json(read_file($pwmembers . 'constituencies.json'));
     foreach my $cons (@$j) {
         (my $consid = $cons->{id}) =~ s#uk.org.publicwhip/cons/##;

--- a/scripts/load-people
+++ b/scripts/load-people
@@ -18,7 +18,9 @@ mySociety::Config::set_file("$FindBin::Bin/../conf/general");
 use DBI;
 use Encode;
 use File::Slurp;
+use Getopt::Long;
 use JSON;
+use POSIX qw(strftime);
 use Data::Dumper;
 
 my %slug_to_house_id = (
@@ -29,13 +31,22 @@ my %slug_to_house_id = (
     'scottish-parliament' => 4,
 );
 
+my $verbose;
+my $from = '';
+GetOptions ("verbose!" => \$verbose, "from=s" => \$from) or die $!;
+my $start_time = time();
+verbose("Start");
 db_connect();
 
 my $pwmembers = mySociety::Config::get('PWMEMBERS');
+verbose("Constituencies");
 load_constituencies();
-load_people_json();
-loadmoffices();
+verbose("People");
+load_people();
+verbose("Offices");
+load_moffices();
 check_member_ids();
+verbose("End");
 
 # ---
 
@@ -71,6 +82,7 @@ sub load_moffices {
             my $pos = $_->{role} || 'Member';
             my $dept = $organizations{$_->{organization_id}} || die $!;
             $dept = '' if $dept eq 'House of Commons';
+            next unless $_->{end_date} ge $from;
             $moffreplace->execute($_->{id}, $dept, $pos, $_->{start_date}, $_->{end_date}, $person, '');
         }
     }
@@ -87,6 +99,8 @@ sub load_constituencies {
         my $end_date = $cons->{end_date} || '9999-12-31';
         $end_date .= '-00-00' if length($end_date) == 4;
 
+        next unless $end_date ge $from;
+
         my $main_name = 1;
         foreach my $name (@{$cons->{names}}) {
             $constituencyadd->execute(
@@ -101,7 +115,7 @@ sub load_constituencies {
     }
 }
 
-sub load_people_json {
+sub load_people {
     my $j = decode_json(read_file($pwmembers . 'people.json'));
     foreach (@{$j->{organizations}}) {
         $organizations{$_->{id}} = $_;
@@ -122,10 +136,14 @@ sub load_member {
     (my $id = $member->{id}) =~ s:uk.org.publicwhip/(member|lord|royal)/::;
     (my $person_id = $member->{person_id}) =~ s#uk.org.publicwhip/person/##;
 
+    $member_ids{$id} = 1;
+
     my $start_date = $member->{start_date} || '0000-00-00';
     $start_date .= '-00-00' if length($start_date) == 4;
     my $end_date = $member->{end_date} || '9999-12-31';
     $end_date .= '-00-00' if length($end_date) == 4;
+
+    return unless $end_date ge $from;
 
     my $org_slug;
     if ($member->{post_id}) {
@@ -157,7 +175,6 @@ sub load_member {
         $member->{end_reason} || ($end_date eq '9999-12-31' && $org_slug ne 'house-of-lords' ? 'still_in_office' : ''),
     );
 
-    $member_ids{$id} = 1;
     return $person_id;
 }
 
@@ -197,4 +214,11 @@ sub check_member_ids {
     while (my @row = $q->fetchrow_array) {
             print "Member $row[0] in DB, not in JSON\n" if (!$member_ids{$row[0]});
     }
+}
+
+sub verbose {
+    my $s = shift;
+    return unless $verbose;
+    my $duration = time() - $start_time;
+    print "$duration $s\n";
 }


### PR DESCRIPTION
The parlparse JSON no longer has sequential duplicates, so we don't need that slow code any more. Add a date so we don't have to consider old things if we don't want to, and store office ID to save deleting the entire table each run.