### PR TITLE
ignore case differences when loading constituencies

### DIFF
--- a/scripts/load-people
+++ b/scripts/load-people
@@ -92,6 +92,7 @@ sub load_moffices {
 sub load_constituencies {
     my $constituencyadd = $dbh->prepare("replace into constituency (cons_id, name, main_name, from_date, to_date) values (?, ?, ?, ?, ?)");
     my $j = decode_json(read_file($pwmembers . 'constituencies.json'));
+    my %seen;
     foreach my $cons (@$j) {
         (my $consid = $cons->{id}) =~ s#uk.org.publicwhip/cons/##;
 
@@ -104,6 +105,11 @@ sub load_constituencies {
 
         my $main_name = 1;
         foreach my $name (@{$cons->{names}}) {
+            # need this becuase mysql is case insensitive by default so can't distinguish
+            # between Berwick-upon-Tweed and Berwick-Upon-Tweed and so you end up setting
+            # main_name to 0 when it replaces the second of these. This then breaks the
+            # constituency name search
+            next if $seen{lc($name)};
             $constituencyadd->execute(
                 $consid,
                 Encode::encode('iso-8859-1', $name),
@@ -111,6 +117,7 @@ sub load_constituencies {
                 $start_date,
                 $end_date,
             );
+            $seen{lc($name)} = 1;
             $main_name = 0;
         }
     }


### PR DESCRIPTION
Because mysql's default collation is case insensitive the replace into
is triggered by case differences in names becuase the index sees
Berwick-upon-Tweed and Berwick-Upon-Tweed as the same. This means the
for the second one we update main_name to 0 which means no results are
found by the constituency name search.

Fixes #856