### PR TITLE
Incrase contast for consituency name in MP header

### DIFF
--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -63,7 +63,6 @@
                     font-size: em-calc(21);
                     line-height: 1.1em;
                     margin: 0.1em 0;
-                    color: #ddd;
 
                     @media (min-width: $medium-screen) {
                         font-size: em-calc(24);


### PR DESCRIPTION
Simple fix for #770.

Makes the MP's constituency white, to improve contrast against the background image.

![grey](https://cloud.githubusercontent.com/assets/739624/8278433/20747498-18c3-11e5-9bc0-c0a05a621d0f.gif)
