### PR TITLE
Standardise page gutters on "new" pages

### DIFF
--- a/www/docs/style/sass/_twfy-mixins.scss
+++ b/www/docs/style/sass/_twfy-mixins.scss
@@ -141,8 +141,7 @@ $weight_bold: 700;
     @include grid-column(12);
 }
 
-.nested-row,
-.page-content__row {
+.nested-row {
   @include grid-row(nest);
   // a nested grid row, used generically to add a nested grid row
 }

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -276,33 +276,49 @@
     }
 }
 
-.person-content__header {
-    /*@include grid-row;*/
-}
 .person-panels {
-    margin-top: em-calc(40);
+    padding-top: em-calc(36);
+    clear: both;
+
     .in-page-nav {
         display: none;
+
         @media (min-width: $medium-screen) {
             display: block;
         }
-        padding: 0px;
+
         & > * {
             @include radius(3px);
+
             &.fixed {
-                width: 16%;
-                max-width: 187px;
+                // Use Foundation functions to work out the width of a 2-column
+                // grid unit, minus default gutter.
+                $percentWidth: gridCalc(2, 12) - $column-gutter; // 13.666666%
+                width: $percentWidth;
+
+                // Element is position:fixed, so width is relative to viewport,
+                // not parent. To stop the element expanding when the window is
+                // wider than 1140px, we cap it to a max-width of X% of 1140px.
+                max-width: 1140px * strip-unit($percentWidth) / 100;
             }
+
             background-color: white;
             margin-left: 0px;
             margin-bottom: 0px;
             font-size: em-calc(16);
         }
+
+        .magellan-placeholder {
+          display: none;
+        }
+
+        .fixed + .magellan-placeholder {
+          display: block;
+        }
+
         li {
             list-style-position: inside;
-            padding-left: 1.5em;
-            padding-top: 0.5em;
-            padding-bottom: 0.5em;
+            padding: 0.5em 0.5em 0.5em 1.5em;
             line-height: 1.3em;
             border-bottom: 1px solid $body-bg;
             color: $borders;

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -10,8 +10,6 @@
 
     .person-header__content {
         color: white;
-        margin-left: 1.5%;
-        margin-right: 1.5%;
 
         @media (min-width: $medium-screen) {
             position: relative; // for search and button positioning

--- a/www/docs/style/sass/pages/_section.scss
+++ b/www/docs/style/sass/pages/_section.scss
@@ -61,15 +61,6 @@ span.hi {
   margin-top: 0;
 }
 
-.debate-header__content {
-  padding-left: 1em;
-  padding-right: 1em;
-  @media (min-width: $large-screen) {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
 .debate-speech {
   background-color: #fff;
   border-top: 1px solid $borders;
@@ -85,7 +76,6 @@ span.hi {
 
   .full-page__row {
     width: auto;
-    padding: 0 20px;
     position: relative;
   }
 
@@ -105,10 +95,6 @@ span.hi {
   @media (min-width: $large-screen) {
     padding-top: 40px;
     padding-bottom: 40px;
-
-    .full-page__row {
-      padding: 0;
-    }
   }
 }
 
@@ -451,10 +437,10 @@ span.hi {
 
 .debate-navigation {
   background-color: $body-bg;
-  padding:0 1em;
   text-align: center;
   @include clearfix;
   position: relative;
+
   a {
     display: block;
     color: $light-text;

--- a/www/docs/style/sass/pages/_topics.scss
+++ b/www/docs/style/sass/pages/_topics.scss
@@ -19,41 +19,35 @@
     background-position: center center;
     background-size: cover;
 
-    .topic-header__content {
-        color: white;
+    .full-page__row {
+        position: relative; // for .topic-postcode-search absolute position
+    }
+
+    .topic-name {
+        color: #fff;
+        @include grid-column(12);
+
+        @media (min-width: $medium-screen) {
+            @include grid-column(8);
+        }
+
+        h1 {
+            color: inherit;
+            margin: 0px;
+            padding: 0px;
+        }
+    }
+
+    .topic-postcode-search {
+        background: rgb(243, 241, 235);
         @include grid-column(12);
         @media (min-width: $medium-screen) {
-            position: relative;
+            @include grid-column(4);
+            position: absolute;
+            bottom: 0;
+            right: 0;
+            margin-bottom: em-calc(30);
         }
-        @media (min-width: $large-screen) {
-            @include grid-column(10);
-        }
-        .topic-name {
-            h1 {
-                color: white;
-                margin: 0px;
-                padding: 0px;
-            }
-
-            @include grid-column(12);
-            @media (min-width: $medium-screen) {
-                @include grid-column(8);
-            }
-
-        }
-
-        .topic-postcode-search {
-            background: rgb(243, 241, 235);
-            @include grid-column(12);
-            @media (min-width: $medium-screen) {
-                @include grid-column(4);
-                position: absolute;
-                bottom: 0;
-                right: 0;
-                margin-bottom: em-calc(30);
-            }
-        }
-
     }
 }
 

--- a/www/includes/easyparliament/templates/html/mp/divisions.php
+++ b/www/includes/easyparliament/templates/html/mp/divisions.php
@@ -5,164 +5,164 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 <div class="full-page">
     <div class="full-page__row">
         <div class="full-page__unit">
-            <div class="person-navigation page-content__row">
+            <div class="person-navigation">
                 <ul>
                     <li><a href="<?= $member_url ?>">Overview</a></li>
                     <li class="active"><a href="<?= $member_url ?>/votes">Voting Record</a></li>
                 </ul>
             </div>
-            <div class="person-panels page-content__row">
-                <div class="sidebar__unit in-page-nav">
-                    <?php if ( isset($policydivisions) && $policydivisions && count($policydivisions) == 1 ) { ?>
-                    <p class="policy-votes-intro">
-                        How <?= $full_name ?> voted on <?= $policydivisions[array_keys($policydivisions)[0]]['desc'] ?>.
-                    </p>
-                    <?php } ?>
-                    <ul>
-                        <li><a href="<?= $member_url ?>/votes">Back to all topics</a></li>
-                    </ul>
+        </div>
+        <div class="person-panels">
+            <div class="sidebar__unit in-page-nav">
+                <?php if ( isset($policydivisions) && $policydivisions && count($policydivisions) == 1 ) { ?>
+                <p class="policy-votes-intro">
+                    How <?= $full_name ?> voted on <?= $policydivisions[array_keys($policydivisions)[0]]['desc'] ?>.
+                </p>
+                <?php } ?>
+                <ul>
+                    <li><a href="<?= $member_url ?>/votes">Back to all topics</a></li>
+                </ul>
+            </div>
+
+            <div class="primary-content__unit">
+
+                <?php if ($party == 'Sinn Fein' && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+                <div class="panel">
+                    <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
                 </div>
+                <?php endif; ?>
 
-                <div class="primary-content__unit">
+                <?php $displayed_votes = FALSE; ?>
+                <?php if ( isset($policydivisions) && $policydivisions ) { ?>
+                    <?php if ( $answered_q ) { ?>
+                        <p class="panel panel--feedback">
+                            Thanks for the feedback.
+                        </p>
+                    <?php } else { ?>
+                        <form method="post" action="<?= OPTION_SURVEY_URL ?>" class="panel panel--feedback">
+                            <input type="hidden" name="sourceidentifier" value="divisions-suggestions">
+                            <input type="hidden" name="datetime" value="<?=time() ?>">
+                            <input type="hidden" name="subgroup" value="0">
 
-                    <?php if ($party == 'Sinn Fein' && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
-                    <div class="panel">
-                        <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
-                    </div>
-                    <?php endif; ?>
+                            <input type="hidden" name="user_code" value="<?=$user_code ?>">
+                            <input type="hidden" name="auth_signature" value="<?=$auth_signature ?>">
 
-                    <?php $displayed_votes = FALSE; ?>
-                    <?php if ( isset($policydivisions) && $policydivisions ) { ?>
-                        <?php if ( $answered_q ) { ?>
-                            <p class="panel panel--feedback">
-                                Thanks for the feedback.
+                            <input type="hidden" name="came_from" value="<?=$page_url ?>">
+                            <input type="hidden" name="return_url" value="<?=$page_url ?>">
+                            <p>
+                                <strong>This page is new!</strong>
+                                Is there anything else you&rsquo;d like to see on it?
                             </p>
-                        <?php } else { ?>
-                            <form method="post" action="<?= OPTION_SURVEY_URL ?>" class="panel panel--feedback">
-                                <input type="hidden" name="sourceidentifier" value="divisions-suggestions">
-                                <input type="hidden" name="datetime" value="<?=time() ?>">
-                                <input type="hidden" name="subgroup" value="0">
+                            <p>
+                                <input type="text" name="policy-page-suggestion" placeholder="I want to see&hellip;">
+                                <input type="submit" class="button small" value="Make it happen!">
+                            </p>
+                        </form>
+                    <?php } ?>
 
-                                <input type="hidden" name="user_code" value="<?=$user_code ?>">
-                                <input type="hidden" name="auth_signature" value="<?=$auth_signature ?>">
+                    <?php if ($has_voting_record) { ?>
 
-                                <input type="hidden" name="came_from" value="<?=$page_url ?>">
-                                <input type="hidden" name="return_url" value="<?=$page_url ?>">
-                                <p>
-                                    <strong>This page is new!</strong>
-                                    Is there anything else you&rsquo;d like to see on it?
-                                </p>
-                                <p>
-                                    <input type="text" name="policy-page-suggestion" placeholder="I want to see&hellip;">
-                                    <input type="submit" class="button small" value="Make it happen!">
-                                </p>
-                            </form>
-                        <?php } ?>
+                        <?php foreach ($policydivisions as $policy) { ?>
 
-                        <?php if ($has_voting_record) { ?>
+                            <?php if ( isset($policy['header']) ) { ?>
+                                <div class="panel policy-votes-hero" style="background-image: url('<?php echo $policy['header']['image']; ?>');">
+                                    <h2><?php echo $policy['header']['title']; ?></h2>
+                                    <p><?php echo $policy['header']['description']; ?>.</p>
+                                    <?php if ( $policy['header']['image_source'] ) { ?>
+                                    <span class="policy-votes-hero__image-attribution">
+                                        Photo:
+                                        <a href="<?php echo $policy['header']['image_source']; ?>">
+                                            <?php echo $policy['header']['image_attribution']; ?>
+                                        </a>
+                                        <a href="<?php echo $policy['header']['image_license_url']; ?>">
+                                            <?php echo $policy['header']['image_license']; ?>
+                                        </a>
+                                    </span>
+                                    <?php } ?>
+                                </div>
+                            <?php } ?>
 
-                            <?php foreach ($policydivisions as $policy) { ?>
 
-                                <?php if ( isset($policy['header']) ) { ?>
-                                    <div class="panel policy-votes-hero" style="background-image: url('<?php echo $policy['header']['image']; ?>');">
-                                        <h2><?php echo $policy['header']['title']; ?></h2>
-                                        <p><?php echo $policy['header']['description']; ?>.</p>
-                                        <?php if ( $policy['header']['image_source'] ) { ?>
-                                        <span class="policy-votes-hero__image-attribution">
-                                            Photo:
-                                            <a href="<?php echo $policy['header']['image_source']; ?>">
-                                                <?php echo $policy['header']['image_attribution']; ?>
-                                            </a>
-                                            <a href="<?php echo $policy['header']['image_license_url']; ?>">
-                                                <?php echo $policy['header']['image_license']; ?>
-                                            </a>
-                                        </span>
+                            <?php if ( isset($policy['position']) ) { ?>
+                                <div class="panel">
+                                    <h3 class="policy-vote-overall-stance">
+                                        <?= $full_name ?> <?= $policy['position']['voted'] == 'never voted' ? $policy['position']['voted'] . ' on' : 'voted ' .$policy['position']['voted'] ?> <?= $policy['desc'] ?>
+                                    </h3>
+
+                                    <?php if ( DEVSITE ) { ?>
+                                    <p class="policy-vote-agree-disagree">
+                                        <button class="button">I agree with this MP</button>
+                                        <button class="button button--negative">I disagree with this MP</button>
+                                    </p>
+                                    <?php } ?>
+
+                                    <h3 class="policy-votes-list-header"><span id="policy-votes-type">All</span> votes about <?= $policy['desc'] ?>:</h3>
+
+                                    <ul class="vote-descriptions policy-votes">
+                                    <?php
+                                        $show_all = FALSE;
+                                        if ( $policy['weak_count'] == count($policy['divisions']) ) {
+                                            $show_all = TRUE;
+                                        }
+                                    ?>
+                                    <?php foreach ($policy['divisions'] as $division) { ?>
+                                        <li id="<?= $division['division_id'] ?>" class="<?= $division['strong'] || $show_all ? 'policy-vote--major' : 'policy-vote--minor' ?>">
+                                            <span class="policy-vote__date">On <?= strftime('%e %b %Y', strtotime($division['date'])) ?>:</span>
+                                            <span class="policy-vote__text"><?= $full_name ?><?= $division['text'] ?></span>
+                                            <?php if ( $division['url'] ) { ?>
+                                                <a class="vote-description__source" href="<?= $division['url'] ?>">Show full debate</a>
+                                            <?php } ?>
+                                        </li>
+
+                                    <?php $displayed_votes = TRUE; ?>
+
+                                    <?php } ?>
+                                    </ul>
+
+                                    <div class="policy-votes-list-footer">
+                                        <p class="policy-votes__byline">Vote information from <a href="http://www.publicwhip.org.uk/mp.php?mpid=<?= $member_id ?>&dmp=<?= $policy['policy_id'] ?>">PublicWhip</a></p>
+                                        <?php if ( !$show_all && $policy['weak_count'] > 0 ) { ?>
+                                        <p><button class="button secondary-button small js-show-all-votes">Show all votes, including <?= $policy['weak_count'] ?> less important <?= $policy['weak_count'] == 1 ? 'vote' : 'votes' ?></button></p>
                                         <?php } ?>
                                     </div>
-                                <?php } ?>
 
-
-                                <?php if ( isset($policy['position']) ) { ?>
-                                    <div class="panel">
-                                        <h3 class="policy-vote-overall-stance">
-                                            <?= $full_name ?> <?= $policy['position']['voted'] == 'never voted' ? $policy['position']['voted'] . ' on' : 'voted ' .$policy['position']['voted'] ?> <?= $policy['desc'] ?>
-                                        </h3>
-
-                                        <?php if ( DEVSITE ) { ?>
-                                        <p class="policy-vote-agree-disagree">
-                                            <button class="button">I agree with this MP</button>
-                                            <button class="button button--negative">I disagree with this MP</button>
-                                        </p>
+                                    <script type="text/javascript">
+                                    $(function(){
+                                        <?php if ( !$show_all ) { ?>
+                                        $('#policy-votes-type').text('Key');
                                         <?php } ?>
+                                        $('.js-show-all-votes').on('click', function(){
+                                            $(this).fadeOut();
+                                            $('.policy-vote--minor').slideDown();
+                                            $('#policy-votes-type').text('All');
+                                        });
+                                    })
+                                    </script>
 
-                                        <h3 class="policy-votes-list-header"><span id="policy-votes-type">All</span> votes about <?= $policy['desc'] ?>:</h3>
-
-                                        <ul class="vote-descriptions policy-votes">
-                                        <?php
-                                            $show_all = FALSE;
-                                            if ( $policy['weak_count'] == count($policy['divisions']) ) {
-                                                $show_all = TRUE;
-                                            }
-                                        ?>
-                                        <?php foreach ($policy['divisions'] as $division) { ?>
-                                            <li id="<?= $division['division_id'] ?>" class="<?= $division['strong'] || $show_all ? 'policy-vote--major' : 'policy-vote--minor' ?>">
-                                                <span class="policy-vote__date">On <?= strftime('%e %b %Y', strtotime($division['date'])) ?>:</span>
-                                                <span class="policy-vote__text"><?= $full_name ?><?= $division['text'] ?></span>
-                                                <?php if ( $division['url'] ) { ?>
-                                                    <a class="vote-description__source" href="<?= $division['url'] ?>">Show full debate</a>
-                                                <?php } ?>
-                                            </li>
-
-                                        <?php $displayed_votes = TRUE; ?>
-
-                                        <?php } ?>
-                                        </ul>
-
-                                        <div class="policy-votes-list-footer">
-                                            <p class="policy-votes__byline">Vote information from <a href="http://www.publicwhip.org.uk/mp.php?mpid=<?= $member_id ?>&dmp=<?= $policy['policy_id'] ?>">PublicWhip</a></p>
-                                            <?php if ( !$show_all && $policy['weak_count'] > 0 ) { ?>
-                                            <p><button class="button secondary-button small js-show-all-votes">Show all votes, including <?= $policy['weak_count'] ?> less important <?= $policy['weak_count'] == 1 ? 'vote' : 'votes' ?></button></p>
-                                            <?php } ?>
-                                        </div>
-
-                                        <script type="text/javascript">
-                                        $(function(){
-                                            <?php if ( !$show_all ) { ?>
-                                            $('#policy-votes-type').text('Key');
-                                            <?php } ?>
-                                            $('.js-show-all-votes').on('click', function(){
-                                                $(this).fadeOut();
-                                                $('.policy-vote--minor').slideDown();
-                                                $('#policy-votes-type').text('All');
-                                            });
-                                        })
-                                        </script>
-
-                                    </div>
-                                <?php } ?>
+                                </div>
                             <?php } ?>
                         <?php } ?>
-
                     <?php } ?>
 
-                    <?php if (!$displayed_votes) { ?>
+                <?php } ?>
 
-                        <div class="panel">
-                            <p>This person has not voted on this policy.</p>
-                        </div>
-
-                    <?php } ?>
-
-
+                <?php if (!$displayed_votes) { ?>
 
                     <div class="panel">
-                        <p>Please feel free to use the data on this page, but if
-                            you do you must cite TheyWorkForYou.com in the body
-                            of your articles as the source of any analysis or
-                            data you get off this site.</p>
+                        <p>This person has not voted on this policy.</p>
                     </div>
 
+                <?php } ?>
+
+
+
+                <div class="panel">
+                    <p>Please feel free to use the data on this page, but if
+                        you do you must cite TheyWorkForYou.com in the body
+                        of your articles as the source of any analysis or
+                        data you get off this site.</p>
                 </div>
+
             </div>
         </div>
     </div>

--- a/www/includes/easyparliament/templates/html/mp/header.php
+++ b/www/includes/easyparliament/templates/html/mp/header.php
@@ -1,74 +1,76 @@
     <div class="regional-header regional-header--<?= $current_assembly ?>">
         <div class="regional-header__overlay"></div>
         <div class="person-header <?= $this_page ?> <?= (isset($data['photo_attribution_text'])?'has-data-attribution':'') ?>">
-            <div class=" full-page__row">
-            <div class="person-header__content page-content__row">
-                <div class="person-name">
-                  <?php if ( $image ) { ?>
-                    <div class="mp-image">
-                        <img src="<?= $image['url'] ?>" height="48">
-                    </div>
-                  <?php } ?>
-                    <div class="mp-name-and-position">
-                        <h1><?= $full_name ?></h1>
-                      <?php if ($current_position) { ?>
-                         <p><?= $current_position ?></p>
-                      <?php } else if ($former_position) { ?>
-                         <p><?= $former_position ?></p>
-                      <?php } ?>
-                    </div>
-                </div>
-                <?php if($image && $image['exists']): ?>
-                    <?php if(isset($data['photo_attribution_text'])) { ?>
-                        <div class="person-data-attribution">
-                          <?php if(isset($data['photo_attribution_link'])) { ?>
-                            Profile photo: <a href="<?= $data['photo_attribution_link'] ?>"><?= $data['photo_attribution_text'] ?></a>
-                          <?php } else { ?>
-                            Profile photo: <?= $data['photo_attribution_text'] ?>
+            <div class="full-page__row">
+                <div class="full-page__unit">
+                    <div class="person-header__content">
+                        <div class="person-name">
+                          <?php if ( $image ) { ?>
+                            <div class="mp-image">
+                                <img src="<?= $image['url'] ?>" height="48">
+                            </div>
+                          <?php } ?>
+                            <div class="mp-name-and-position">
+                                <h1><?= $full_name ?></h1>
+                              <?php if ($current_position) { ?>
+                                 <p><?= $current_position ?></p>
+                              <?php } else if ($former_position) { ?>
+                                 <p><?= $former_position ?></p>
+                              <?php } ?>
+                            </div>
+                        </div>
+                        <?php if($image && $image['exists']): ?>
+                            <?php if(isset($data['photo_attribution_text'])) { ?>
+                                <div class="person-data-attribution">
+                                  <?php if(isset($data['photo_attribution_link'])) { ?>
+                                    Profile photo: <a href="<?= $data['photo_attribution_link'] ?>"><?= $data['photo_attribution_text'] ?></a>
+                                  <?php } else { ?>
+                                    Profile photo: <?= $data['photo_attribution_text'] ?>
+                                  <?php } ?>
+                                </div>
+                            <?php } ?>
+                        <?php else: ?>
+                            <div class="person-data-attribution">
+                                We&rsquo;re missing a photo of <?= $full_name ?>. If you have a
+                                photo <em>that you can release under a Creative Commons Attribution-ShareAlike
+                                license</em> or can locate a <em>copyright free</em> photo,
+                                <a href="mailto:<?= str_replace('@', '&#64;', CONTACTEMAIL) ?>">please email it to us</a>.
+                                Please do not email us about copyrighted photos elsewhere on the internet; we can&rsquo;t
+                                use them.
+                            </div>
+                        <?php endif; ?>
+                        <div class="person-constituency">
+                          <?php if ( $constituency && $this_page != 'peer' && $this_page != 'royal' ) { ?>
+                            <span class="constituency"><?= $constituency ?></span>
+                          <?php } ?>
+                          <?php if ( $party ) { ?>
+                            <span class="party <?= $party_short ?>"><?= $party ?></span>
                           <?php } ?>
                         </div>
-                    <?php } ?>
-                <?php else: ?>
-                    <div class="person-data-attribution">
-                        We&rsquo;re missing a photo of <?= $full_name ?>. If you have a
-                        photo <em>that you can release under a Creative Commons Attribution-ShareAlike
-                        license</em> or can locate a <em>copyright free</em> photo,
-                        <a href="mailto:<?= str_replace('@', '&#64;', CONTACTEMAIL) ?>">please email it to us</a>.
-                        Please do not email us about copyrighted photos elsewhere on the internet; we can&rsquo;t
-                        use them.
-                    </div>
-                <?php endif; ?>
-                <div class="person-constituency">
-                  <?php if ( $constituency && $this_page != 'peer' && $this_page != 'royal' ) { ?>
-                    <span class="constituency"><?= $constituency ?></span>
-                  <?php } ?>
-                  <?php if ( $party ) { ?>
-                    <span class="party <?= $party_short ?>"><?= $party ?></span>
-                  <?php } ?>
-                </div>
-                <div class="person-search">
-                    <form action="<?= $search_url ?>" method="get" onsubmit="trackFormSubmit(this, 'Search', 'Submit', 'Person'); return false;">
-                        <input id="person_search_input" name="q" maxlength="200" placeholder="Search this person's speeches"><input type="submit" class="submit" value="GO">
-                        <input type="hidden" name="pid" value="<?= $person_id ?>">
-                    </form>
-                </div>
-                <div class="person-buttons">
-                  <?php if ($current_member_anywhere && $this_page != 'royal') { ?>
-                    <a href="https://www.writetothem.com/<?php
-                        if ($current_member[HOUSE_TYPE_LORDS]) {
-                            echo "?person=uk.org.publicwhip/person/$person_id";
-                        }
-                        if ($the_users_mp) {
-                            echo "?a=WMC&amp;pc=" . _htmlentities(urlencode($user_postcode));
-                        }
-                    ?>" class="button wtt" onclick="trackLinkClick(this, 'Links', 'WriteToThem', 'Person'); return false;"><img src="/style/img/envelope.png">Send a message</a>
+                        <div class="person-search">
+                            <form action="<?= $search_url ?>" method="get" onsubmit="trackFormSubmit(this, 'Search', 'Submit', 'Person'); return false;">
+                                <input id="person_search_input" name="q" maxlength="200" placeholder="Search this person's speeches"><input type="submit" class="submit" value="GO">
+                                <input type="hidden" name="pid" value="<?= $person_id ?>">
+                            </form>
+                        </div>
+                        <div class="person-buttons">
+                          <?php if ($current_member_anywhere && $this_page != 'royal') { ?>
+                            <a href="https://www.writetothem.com/<?php
+                                if ($current_member[HOUSE_TYPE_LORDS]) {
+                                    echo "?person=uk.org.publicwhip/person/$person_id";
+                                }
+                                if ($the_users_mp) {
+                                    echo "?a=WMC&amp;pc=" . _htmlentities(urlencode($user_postcode));
+                                }
+                            ?>" class="button wtt" onclick="trackLinkClick(this, 'Links', 'WriteToThem', 'Person'); return false;"><img src="/style/img/envelope.png">Send a message</a>
 
-                  <?php } ?>
-                  <?php if ($has_email_alerts) { ?>
-                    <a href="<?= WEBPATH ?>alert/?pid=<?= $person_id ?>#" class="button alert" onclick="trackLinkClick(this, 'Alert', 'Search', 'Person'); return false;"><img src="/style/img/plus-circle.png">Get email updates</a>
-                  <?php } ?>
+                          <?php } ?>
+                          <?php if ($has_email_alerts) { ?>
+                            <a href="<?= WEBPATH ?>alert/?pid=<?= $person_id ?>#" class="button alert" onclick="trackLinkClick(this, 'Alert', 'Search', 'Person'); return false;"><img src="/style/img/plus-circle.png">Get email updates</a>
+                          <?php } ?>
+                        </div>
+                    </div>
                 </div>
-            </div>
             </div>
         </div>
     </div>

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -6,312 +6,312 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
     <div class="full-page__row">
         <div class="full-page__unit">
             <?php if (count($policyPositions->positions) > 0): ?>
-            <div class="person-navigation page-content__row">
+            <div class="person-navigation">
                 <ul>
                     <li class="active"><a href="<?= $member_url ?>">Overview</a></li>
                     <li><a href="<?= $member_url ?>/votes">Voting Record</a></li>
                 </ul>
             </div>
             <?php endif; ?>
-            <div class="person-panels page-content__row">
-                <div class="sidebar__unit in-page-nav">
-                    <ul data-magellan-expedition="fixed">
-                      <?php if (count($policyPositions->positions) > 0): ?>
-                        <li data-magellan-arrival="votes"><a href="#votes">Votes</a></li>
-                      <?php endif; ?>
-                      <?php if (count($recent_appearances['appearances'])): ?>
-                        <li data-magellan-arrival="appearances"><a href="#appearances">Appearances</a></li>
-                      <?php endif; ?>
-                        <li data-magellan-arrival="profile"><a href="#profile">Profile</a></li>
-                      <?php if (count($numerology) > 0): ?>
-                        <li data-magellan-arrival="numerology"><a href="#numerology">Numerology</a></li>
-                      <?php endif; ?>
-                      <?php if ($register_interests): ?>
-                        <li data-magellan-arrival="register"><a href="#register">Register of Interests</a></li>
-                      <?php endif; ?>
-                        <li hidden id="research-qual2-bucket2"><a href="/action/where-next">What to do with the information on this page?</a></li>
-                    </ul>
-                    <div>&nbsp;</div>
+        </div>
+        <div class="person-panels">
+            <div class="sidebar__unit in-page-nav">
+                <ul data-magellan-expedition="fixed">
+                  <?php if (count($policyPositions->positions) > 0): ?>
+                    <li data-magellan-arrival="votes"><a href="#votes">Votes</a></li>
+                  <?php endif; ?>
+                  <?php if (count($recent_appearances['appearances'])): ?>
+                    <li data-magellan-arrival="appearances"><a href="#appearances">Appearances</a></li>
+                  <?php endif; ?>
+                    <li data-magellan-arrival="profile"><a href="#profile">Profile</a></li>
+                  <?php if (count($numerology) > 0): ?>
+                    <li data-magellan-arrival="numerology"><a href="#numerology">Numerology</a></li>
+                  <?php endif; ?>
+                  <?php if ($register_interests): ?>
+                    <li data-magellan-arrival="register"><a href="#register">Register of Interests</a></li>
+                  <?php endif; ?>
+                    <li hidden id="research-qual2-bucket2"><a href="/action/where-next">What to do with the information on this page?</a></li>
+                </ul>
+                <div class="magellan-placeholder">&nbsp;</div>
+            </div>
+            <div class="primary-content__unit">
+
+                <?php if (($party == 'Sinn Fein' || $party == utf8_decode('Sinn Féin')) && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+                <div class="panel">
+                    <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
                 </div>
-                <div class="primary-content__unit">
+                <?php elseif (isset($is_new_mp) && $is_new_mp && count($recent_appearances['appearances']) == 0): ?>
+                <div class="panel--secondary">
+                    <h3><?= $full_name ?> is a recently elected MP &ndash; elected on <?= format_date($entry_date, LONGDATEFORMAT) ?></h3>
 
-                    <?php if (($party == 'Sinn Fein' || $party == utf8_decode('Sinn Féin')) && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
-                    <div class="panel">
-                        <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
-                    </div>
-                    <?php elseif (isset($is_new_mp) && $is_new_mp && count($recent_appearances['appearances']) == 0): ?>
-                    <div class="panel--secondary">
-                        <h3><?= $full_name ?> is a recently elected MP &ndash; elected on <?= format_date($entry_date, LONGDATEFORMAT) ?></h3>
+                    <p>When <?= $full_name ?> starts to speak in debates and vote on bills, that information will appear on this page.</p>
 
-                        <p>When <?= $full_name ?> starts to speak in debates and vote on bills, that information will appear on this page.</p>
+                  <?php if ($has_email_alerts) { ?>
+                    <a href="<?= WEBPATH ?>alert/?pid=<?= $person_id ?>#" onclick="trackLinkClick(this, 'Alert', 'Search', 'Person'); return false;">Sign up for email alerts to be the first to know when that happens.</a>
+                  <?php } ?>
+                </div>
+                <?php endif; ?>
 
-                      <?php if ($has_email_alerts) { ?>
-                        <a href="<?= WEBPATH ?>alert/?pid=<?= $person_id ?>#" onclick="trackLinkClick(this, 'Alert', 'Search', 'Person'); return false;">Sign up for email alerts to be the first to know when that happens.</a>
-                      <?php } ?>
-                    </div>
-                    <?php endif; ?>
+                <?php if (count($policyPositions->positions) > 0): ?>
+                <div class="panel">
+                    <a name="votes"></a>
+                    <h2 data-magellan-destination="votes">A selection of <?= $full_name ?>'s votes</h2>
+
+                    <p><a href="<?= $member_url ?>/votes">See full list of topics voted on</a></p>
 
                     <?php if (count($policyPositions->positions) > 0): ?>
-                    <div class="panel">
-                        <a name="votes"></a>
-                        <h2 data-magellan-destination="votes">A selection of <?= $full_name ?>'s votes</h2>
 
-                        <p><a href="<?= $member_url ?>/votes">See full list of topics voted on</a></p>
+                        <ul class="vote-descriptions">
+                          <?php foreach ($policyPositions->positions as $key_vote): ?>
+                            <li>
+                                <?= $key_vote['desc'] ?>
+                                <a class="vote-description__source" href="<?= $member_url?>/divisions?policy=<?= $key_vote['policy_id'] ?>">Details</a>
+                            </li>
+                          <?php endforeach; ?>
+                        </ul>
 
-                        <?php if (count($policyPositions->positions) > 0): ?>
+                        <p>New: more <a href="<?= $member_url ?>/votes">analysis of votes</a> on <a href="<?= $member_url ?>/votes#health">health</a>, <a href="<?= $member_url ?>/votes#welfare">welfare</a>, <a href="<?= $member_url ?>/votes#foreign">foreign policy</a>, <a href="<?= $member_url ?>/votes#social">social issues</a>, <a href="<?= $member_url ?>/votes#taxation">taxation</a> and more.</p>
 
-                            <ul class="vote-descriptions">
-                              <?php foreach ($policyPositions->positions as $key_vote): ?>
-                                <li>
-                                    <?= $key_vote['desc'] ?>
-                                    <a class="vote-description__source" href="<?= $member_url?>/divisions?policy=<?= $key_vote['policy_id'] ?>">Details</a>
-                                </li>
-                              <?php endforeach; ?>
-                            </ul>
+                    <?php else: ?>
 
-                            <p>New: more <a href="<?= $member_url ?>/votes">analysis of votes</a> on <a href="<?= $member_url ?>/votes#health">health</a>, <a href="<?= $member_url ?>/votes#welfare">welfare</a>, <a href="<?= $member_url ?>/votes#foreign">foreign policy</a>, <a href="<?= $member_url ?>/votes#social">social issues</a>, <a href="<?= $member_url ?>/votes#taxation">taxation</a> and more.</p>
+                        <p>No votes to display.</p>
 
-                        <?php else: ?>
-
-                            <p>No votes to display.</p>
-
-                        <?php endif; ?>
-
-                        <p><?= $full_name ?> <?= $rebellion_rate ?></p>
-
-                    </div>
                     <?php endif; ?>
 
-                    <?php if (count($recent_appearances['appearances'])): ?>
-                    <div class="panel">
-                        <a name="appearances"></a>
-                        <h2 data-magellan-destination="appearances">Recent appearances</h2>
+                    <p><?= $full_name ?> <?= $rebellion_rate ?></p>
 
-                        <?php if (count($recent_appearances['appearances']) > 0): ?>
+                </div>
+                <?php endif; ?>
 
-                            <ul class="appearances">
+                <?php if (count($recent_appearances['appearances'])): ?>
+                <div class="panel">
+                    <a name="appearances"></a>
+                    <h2 data-magellan-destination="appearances">Recent appearances</h2>
 
-                            <?php foreach ($recent_appearances['appearances'] as $recent_appearance): ?>
+                    <?php if (count($recent_appearances['appearances']) > 0): ?>
 
-                                <li>
-                                    <h4><a href="<?= $recent_appearance['listurl'] ?>"><?= $recent_appearance['parent']['body'] ?></a> <span class="date"><?= date('j M Y', strtotime($recent_appearance['hdate'])) ?></span></h4>
-                                    <blockquote><?= $recent_appearance['extract'] ?></blockquote>
-                                </li>
+                        <ul class="appearances">
 
-                            <?php endforeach; ?>
+                        <?php foreach ($recent_appearances['appearances'] as $recent_appearance): ?>
 
-                            </ul>
+                            <li>
+                                <h4><a href="<?= $recent_appearance['listurl'] ?>"><?= $recent_appearance['parent']['body'] ?></a> <span class="date"><?= date('j M Y', strtotime($recent_appearance['hdate'])) ?></span></h4>
+                                <blockquote><?= $recent_appearance['extract'] ?></blockquote>
+                            </li>
 
-                            <p><a href="<?= $recent_appearances['more_href'] ?>"><?= $recent_appearances['more_text'] ?></a></p>
-
-                            <?php if (isset($recent_appearances['additional_links'])): ?>
-                            <?= $recent_appearances['additional_links'] ?>
-                            <?php endif; ?>
-
-                        <?php else: ?>
-
-                            <p>No recent appearances to display.</p>
-
-                        <?php endif; ?>
-
-                    </div>
-                    <?php endif; ?>
-
-                    <div class="panel">
-                        <a name="profile"></a>
-                        <h2 data-magellan-destination="profile">Profile</h2>
-
-                        <p><?= $member_summary ?></p>
-
-                        <?php if (count($enter_leave) > 0): ?>
-                            <?php foreach ($enter_leave as $string): ?>
-                                <p><?= $string ?></p>
-                            <?php endforeach; ?>
-                        <?php endif; ?>
-
-                        <?php if ($other_parties): ?>
-                        <p><?= $other_parties ?></p>
-                        <?php endif; ?>
-
-                        <?php if ($other_constituencies): ?>
-                        <p><?= $other_constituencies ?></p>
-                        <?php endif; ?>
-
-                        <?php if (count($useful_links) > 0): ?>
-
-                        <ul class="comma-list">
-
-                            <?php foreach ($useful_links as $link): ?>
-                            <li><a href="<?= $link['href'] ?>"><?= $link['text'] ?></a></li>
-                            <?php endforeach; ?>
+                        <?php endforeach; ?>
 
                         </ul>
 
+                        <p><a href="<?= $recent_appearances['more_href'] ?>"><?= $recent_appearances['more_text'] ?></a></p>
+
+                        <?php if (isset($recent_appearances['additional_links'])): ?>
+                        <?= $recent_appearances['additional_links'] ?>
                         <?php endif; ?>
 
-                        <?php if ($has_expenses): ?>
-                        <h3>Expenses</h3>
+                    <?php else: ?>
 
-                        <p>Expenses data for MPs is available from 2004 onwards
+                        <p>No recent appearances to display.</p>
+
+                    <?php endif; ?>
+
+                </div>
+                <?php endif; ?>
+
+                <div class="panel">
+                    <a name="profile"></a>
+                    <h2 data-magellan-destination="profile">Profile</h2>
+
+                    <p><?= $member_summary ?></p>
+
+                    <?php if (count($enter_leave) > 0): ?>
+                        <?php foreach ($enter_leave as $string): ?>
+                            <p><?= $string ?></p>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
+
+                    <?php if ($other_parties): ?>
+                    <p><?= $other_parties ?></p>
+                    <?php endif; ?>
+
+                    <?php if ($other_constituencies): ?>
+                    <p><?= $other_constituencies ?></p>
+                    <?php endif; ?>
+
+                    <?php if (count($useful_links) > 0): ?>
+
+                    <ul class="comma-list">
+
+                        <?php foreach ($useful_links as $link): ?>
+                        <li><a href="<?= $link['href'] ?>"><?= $link['text'] ?></a></li>
+                        <?php endforeach; ?>
+
+                    </ul>
+
+                    <?php endif; ?>
+
+                    <?php if ($has_expenses): ?>
+                    <h3>Expenses</h3>
+
+                    <p>Expenses data for MPs is available from 2004 onwards
 split over several locations. At the moment we don't have the time to convert
 it to a format we can display on the site so we just have to point you to where
 you can find it.</p>
 
-                        <ul>
-                            <li><a href="<?= $expenses_url_2004 ?>">Expenses from 2004 to 2009</a></li>
-                            <li><a href="http://www.parliamentary-standards.org.uk/AnnualisedData.aspx">Expenses from 2010 onwards</a></li>
-                        </ul>
-                        <?php endif; ?>
+                    <ul>
+                        <li><a href="<?= $expenses_url_2004 ?>">Expenses from 2004 to 2009</a></li>
+                        <li><a href="http://www.parliamentary-standards.org.uk/AnnualisedData.aspx">Expenses from 2010 onwards</a></li>
+                    </ul>
+                    <?php endif; ?>
 
-                        <?php if (count($topics_of_interest) > 0): ?>
+                    <?php if (count($topics_of_interest) > 0): ?>
 
-                        <h3>Topics of interest</h3>
+                    <h3>Topics of interest</h3>
 
-                        <ul class="comma-list">
+                    <ul class="comma-list">
 
-                            <?php foreach ($topics_of_interest as $topic): ?>
-                            <li><?= $topic ?></li>
-                            <?php endforeach; ?>
+                        <?php foreach ($topics_of_interest as $topic): ?>
+                        <li><?= $topic ?></li>
+                        <?php endforeach; ?>
 
-                        </ul>
-
-                        <?php endif; ?>
-
-                        <?php if (count($current_offices) > 0): ?>
-
-                        <h3>Currently held offices</h3>
-
-                        <ul class='list-dates'>
-
-                            <?php foreach ($current_offices as $office): ?>
-                            <li><?= $office ?> <small>(<?= $office->pretty_dates() ?>)</small></li>
-                            <?php endforeach; ?>
-
-                        </ul>
-
-                        <?php endif; ?>
-
-                        <?php if (count($previous_offices) > 0): ?>
-
-                        <h3>Other offices held in the past</h3>
-
-                        <ul class='list-dates'>
-
-                            <?php foreach ($previous_offices as $office): ?>
-                            <li><?= $office ?> <small>(<?= $office->pretty_dates() ?>)</small></li>
-                            <?php endforeach; ?>
-
-                        </ul>
-
-                        <?php endif; ?>
-
-                        <?php if (count($constituency_previous_mps) > 0): ?>
-
-                        <h3>Previous MPs in this constituency</h3>
-
-                        <ul class="comma-list">
-
-                            <?php foreach ($constituency_previous_mps as $constituency_previous_mp): ?>
-                            <li><a href="<?= $constituency_previous_mp['href'] ?>"><?= $constituency_previous_mp['text'] ?></a></li>
-                            <?php endforeach; ?>
-
-                        </ul>
-
-                        <?php endif; ?>
-
-                        <?php if (count($constituency_future_mps) > 0): ?>
-
-                        <h3>Future MPs in this constituency</h3>
-
-                        <ul class="comma-list">
-
-                            <?php foreach ($constituency_future_mps as $constituency_future_mp): ?>
-                            <li><a href="<?= $constituency_future_mp['href'] ?>"><?= $constituency_future_mp['text'] ?></a></li>
-                            <?php endforeach; ?>
-
-                        </ul>
-
-                        <?php endif; ?>
-
-                        <?php if (count($public_bill_committees['data']) > 0): ?>
-
-                        <h3>Public bill committees <small>(Sittings attended)</small></h3>
-
-                        <?php if ($public_bill_committees['info']): ?>
-                            <p><em><?= $public_bill_committees['info'] ?></em></p>
-                        <?php endif; ?>
-
-                        <ul>
-
-                            <?php foreach ($public_bill_committees['data'] as $committee): ?>
-                            <li><a href="<?= $committee['href'] ?>"><?= $committee['text'] ?></a> (<?= $committee['attending'] ?>)</li>
-                            <?php endforeach; ?>
-
-                        </ul>
-
-                        <?php endif; ?>
-
-                    </div>
-
-                    <?php if (count($numerology) > 0): ?>
-
-                    <div class="panel">
-                        <a name="numerology"></a>
-                        <h2 data-magellan-destination="numerology">Numerology</h2>
-
-                        <p>Please note that numbers do not measure quality. Also, representatives may do other things not currently covered by this site.<br><small><a href="<?= WEBPATH ?>help/#numbers">More about this</a></small></p>
-
-                        <ul class="numerology">
-
-                            <?php foreach ($numerology as $numerology_item): ?>
-                            <?php if ($numerology_item): ?>
-                            <li><?= $numerology_item ?></li>
-                            <?php endif; ?>
-                            <?php endforeach; ?>
-
-                        </ul>
-
-                    </div>
+                    </ul>
 
                     <?php endif; ?>
 
-                    <?php if ($register_interests): ?>
-                    <div class="panel register">
-                        <a name="register"></a>
-                        <h2 data-magellan-destination="register">Register of Members&rsquo; Interests</h2>
+                    <?php if (count($current_offices) > 0): ?>
 
-                        <?php if ($register_interests['date']): ?>
-                            <p>Last updated: <?= $register_interests['date'] ?>.</p>
-                        <?php endif; ?>
+                    <h3>Currently held offices</h3>
 
-                        <?= $register_interests['data'] ?>
+                    <ul class='list-dates'>
 
-                        <p>
-                            <a href="<?= WEBPATH ?>regmem/?p=<?= $person_id ?>">View the history of this MP&rsquo;s entries in the Register</a>
-                        </p>
+                        <?php foreach ($current_offices as $office): ?>
+                        <li><?= $office ?> <small>(<?= $office->pretty_dates() ?>)</small></li>
+                        <?php endforeach; ?>
 
-                        <p>
-                             <a class="moreinfo-link" href="http://www.publications.parliament.uk/pa/cm/cmregmem/100927/introduction.htm">More about the register</a>
-                        </p>
-                    </div>
+                    </ul>
+
                     <?php endif; ?>
 
-                    <div class="about-this-page">
-                        <div class="about-this-page__one-of-one">
-                            <div class="panel--secondary">
-                                <p>Please feel free to use the data on this page, but if
-                                    you do you must cite TheyWorkForYou.com in the body
-                                    of your articles as the source of any analysis or
-                                    data you get off this site.</p>
+                    <?php if (count($previous_offices) > 0): ?>
 
-                                <p>This data was produced by TheyWorkForYou from a variety
-                                    of sources. Voting information from
-                                    <a href="http://www.publicwhip.org.uk/mp.php?id=uk.org.publicwhip/member/<?= $member_id ?>&amp;showall=yes">Public Whip</a>.</p>
-                            </div>
-                        </div>
-                    </div>
+                    <h3>Other offices held in the past</h3>
+
+                    <ul class='list-dates'>
+
+                        <?php foreach ($previous_offices as $office): ?>
+                        <li><?= $office ?> <small>(<?= $office->pretty_dates() ?>)</small></li>
+                        <?php endforeach; ?>
+
+                    </ul>
+
+                    <?php endif; ?>
+
+                    <?php if (count($constituency_previous_mps) > 0): ?>
+
+                    <h3>Previous MPs in this constituency</h3>
+
+                    <ul class="comma-list">
+
+                        <?php foreach ($constituency_previous_mps as $constituency_previous_mp): ?>
+                        <li><a href="<?= $constituency_previous_mp['href'] ?>"><?= $constituency_previous_mp['text'] ?></a></li>
+                        <?php endforeach; ?>
+
+                    </ul>
+
+                    <?php endif; ?>
+
+                    <?php if (count($constituency_future_mps) > 0): ?>
+
+                    <h3>Future MPs in this constituency</h3>
+
+                    <ul class="comma-list">
+
+                        <?php foreach ($constituency_future_mps as $constituency_future_mp): ?>
+                        <li><a href="<?= $constituency_future_mp['href'] ?>"><?= $constituency_future_mp['text'] ?></a></li>
+                        <?php endforeach; ?>
+
+                    </ul>
+
+                    <?php endif; ?>
+
+                    <?php if (count($public_bill_committees['data']) > 0): ?>
+
+                    <h3>Public bill committees <small>(Sittings attended)</small></h3>
+
+                    <?php if ($public_bill_committees['info']): ?>
+                        <p><em><?= $public_bill_committees['info'] ?></em></p>
+                    <?php endif; ?>
+
+                    <ul>
+
+                        <?php foreach ($public_bill_committees['data'] as $committee): ?>
+                        <li><a href="<?= $committee['href'] ?>"><?= $committee['text'] ?></a> (<?= $committee['attending'] ?>)</li>
+                        <?php endforeach; ?>
+
+                    </ul>
+
+                    <?php endif; ?>
 
                 </div>
+
+                <?php if (count($numerology) > 0): ?>
+
+                <div class="panel">
+                    <a name="numerology"></a>
+                    <h2 data-magellan-destination="numerology">Numerology</h2>
+
+                    <p>Please note that numbers do not measure quality. Also, representatives may do other things not currently covered by this site.<br><small><a href="<?= WEBPATH ?>help/#numbers">More about this</a></small></p>
+
+                    <ul class="numerology">
+
+                        <?php foreach ($numerology as $numerology_item): ?>
+                        <?php if ($numerology_item): ?>
+                        <li><?= $numerology_item ?></li>
+                        <?php endif; ?>
+                        <?php endforeach; ?>
+
+                    </ul>
+
+                </div>
+
+                <?php endif; ?>
+
+                <?php if ($register_interests): ?>
+                <div class="panel register">
+                    <a name="register"></a>
+                    <h2 data-magellan-destination="register">Register of Members&rsquo; Interests</h2>
+
+                    <?php if ($register_interests['date']): ?>
+                        <p>Last updated: <?= $register_interests['date'] ?>.</p>
+                    <?php endif; ?>
+
+                    <?= $register_interests['data'] ?>
+
+                    <p>
+                        <a href="<?= WEBPATH ?>regmem/?p=<?= $person_id ?>">View the history of this MP&rsquo;s entries in the Register</a>
+                    </p>
+
+                    <p>
+                         <a class="moreinfo-link" href="http://www.publications.parliament.uk/pa/cm/cmregmem/100927/introduction.htm">More about the register</a>
+                    </p>
+                </div>
+                <?php endif; ?>
+
+                <div class="about-this-page">
+                    <div class="about-this-page__one-of-one">
+                        <div class="panel--secondary">
+                            <p>Please feel free to use the data on this page, but if
+                                you do you must cite TheyWorkForYou.com in the body
+                                of your articles as the source of any analysis or
+                                data you get off this site.</p>
+
+                            <p>This data was produced by TheyWorkForYou from a variety
+                                of sources. Voting information from
+                                <a href="http://www.publicwhip.org.uk/mp.php?id=uk.org.publicwhip/member/<?= $member_id ?>&amp;showall=yes">Public Whip</a>.</p>
+                        </div>
+                    </div>
+                </div>
+
             </div>
         </div>
     </div>

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -5,99 +5,99 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 <div class="full-page">
     <div class="full-page__row">
         <div class="full-page__unit">
-            <div class="person-navigation page-content__row">
+            <div class="person-navigation">
                 <ul>
                     <li><a href="<?= $member_url ?>">Overview</a></li>
                     <li class="active"><a href="<?= $member_url ?>/votes">Voting Record</a></li>
                 </ul>
             </div>
-            <div class="person-panels page-content__row">
-                <div class="sidebar__unit in-page-nav">
-                    <ul data-magellan-expedition="fixed">
-                        <?php if ($has_voting_record): ?>
-                        <?php foreach ($key_votes_segments as $segment): ?>
-                        <?php if (count($segment['votes']->positions) > 0): ?>
-                        <li data-magellan-arrival="<?= $segment['key'] ?>"><a href="#<?= $segment['key'] ?>"><?= $segment['title'] ?></a></li>
-                        <?php endif; ?>
-                        <?php endforeach; ?>
-                        <?php endif; ?>
-                    </ul>
-                    <div>&nbsp;</div>
-                </div>
-                <div class="primary-content__unit">
-
-                    <?php if ($party == 'Sinn Fein' && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
-                    <div class="panel">
-                        <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
-                    </div>
-                    <?php elseif (isset($is_new_mp) && $is_new_mp && !$has_voting_record): ?>
-                    <div class="panel--secondary">
-                        <h3><?= $full_name ?> is a recently elected MP - elected on <?= format_date($entry_date, LONGDATEFORMAT) ?></h3>
-
-                        <p>When <?= $full_name ?> starts to vote on bills, that information will appear on this page.</p>
-                    </div>
-                    <?php endif; ?>
-
+        </div>
+        <div class="person-panels">
+            <div class="sidebar__unit in-page-nav">
+                <ul data-magellan-expedition="fixed">
                     <?php if ($has_voting_record): ?>
+                    <?php foreach ($key_votes_segments as $segment): ?>
+                    <?php if (count($segment['votes']->positions) > 0): ?>
+                    <li data-magellan-arrival="<?= $segment['key'] ?>"><a href="#<?= $segment['key'] ?>"><?= $segment['title'] ?></a></li>
+                    <?php endif; ?>
+                    <?php endforeach; ?>
+                    <?php endif; ?>
+                </ul>
+                <div class="magellan-placeholder">&nbsp;</div>
+            </div>
+            <div class="primary-content__unit">
 
-                        <?php $displayed_votes = FALSE; ?>
+                <?php if ($party == 'Sinn Fein' && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+                <div class="panel">
+                    <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
+                </div>
+                <?php elseif (isset($is_new_mp) && $is_new_mp && !$has_voting_record): ?>
+                <div class="panel--secondary">
+                    <h3><?= $full_name ?> is a recently elected MP - elected on <?= format_date($entry_date, LONGDATEFORMAT) ?></h3>
 
-                        <?php foreach ($key_votes_segments as $segment): ?>
+                    <p>When <?= $full_name ?> starts to vote on bills, that information will appear on this page.</p>
+                </div>
+                <?php endif; ?>
 
-                            <?php if (count($segment['votes']->positions) > 0): ?>
+                <?php if ($has_voting_record): ?>
 
-                                <div class="panel">
+                    <?php $displayed_votes = FALSE; ?>
 
-                                <h2 id="<?= $segment['key'] ?>" data-magellan-destination="<?= $segment['key'] ?>">
-                                    How <?= $full_name ?> voted on <?= $segment['title'] ?>
-                                    <small><a class="nav-anchor" href="<?= $member_url ?>/votes#<?= $segment['key'] ?>">#</a></small>
-                                </h2>
+                    <?php foreach ($key_votes_segments as $segment): ?>
 
-                                <ul class="vote-descriptions">
-                                  <?php foreach ($segment['votes']->positions as $key_vote): ?>
-                                    <li>
-                                        <?= $key_vote['desc'] ?>
-                                        <a class="vote-description__source" href="<?= $member_url?>/divisions?policy=<?= $key_vote['policy_id'] ?>">Details</a>
-                                    </li>
-                                  <?php endforeach; ?>
-                                </ul>
-
-                                </div>
-
-                                <?php $displayed_votes = TRUE; ?>
-
-                            <?php endif; ?>
-
-                        <?php endforeach; ?>
-
-                        <?php if ($displayed_votes): ?>
-
-                            <?php if (isset($segment['votes']->moreLinksString)): ?>
-
-                                <div class="panel">
-                                    <p><?= $segment['votes']->moreLinksString ?></p>
-                                </div>
-
-                            <?php endif; ?>
-
-                        <?php else: ?>
+                        <?php if (count($segment['votes']->positions) > 0): ?>
 
                             <div class="panel">
-                                <p>This person has not voted on any of the key issues which we keep track of.</p>
+
+                            <h2 id="<?= $segment['key'] ?>" data-magellan-destination="<?= $segment['key'] ?>">
+                                How <?= $full_name ?> voted on <?= $segment['title'] ?>
+                                <small><a class="nav-anchor" href="<?= $member_url ?>/votes#<?= $segment['key'] ?>">#</a></small>
+                            </h2>
+
+                            <ul class="vote-descriptions">
+                              <?php foreach ($segment['votes']->positions as $key_vote): ?>
+                                <li>
+                                    <?= $key_vote['desc'] ?>
+                                    <a class="vote-description__source" href="<?= $member_url?>/divisions?policy=<?= $key_vote['policy_id'] ?>">Details</a>
+                                </li>
+                              <?php endforeach; ?>
+                            </ul>
+
+                            </div>
+
+                            <?php $displayed_votes = TRUE; ?>
+
+                        <?php endif; ?>
+
+                    <?php endforeach; ?>
+
+                    <?php if ($displayed_votes): ?>
+
+                        <?php if (isset($segment['votes']->moreLinksString)): ?>
+
+                            <div class="panel">
+                                <p><?= $segment['votes']->moreLinksString ?></p>
                             </div>
 
                         <?php endif; ?>
 
+                    <?php else: ?>
+
+                        <div class="panel">
+                            <p>This person has not voted on any of the key issues which we keep track of.</p>
+                        </div>
+
                     <?php endif; ?>
 
-                    <div class="panel">
-                        <p>Please feel free to use the data on this page, but if
-                            you do you must cite TheyWorkForYou.com in the body
-                            of your articles as the source of any analysis or
-                            data you get off this site.</p>
-                    </div>
+                <?php endif; ?>
 
+                <div class="panel">
+                    <p>Please feel free to use the data on this page, but if
+                        you do you must cite TheyWorkForYou.com in the body
+                        of your articles as the source of any analysis or
+                        data you get off this site.</p>
                 </div>
+
             </div>
         </div>
     </div>

--- a/www/includes/easyparliament/templates/html/section/section.php
+++ b/www/includes/easyparliament/templates/html/section/section.php
@@ -8,7 +8,7 @@
 <div class="debate-header regional-header regional-header--<?= $current_assembly ?>">
     <div class="regional-header__overlay"></div>
     <div class="full-page__row">
-        <div class="debate-header__content">
+        <div class="debate-header__content full-page__unit">
             <h1><?= $heading ?></h1>
             <p class="lead">
                 <?= $intro ?> <?= $location ?>
@@ -23,24 +23,26 @@
     </div>
     <nav class="debate-navigation" role="navigation">
         <div class="full-page__row">
-            <div class="debate-navigation__pagination">
-                <?php if (isset($nextprev['prev'])) { ?>
-                <div class="debate-navigation__previous-debate">
-                    <a href="<?= $nextprev['prev']['url'] ?>" rel="prev">&laquo; <?= $nextprev['prev']['body'] ?></a>
-                </div>
-                <?php } ?>
+            <div class="full-page__unit">
+                <div class="debate-navigation__pagination">
+                    <?php if (isset($nextprev['prev'])) { ?>
+                    <div class="debate-navigation__previous-debate">
+                        <a href="<?= $nextprev['prev']['url'] ?>" rel="prev">&laquo; <?= $nextprev['prev']['body'] ?></a>
+                    </div>
+                    <?php } ?>
 
-                <?php if (isset($nextprev['up'])) { ?>
-                <div class="debate-navigation__all-debates">
-                    <a href="<?= $nextprev['up']['url'] ?>" rel="up"><?= $nextprev['up']['body'] ?></a>
-                </div>
-                <?php } ?>
+                    <?php if (isset($nextprev['up'])) { ?>
+                    <div class="debate-navigation__all-debates">
+                        <a href="<?= $nextprev['up']['url'] ?>" rel="up"><?= $nextprev['up']['body'] ?></a>
+                    </div>
+                    <?php } ?>
 
-                <?php if (isset($nextprev['next'])) { ?>
-                <div class="debate-navigation__next-debate">
-                    <a href="<?= $nextprev['next']['url'] ?>" rel="next"><?= $nextprev['next']['body'] ?> &raquo;</a>
+                    <?php if (isset($nextprev['next'])) { ?>
+                    <div class="debate-navigation__next-debate">
+                        <a href="<?= $nextprev['next']['url'] ?>" rel="next"><?= $nextprev['next']['body'] ?> &raquo;</a>
+                    </div>
+                    <?php } ?>
                 </div>
-                <?php } ?>
             </div>
         </div>
     </nav>
@@ -49,7 +51,9 @@
 <div class="full-page">
     <div class="debate-speech__notice">
         <div class="full-page__row">
-            Due to changes made to the official Scottish Parliament, our parser that used to fetch their web pages and convert them into more structured information has stopped working. We're afraid we cannot give a timescale as to when we will be able to cover the Scottish Parliament again. Sorry for any inconvenience caused.
+            <div class="full-page__unit">
+                Due to changes made to the official Scottish Parliament, our parser that used to fetch their web pages and convert them into more structured information has stopped working. We're afraid we cannot give a timescale as to when we will be able to cover the Scottish Parliament again. Sorry for any inconvenience caused.
+            </div>
         </div>
     </div>
 </div>
@@ -160,6 +164,8 @@
 
     <div class="debate-speech" id="g<?= gid_to_anchor($speech['gid']) ?>">
         <div class="full-page__row">
+            <div class="full-page__unit">
+
             <a name="g<?= gid_to_anchor($speech['gid']) ?>"></a>
 
             <div class="debate-speech__speaker-and-content">
@@ -324,6 +330,9 @@
                 }
 ?>
             </ul>
+
+        </div>
+
         </div>
     </div>
 
@@ -331,7 +340,7 @@
 
   <?php } // end foreach
         if (isset($data['subrows'])) {
-        print '<div class="subrows"><div class="full-page__row"><ul>';
+        print '<div class="subrows"><div class="full-page__row"><div class="full-page__unit"><ul>';
         foreach ($data['subrows'] as $row) {
             print '<li class="subrows__list-item">';
             if (isset($row['contentcount']) && $row['contentcount'] > 0) {
@@ -366,18 +375,20 @@
                 print "<p class=\"subrows__excerpt\">" . trim_characters($row['excerpt'], 0, 200) . "</p>";
             }
         }
-        print '</ul></div></div>';
+        print '</ul></div></div></div>';
     }
     if ($individual_item) { ?>
         <div class="debate-comments">
             <div class="full-page__row">
-            <?php
-                # XXX
-                global $PAGE;
-                $comments['object']->display('ep', $comments['args']);
-                $PAGE->comment_form($comments['commentdata']);
-                # XXX COMMENT SIDEBAR SHOULD GO HERE IF LOGGED IN
-            ?>
+                <div class="full-page__unit">
+                <?php
+                    # XXX
+                    global $PAGE;
+                    $comments['object']->display('ep', $comments['args']);
+                    $PAGE->comment_form($comments['commentdata']);
+                    # XXX COMMENT SIDEBAR SHOULD GO HERE IF LOGGED IN
+                ?>
+                </div>
             </div>
         </div>
         <?php

--- a/www/includes/easyparliament/templates/html/topic/topic.php
+++ b/www/includes/easyparliament/templates/html/topic/topic.php
@@ -1,38 +1,30 @@
 <div class="topic-header">
     <div class="full-page">
         <div class="full-page__row">
-            <div class="topic-header__content page-content__row">
 
-                <div class="topic-name">
-
-                    <h1><?= $title ?></h1>
-                    <h1 class="subheader">&amp; the UK Parliament</h1>
-
-                    <p class="lead"><?= $blurb ?> Here are some places you might want to start.</p>
-
-                </div>
-
-                <?php if (isset($policytitle) AND $display_postcode_form): ?>
-
-                <div class="topic-postcode-search">
-                    <h3>What does your MP think?</h3>
-
-                    <form action="#yourrep" method="get">
-
-                        <div class="row collapse">
-                            <div class="small-10 columns">
-                                <input type="text" name="pc" value="" maxlength="10" size="10" placeholder="Your postcode">
-                            </div>
-                            <div class="small-2 columns">
-                                <input type="submit" value="GO" class="button prefix">
-                            </div>
-                        </div>
-                    </form>
-                </div>
-
-                <?php endif; ?>
-
+            <div class="topic-name">
+                <h1><?= $title ?></h1>
+                <h1 class="subheader">&amp; the UK Parliament</h1>
+                <p class="lead"><?= $blurb ?> Here are some places you might want to start.</p>
             </div>
+
+          <?php if (isset($policytitle) AND $display_postcode_form): ?>
+            <div class="topic-postcode-search">
+                <h3>What does your MP think?</h3>
+
+                <form action="#yourrep" method="get">
+                    <div class="row collapse">
+                        <div class="small-10 columns">
+                            <input type="text" name="pc" value="" maxlength="10" size="10" placeholder="Your postcode">
+                        </div>
+                        <div class="small-2 columns">
+                            <input type="submit" value="GO" class="button prefix">
+                        </div>
+                    </div>
+                </form>
+            </div>
+          <?php endif; ?>
+
         </div>
     </div>
 </div>


### PR DESCRIPTION
Fixes #695.

MP pages and debates pages were using a variety of different methods to set columns and gutters, especially on full-width elements, and each of these methods resulted in a lack of gutters at one breakpoint or another.

This PR standardises all the "new style" pages (MP pages, debates/wrans pages, topic pages) to use the `.full-page__unit` convention, and to avoid nested grid columns. The `/alert/by-postcode` page and [new homepage](https://github.com/mysociety/theyworkforyou/tree/issues/589-new-homepage-design) already use `.full-page__unit` where necessary, so didn't need any fixes.

The template changes *look* more drastic than they really are, because a lot of them are indentation changes as I've added or removed wrapping elements, to keep the same structure across all the pages.

I've kept the commits separate rather than squashing as the changes were pretty far-reaching and I'm worried, if they're compressed into a single change, Future Me will have no idea what happened. But if still want them squashed, @dracos, let me know.

From a design perspective, this is ready to go, but I'd appreciate a :+1: from a developer /cc @dracos @struan before merging.