### PR TITLE
Add postcode search to /mp page if redirect fails

### DIFF
--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -671,13 +671,37 @@ try {
     }
 
 } catch (MySociety\TheyWorkForYou\MemberException $e){
+    global $this_page;
+
+    switch($this_page) {
+    case 'mla':
+        $rep = 'MLA';
+        $SEARCHURL = '/postcode/';
+        $MPSURL = new \URL('mlas');
+        break;
+    case 'msp':
+        $rep = 'MSP';
+        $SEARCHURL = '/postcode/';
+        $MPSURL = new \URL('msps');
+        break;
+    case 'peer':
+        $rep = 'Lord';
+        $SEARCHURL = '';
+        $MPSURL = new \URL('peers');
+        break;
+    default:
+        $rep = 'MP';
+        $SEARCHURL = new \URL('mp');
+        $SEARCHURL = $SEARCHURL->generate();
+        $MPSURL = new \URL('mps');
+    }
 
     // The message belongs in the output...
     $data['error'] = $e->getMessage();
 
-    // Generate a URL to a full list to try get the user back on track.
-    $MPSURL = new \URL('mps');
+    $data['rep_name'] = $rep;
     $data['all_mps_url'] = $MPSURL->generate();
+    $data['rep_search_url'] = $SEARCHURL;
 
     // Render it!
     MySociety\TheyWorkForYou\Renderer::output('mp/error', $data);

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -735,3 +735,11 @@ a[href^="http://www.publicwhip.org"] {
         }
     }
 }
+
+.mp-postcode-search {
+    @include grid-column(12);
+    @media (min-width: $medium-screen) {
+        @include grid-column(4);
+        margin-bottom: em-calc(30);
+    }
+}

--- a/www/includes/easyparliament/metadata.php
+++ b/www/includes/easyparliament/metadata.php
@@ -545,7 +545,7 @@ $this->page = array (
 ),
     'mla' => array (
         'parent'		=> 'mlas',
-        'title'			=> 'MLA',
+        'title'			=> 'Find your MLA',
         'url'			=> 'mla/'
     ),
     'mlas' => array (
@@ -568,13 +568,13 @@ $this->page = array (
     ),
     'msp' => array (
         'parent'		=> 'msps',
-        'title'			=> 'MSP',
+        'title'			=> 'Find your MSP',
         'url'			=> 'msp/'
     ),
     /* Not 'Your MP', whose name is 'yourmp'... */
     'mp' => array (
         'parent'			=> 'mps',
-        'title'			=> 'MP',
+        'title'			=> 'Find your MP',
         'url'			=> 'mp/'
     ),
     'emailfriend' => array (

--- a/www/includes/easyparliament/templates/html/mp/error.php
+++ b/www/includes/easyparliament/templates/html/mp/error.php
@@ -6,8 +6,35 @@
 
             <p><?= $error ?></p>
 
-            <p>Why not <a href="<?= $all_mps_url ?>">browse all MPs</a>?</p>
+        <?php if ( $rep_search_url ) { ?>
+            <p>Why not&hellip;</p>
 
         </div>
+
+        <div class="full-page__unit">
+            <div class="mp-postcode-search">
+            <h3>Search for your <?= $rep_name ?> by postcode</h3>
+
+            <form action="<?= $rep_search_url ?>" method="get">
+
+                    <div class="row collapse">
+                        <div class="small-10 columns">
+                            <input type="text" name="pc" value="" maxlength="10" size="10" placeholder="Your postcode">
+                        </div>
+                        <div class="small-2 columns">
+                            <input type="submit" value="GO" class="button prefix">
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <div class="full-page__unit">
+        <p>Or <a href="<?= $all_mps_url ?>">browse all <?= $rep_name ?>s</a>?</p>
+        </div>
+        <?php } else { ?>
+        <p>Why not <a href="<?= $all_mps_url ?>">browse all <?= $rep_name ?>s</a>?</p>
+        </div>
+        <? } ?>
     </div>
 </div>


### PR DESCRIPTION
If someone arrives at /mp without either a session with a postcode or a query string then present them with a postcode lookup dialog and also a link to the appropriate list of representatives for the page type.