### PR TITLE
detect signups for postcodes with a keyword and advise user

### DIFF
--- a/tests/AlertsPageTest.php
+++ b/tests/AlertsPageTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * Provides test methods to ensure pages contain what we want them to in various ways.
+ */
+class AlertsPageTest extends FetchPageTestCase
+{
+
+    /**
+     * Loads the member testing fixture.
+     */
+    public function getDataSet()
+    {
+        return $this->createMySQLXMLDataSet(dirname(__FILE__).'/_fixtures/alertspage.xml');
+    }
+
+    private function fetch_page($vars)
+    {
+        return $this->base_fetch_page('', $vars, 'www/docs/alert');
+    }
+
+    public function testFetchPage()
+    {
+        $page = $this->fetch_page( array() );
+        $this->assertContains('TheyWorkForYou Email Alerts', $page);
+    }
+
+    public function testKeywordOnly() {
+        $page = $this->fetch_page( array( 'alertsearch' => 'elephant') );
+        $this->assertContains('Mentions of [elephant]', $page);
+    }
+
+    public function testPostCodeOnly() {
+        $page = $this->fetch_page( array( 'alertsearch' => 'SE17 3HE') );
+        $this->assertContains('things by Mrs Test Current-MP', $page);
+    }
+
+    public function testPostCodeWithKeyWord()
+    {
+        $page = $this->fetch_page( array( 'alertsearch' => 'SE17 3HE elephant') );
+        $this->assertContains('You have used a postcode and something else', $page);
+        $this->assertContains('[elephant] by Mrs Test Current-MP', $page);
+        $this->assertNotContains('by your MSP', $page);
+    }
+
+    public function testScottishPostcodeWithKeyword() {
+        $page = $this->fetch_page( array( 'alertsearch' => 'PH6 2DB elephant') );
+        $this->assertContains('You have used a postcode and something else', $page);
+        $this->assertContains('[elephant] by your MP, Mr Test2 Current-MP', $page);
+        $this->assertContains('[elephant] by your MSP, Mrs Test Current-MSP', $page);
+    }
+
+    public function testPostcodeAndKeywordWithNoSittingMP() {
+        $page = $this->fetch_page( array( 'alertsearch' => 'OX1 4LF elephant') );
+        $this->assertContains('You have used a postcode and something else', $page);
+        $this->assertContains('problem looking up your representative', $page);
+    }
+}

--- a/tests/_fixtures/alertspage.xml
+++ b/tests/_fixtures/alertspage.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0"?>
+<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<database name="twfy_testing">
+	<table_data name="alerts">
+	</table_data>
+	<table_data name="anonvotes">
+	</table_data>
+	<table_data name="api_key">
+	</table_data>
+	<table_data name="api_stats">
+	</table_data>
+	<table_data name="bills">
+		<row>
+			<field name="id">1</field>
+			<field name="title">Test Bill</field>
+			<field name="url">http://example.com</field>
+			<field name="type">unknown</field>
+			<field name="lords">0</field>
+			<field name="session">2013-14</field>
+			<field name="standingprefix">test_</field>
+		</row>
+	</table_data>
+	<table_data name="campaigners">
+	</table_data>
+	<table_data name="campaigners_sent_email">
+	</table_data>
+	<table_data name="commentreports">
+	</table_data>
+	<table_data name="comments">
+	</table_data>
+	<table_data name="consinfo">
+		<row>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="data_key">test_constituency_key</field>
+			<field name="data_value">Test Constituency Value</field>
+		</row>
+	</table_data>
+	<table_data name="constituency">
+	</table_data>
+	<table_data name="editqueue">
+	</table_data>
+	<table_data name="epobject">
+	</table_data>
+	<table_data name="future">
+	</table_data>
+	<table_data name="future_people">
+	</table_data>
+	<table_data name="gidredirect">
+	</table_data>
+	<table_data name="glossary">
+	</table_data>
+	<table_data name="hansard">
+	</table_data>
+	<table_data name="indexbatch">
+	</table_data>
+	<table_data name="member">
+		<row>
+			<field name="member_id">1</field>
+			<field name="house">1</field>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="party"></field>
+			<field name="entered_house">2007-05-06</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">2</field>
+			<field name="lastupdate">2013-08-07 11:02:49</field>
+		</row>
+		<row>
+			<field name="member_id">2</field>
+			<field name="house">1</field>
+			<field name="constituency">Test Scottish Westminster Constituency</field>
+			<field name="party"></field>
+			<field name="entered_house">2007-05-06</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">3</field>
+			<field name="lastupdate">2013-08-07 11:02:49</field>
+		</row>
+		<row>
+			<field name="member_id">3</field>
+			<field name="house">4</field>
+			<field name="constituency">Test Holyrood Constituency</field>
+			<field name="party"></field>
+			<field name="entered_house">2007-05-06</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">4</field>
+			<field name="lastupdate">2013-08-07 11:02:49</field>
+		</row>
+	</table_data>
+	<table_data name="person_names">
+		<row>
+			<field name="given_name">Test</field>
+			<field name="family_name">Current-MP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">2</field>
+			<field name="title">Mrs</field>
+		</row>
+		<row>
+			<field name="given_name">Test2</field>
+			<field name="family_name">Current-MP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">3</field>
+			<field name="title">Mr</field>
+		</row>
+		<row>
+			<field name="given_name">Test</field>
+			<field name="family_name">Current-MSP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">4</field>
+			<field name="title">Mrs</field>
+		</row>
+	</table_data>
+	<table_data name="memberinfo">
+	</table_data>
+	<table_data name="mentions">
+	</table_data>
+	<table_data name="moffice">
+	</table_data>
+	<table_data name="pbc_members">
+	</table_data>
+	<table_data name="personinfo">
+	</table_data>
+	<table_data name="postcode_lookup">
+      <row>
+          <field name="postcode">PH6 2DB</field>
+          <field name="name">Test Scottish Westminster Constituency|Test Holyrood Constituency|Test Scottish Region</field>
+      </row>
+      <row>
+          <field name="postcode">SE17 3HE</field>
+          <field name="name">Test Westminster Constituency</field>
+      </row>
+      <row>
+          <field name="postcode">OX1 4LF</field>
+          <field name="name">Another Westminster Constituency</field>
+      </row>
+	</table_data>
+	<table_data name="search_query_log">
+	</table_data>
+	<table_data name="survey">
+	</table_data>
+	<table_data name="titles">
+	</table_data>
+	<table_data name="titles_ignored">
+	</table_data>
+	<table_data name="trackbacks">
+	</table_data>
+	<table_data name="users">
+	</table_data>
+	<table_data name="uservotes">
+	</table_data>
+	<table_data name="video_timestamps">
+	</table_data>
+	<table_data name="editorial">
+	</table_data>
+</database>
+</mysqldump>


### PR DESCRIPTION
If someone is signing up for and alert that is of the form

    ZZ1 1AA elephants

then it's likely they actually want to sign up for the MP for that
postcode mentioning elephants so put in a notice to this effect and also
a button to enable them to subscribe to an alert for that.

part of #593