### PR TITLE
Add section to new MP's pages saying they are new

### DIFF
--- a/classes/Member.php
+++ b/classes/Member.php
@@ -65,6 +65,51 @@ class Member extends \MEMBER {
 
     }
 
+    /*
+     * Determine if the member is a new member of a house where new is
+     * within the last 6 months.
+     *
+     * @param int house - identifier for the house, defaults to 1 for westminster
+     *
+     * @return boolean
+     */
+
+    public function isNew($house = 1) {
+        $date_entered = $this->getEntryDate($house);
+
+        if ($date_entered) {
+            $date_entered = new \DateTime($date_entered);
+            $now = new \DateTime();
+
+            $diff = $date_entered->diff($now);
+            if ( $diff->y == 0 && $diff->m <= 6 ) {
+                return TRUE;
+            }
+        }
+
+        return FALSE;
+    }
+
+    /*
+     * Get the date the person first entered a house. May not be for their current seat.
+     *
+     * @param int house - identifier for the house, defaults to 1 for westminster
+     *
+     * @return string - blank if no entry date for that house otherwise in YYYY-MM-DD format
+     */
+
+    public function getEntryDate($house = 1) {
+        $date_entered = '';
+
+        $entered_house = $this->entered_house($house);
+
+        if ( $entered_house ) {
+            $date_entered = $entered_house['date'];
+        }
+
+        return $date_entered;
+    }
+
     /**
     * Image
     *

--- a/tests/MemberTest.php
+++ b/tests/MemberTest.php
@@ -295,4 +295,27 @@ class MemberTest extends TWFY_Database_TestCase
 
     }
 
+    public function testIsNew() {
+        $MEMBER = new MySociety\TheyWorkForYou\Member(array('person_id' => 17));
+
+        $this->assertNotTrue($MEMBER->isNew());
+
+        $this->db->query("UPDATE member SET entered_house = NOW() WHERE person_id = 17");
+
+        // do this to force a reload
+        $MEMBER = new MySociety\TheyWorkForYou\Member(array('person_id' => 17));
+        $this->assertTrue($MEMBER->isNew());
+    }
+
+    public function testGetEntryDate() {
+        $MEMBER = new MySociety\TheyWorkForYou\Member(array('person_id' => 18));
+
+        $this->assertEquals($MEMBER->getEntryDate(), '2014-05-01');
+        $this->assertEquals($MEMBER->getEntryDate(1), '2014-05-01');
+        $this->assertEquals($MEMBER->getEntryDate(2), '2010-05-01');
+        $this->assertEquals($MEMBER->getEntryDate(3), '2012-05-01');
+        $this->assertEquals($MEMBER->getEntryDate(4), '2004-05-01');
+        $this->assertEquals($MEMBER->getEntryDate(5), '');
+    }
+
 }

--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -84,4 +84,12 @@ class PageTest extends FetchPageTestCase
         $this->assertNotContains('This is a banner', $page);
     }
 
+    public function testNewMPMessage() {
+        $page = $this->fetch_page( array( 'pid' => 17, 'url' => '/mp/17/recent_mp/test_westminster_constituency' ) );
+        $this->assertNotContains('is a recently elected MP', $page);
+        $this->db->query('UPDATE member SET entered_house = NOW() WHERE person_id = 17');
+        $page = $this->fetch_page( array( 'pid' => 17, 'url' => '/mp/17/recent_mp/test_westminster_constituency' ) );
+        $this->assertContains('is a recently elected MP', $page);
+    }
+
 }

--- a/tests/_fixtures/member.xml
+++ b/tests/_fixtures/member.xml
@@ -294,6 +294,81 @@
 			<field name="title">Mr</field>
 			<field name="lastupdate">2013-08-07 15:06:19</field>
 		</row>
+		<row>
+			<field name="member_id">16</field>
+			<field name="house">1</field>
+			<field name="first_name">Recent</field>
+			<field name="last_name">MP</field>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="party"></field>
+			<field name="entered_house">2014-05-01</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">17</field>
+			<field name="title">Mr</field>
+			<field name="lastupdate">2015-05-01 15:06:19</field>
+		</row>
+		<row>
+			<field name="member_id">17</field>
+			<field name="house">1</field>
+			<field name="first_name">House1</field>
+			<field name="last_name">MP</field>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="party"></field>
+			<field name="entered_house">2014-05-01</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">18</field>
+			<field name="title">Mr</field>
+			<field name="lastupdate">2015-05-01 15:06:19</field>
+		</row>
+		<row>
+			<field name="member_id">18</field>
+			<field name="house">2</field>
+			<field name="first_name">House2</field>
+			<field name="last_name">Lord</field>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="party"></field>
+			<field name="entered_house">2010-05-01</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">18</field>
+			<field name="title">Mr</field>
+			<field name="lastupdate">2015-05-01 15:06:19</field>
+		</row>
+		<row>
+			<field name="member_id">19</field>
+			<field name="house">3</field>
+			<field name="first_name">House3</field>
+			<field name="last_name">MLA</field>
+			<field name="constituency">Test NI Constituency</field>
+			<field name="party"></field>
+			<field name="entered_house">2012-05-01</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">18</field>
+			<field name="title">Mr</field>
+			<field name="lastupdate">2015-05-01 15:06:19</field>
+		</row>
+		<row>
+			<field name="member_id">20</field>
+			<field name="house">4</field>
+			<field name="first_name">House4</field>
+			<field name="last_name">MSP</field>
+			<field name="constituency">Test Scottish Constituency</field>
+			<field name="party"></field>
+			<field name="entered_house">2004-05-01</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">18</field>
+			<field name="title">Mr</field>
+			<field name="lastupdate">2015-05-01 15:06:19</field>
+		</row>
 	</table_data>
 	<table_data name="memberinfo">
 		<row>

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -483,6 +483,8 @@ try {
         $data['image'] = $MEMBER->image();
         $data['member_summary'] = person_summary_description($MEMBER);
         $data['enter_leave'] = $MEMBER->getEnterLeaveStrings();
+        $data['entry_date'] = $MEMBER->getEntryDate();
+        $data['is_new_mp'] = $MEMBER->isNew();
         $data['other_parties'] = $MEMBER->getOtherPartiesString();
         $data['other_constituencies'] = $MEMBER->getOtherConstituenciesString();
         $data['rebellion_rate'] = person_rebellion_rate($MEMBER);

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -39,6 +39,16 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                     <div class="panel">
                         <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
                     </div>
+                    <?php elseif (isset($is_new_mp) && $is_new_mp && count($recent_appearances['appearances']) == 0): ?>
+                    <div class="panel--secondary">
+                        <h3><?= $full_name ?> is a recently elected MP &ndash; elected on <?= format_date($entry_date, LONGDATEFORMAT) ?></h3>
+
+                        <p>When <?= $full_name ?> starts to speak in debates and vote on bills, that information will appear on this page.</p>
+
+                      <?php if ($has_email_alerts) { ?>
+                        <a href="<?= WEBPATH ?>alert/?pid=<?= $person_id ?>#" onclick="trackLinkClick(this, 'Alert', 'Search', 'Person'); return false;">Sign up for email alerts to be the first to know when that happens.</a>
+                      <?php } ?>
+                    </div>
                     <?php endif; ?>
 
                     <?php if (count($policyPositions->positions) > 0): ?>

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -30,6 +30,12 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                     <div class="panel">
                         <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
                     </div>
+                    <?php elseif (isset($is_new_mp) && $is_new_mp && !$has_voting_record): ?>
+                    <div class="panel--secondary">
+                        <h3><?= $full_name ?> is a recently elected MP - elected on <?= format_date($entry_date, LONGDATEFORMAT) ?></h3>
+
+                        <p>When <?= $full_name ?> starts to vote on bills, that information will appear on this page.</p>
+                    </div>
                     <?php endif; ?>
 
                     <?php if ($has_voting_record): ?>


### PR DESCRIPTION
Note to say they were recently elected which is why there's not much
content on the page. Dissapears either after 6 months or if they've got
recent activity.

Similar for policy page.

Fixes #703