### PR TITLE
Display any votes where MP differs from party on profile page

### DIFF
--- a/classes/Member.php
+++ b/classes/Member.php
@@ -204,42 +204,51 @@ class Member extends \MEMBER {
             $office = $office['office'];
 
             foreach ($office as $row) {
-
-                // Reset the inclusion of this position
-                $include_office = TRUE;
-
-                // If we should only include previous offices, and the to date is in the future, suppress this office.
-                if ($include_only == 'previous' AND $row['to_date'] == '9999-12-31') {
-                    $include_office = FALSE;
-                }
-
-                // If we should only include previous offices, and the to date is in the past, suppress this office.
-                if ($include_only == 'current' AND $row['to_date'] != '9999-12-31') {
-                    $include_office = FALSE;
-                }
-
                 $office_title = prettify_office($row['position'], $row['dept']);
 
-                if (($priority_only AND in_array($office_title, $this->priority_offices))
-                    OR !$priority_only) {
-                    if ($include_office) {
-                        $officeObject = new Office;
-
-                        $officeObject->title = $office_title;
-
-                        $officeObject->from_date = $row['from_date'];
-                        $officeObject->to_date = $row['to_date'];
-
-                        $officeObject->source = $row['source'];
-
-                        $out[] = $officeObject;
-                    }
+                if ( $officeObject = $this->getOfficeObject($include_only, $priority_only, $office_title, $row) ) {
+                    $out[] = $officeObject;
                 }
             }
         }
 
         return $out;
 
+    }
+
+    private function getOfficeObject($include_only, $priority_only, $office_title, $row) {
+        $officeObject = null;
+
+        if ( $this->includeOffice($include_only, $row['to_date']) ) {
+            if (($priority_only AND in_array($office_title, $this->priority_offices)) OR !$priority_only) {
+                $officeObject = new Office;
+
+                $officeObject->title = $office_title;
+
+                $officeObject->from_date = $row['from_date'];
+                $officeObject->to_date = $row['to_date'];
+
+                $officeObject->source = $row['source'];
+            }
+        }
+
+        return $officeObject;
+    }
+
+    private function includeOffice($include_only, $to_date) {
+        $include_office = TRUE;
+
+        // If we should only include previous offices, and the to date is in the future, suppress this office.
+        if ($include_only == 'previous' AND $to_date == '9999-12-31') {
+            $include_office = FALSE;
+        }
+
+        // If we should only include previous offices, and the to date is in the past, suppress this office.
+        if ($include_only == 'current' AND $to_date != '9999-12-31') {
+            $include_office = FALSE;
+        }
+
+        return $include_office;
     }
 
     /**

--- a/classes/Member.php
+++ b/classes/Member.php
@@ -360,6 +360,10 @@ class Member extends \MEMBER {
         $policy_diffs = array();
         $party_positions = $party->getAllPolicyPositions($policiesList);
 
+        if ( !$party_positions ) {
+            return $policy_diffs;
+        }
+
         foreach ( $positions->positionsById as $policy_id => $details ) {
             if ( $details['score'] != -1 ) {
                 $mp_score = $details['score'];

--- a/classes/Member.php
+++ b/classes/Member.php
@@ -365,7 +365,7 @@ class Member extends \MEMBER {
         }
 
         foreach ( $positions->positionsById as $policy_id => $details ) {
-            if ( $details['score'] != -1 ) {
+            if ( $details['score'] != -1 && isset($party_positions[$policy_id])) {
                 $mp_score = $details['score'];
                 $party_score = $party_positions[$policy_id]['score'];
 

--- a/classes/Member.php
+++ b/classes/Member.php
@@ -356,6 +356,49 @@ class Member extends \MEMBER {
         }
     }
 
+    public function getPartyPolicyDiffs($party, $policiesList, $positions, $only_diffs = false) {
+        $policy_diffs = array();
+        $party_positions = $party->getAllPolicyPositions($policiesList);
+
+        foreach ( $positions->positionsById as $policy_id => $details ) {
+            if ( $details['score'] != -1 ) {
+                $mp_score = $details['score'];
+                $party_score = $party_positions[$policy_id]['score'];
+
+                $score_diff = $this->calculatePolicyDiffScore($mp_score, $party_score);
+
+                // skip anything that isn't a yes vs no diff
+                if ( $only_diffs && $score_diff < 2 ) {
+                    continue;
+                }
+                $policy_diffs[$policy_id] = $score_diff;
+            }
+        }
+
+        arsort($policy_diffs);
+
+        return $policy_diffs;
+    }
+
+    private function calculatePolicyDiffScore( $mp_score, $party_score ) {
+        $score_diff = abs($mp_score - $party_score);
+        // if they are on opposite sides of mixture of for and against
+        if (
+            ( $mp_score < 0.4 && $party_score > 0.6 ) ||
+            ( $mp_score > 0.6 && $party_score < 0.4 )
+        ) {
+            $score_diff += 2;
+        // if on is mixture of for and against and one is for/against
+        } else if (
+            ( $mp_score > 0.4 && $mp_score < 0.6 && ( $party_score > 0.6 || $party_score < 0.4 ) ) ||
+            ( $party_score > 0.4 && $party_score < 0.6 && ( $mp_score > 0.6 || $mp_score < 0.4 ) )
+        ) {
+            $score_diff += 1;
+        }
+
+        return $score_diff;
+    }
+
     public static function getRegionalList($postcode, $house, $type) {
         $db = new \ParlDB;
 

--- a/classes/Party.php
+++ b/classes/Party.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Party Class
+ *
+ * @package TheyWorkForYou
+ */
+
+namespace MySociety\TheyWorkForYou;
+
+/**
+ * Party
+ */
+
+class Party {
+
+    public $name;
+
+    private $db;
+
+    public function __construct($name) {
+        $this->name = $name;
+        $this->db = new \ParlDB;
+    }
+
+    public function calculateAllPolicyPositions($policies) {
+        $positions = array();
+
+        foreach ( $policies->getPolicies() as $policy_id => $policy_text ) {
+            list( $position, $score ) = $this->calculate_policy_position($policy_id, true);
+            if ( $position === null ) {
+                continue;
+            }
+
+            $positions[$policy_id] = array(
+                'policy_id' => $policy_id,
+                'position' => $position,
+                'score' => $score,
+                'desc' => $policy_text
+            );
+        }
+
+        return $positions;
+    }
+
+    public function calculate_policy_position($policy_id, $want_score = false) {
+
+        // This could be done as a join but it turns out to be
+        // much slower to do that
+        $divisions = $this->db->query(
+            "SELECT division_id, policy_vote, division_date
+            FROM policydivisions
+            WHERE policy_id = :policy_id
+            AND house = 'commons'",
+            array(
+                ':policy_id' => $policy_id
+            )
+        );
+
+        $score = 0;
+        $max_score = 0;
+        $num_divs = $divisions->rows;
+        $total_votes = 0;
+
+        for ( $i = 0; $i < $num_divs; $i++ ) {
+            $division_id = $divisions->field($i, 'division_id');
+            $weights = $this->get_vote_scores($divisions->field($i, 'policy_vote'));
+
+            $votes = $this->db->query(
+                "SELECT count(*) as num_votes, vote
+                FROM persondivisionvotes
+                JOIN member ON persondivisionvotes.person_id = member.person_id
+                WHERE
+                    party = :party
+                    AND member.house = 1
+                    AND division_id = :division_id
+                    AND left_house = '9999-12-31'
+                GROUP BY vote",
+                array(
+                    ':party' => $this->name,
+                    ':division_id' => $division_id
+                )
+            );
+
+            $num_votes = 0;
+            for ( $j = 0; $j < $votes->rows(); $j++ ) {
+                $vote_dir = $votes->field($j, 'vote');
+                if ( $vote_dir == 'tellno' ) $vote_dir = 'no';
+                if ( $vote_dir == 'tellaye' ) $vote_dir = 'aye';
+
+                $num_votes += $votes->field($j, 'num_votes');
+                $score += ($votes->field($j, 'num_votes') * $weights[$vote_dir]);
+            }
+
+            $total_votes += $num_votes;
+            $max_score += $num_votes * max( array_values( $weights ) );
+        }
+
+        if ( $total_votes == 0 ) {
+            return null;
+        }
+
+        if ( $max_score == 0 ) {
+            $max_score = 1;
+        }
+        $weight = 1 - ( $score/$max_score );
+        $score_desc = score_to_strongly($weight);
+
+        if ( $want_score ) {
+            return array( $score_desc, $weight);
+        } else {
+            return $score_desc;
+        }
+    }
+
+    public function cache_position( $position ) {
+        $this->db->query(
+            "REPLACE INTO partypolicy
+                (party, house, policy_id, score)
+                VALUES (:party, 1, :policy_id, :score)",
+            array(
+                ':score' => $position['score'],
+                ':party' => $this->name,
+                ':policy_id' => $position['policy_id']
+            )
+        );
+    }
+
+    private function get_vote_scores($vote) {
+        $absent = 1;
+        $both = 1;
+        $agree = 10;
+
+        if ( stripos($vote, '3') !== FALSE ) {
+            $agree = 50;
+            $absent = 25;
+            $both = 25;
+        }
+
+        $scores = array(
+            'absent' => $absent,
+            'both' => $both
+        );
+
+        if ( stripos($vote, 'aye') !== FALSE ) {
+            $scores['aye'] = $agree;
+            $scores['no'] = 0;
+        } else if ( stripos($vote, 'no') !== FALSE ) {
+            $scores['no'] = $agree;
+            $scores['aye'] = 0;
+        } else {
+            $scores['both'] = 0;
+            $scores['absent'] = 0;
+            $scores['no'] = 0;
+            $scores['aye'] = 0;
+        }
+
+        return $scores;
+    }
+
+    public static function getParties() {
+        $db = new \ParlDB;
+
+        $party_list = $db->query(
+            "SELECT DISTINCT party FROM member"
+        );
+
+        $parties = array();
+        $party_count = $party_list->rows;
+
+        for ( $i = 0; $i < $party_count; $i++ ) {
+            $parties[] = $party_list->field($i, 'party');
+        }
+
+        return $parties;
+    }
+}

--- a/classes/Party.php
+++ b/classes/Party.php
@@ -137,10 +137,14 @@ class Party {
             return null;
         }
 
+        // this implies that all the divisions in the policy have a policy
+        // position of absent so we set weight to -1 to indicate we can't
+        // really say what the parties position is.
         if ( $max_score == 0 ) {
-            $max_score = 1;
+            $weight = -1;
+        } else {
+            $weight = 1 - ( $score/$max_score );
         }
-        $weight = 1 - ( $score/$max_score );
         $score_desc = score_to_strongly($weight);
 
         if ( $want_score ) {

--- a/classes/Party.php
+++ b/classes/Party.php
@@ -202,14 +202,22 @@ class Party {
         $db = new \ParlDB;
 
         $party_list = $db->query(
-            "SELECT DISTINCT party FROM member"
+            "SELECT DISTINCT party FROM member WHERE party <> ''"
         );
 
         $parties = array();
         $party_count = $party_list->rows;
 
         for ( $i = 0; $i < $party_count; $i++ ) {
-            $parties[] = $party_list->field($i, 'party');
+            $party = $party_list->field($i, 'party');
+            if (
+                !$party
+                || $party == 'Independent'
+                || $party == 'Crossbench'
+            ) {
+                continue;
+            }
+            $parties[] = $party;
         }
 
         return $parties;

--- a/classes/PolicyPositions.php
+++ b/classes/PolicyPositions.php
@@ -110,11 +110,14 @@ class PolicyPositions {
                 if (!empty($dream_info)) {
                     $this->positions[] = array(
                         'policy_id' => $policy[0],
-                        'desc' => $dream_info['full_sentence']
+                        'desc' => $dream_info['full_sentence'],
+                        'position' => $dream_info['position']
                     );
                     $this->positionsById[$policy[0]] = array(
                         'policy_id' => $policy[0],
-                        'desc' => $dream_info['full_sentence']
+                        'desc' => $dream_info['full_sentence'],
+                        'position' => $dream_info['position'],
+                        'score' => $dream_info['score'],
                     );
                     $i++;
                 }
@@ -158,6 +161,7 @@ class PolicyPositions {
         if (isset($extra_info["public_whip_dreammp${dreamid}_distance"])) {
             if ($extra_info["public_whip_dreammp${dreamid}_both_voted"] == 0) {
                 $consistency = 'has never voted on';
+                $dmpscore = -1;
             } else {
                 $dmpscore = floatval($extra_info["public_whip_dreammp${dreamid}_distance"]);
                 if ($inverse)
@@ -165,7 +169,7 @@ class PolicyPositions {
                 $consistency = score_to_strongly($dmpscore);
             }
             $full_sentence = $consistency . ' ' . $policy_description;
-            $out = array( 'full_sentence' => $full_sentence );
+            $out = array( 'full_sentence' => $full_sentence, 'score' => $dmpscore, 'position' => $consistency );
         }
 
         return $out;

--- a/db/0007-add-policy-vote-to-divisions.sql
+++ b/db/0007-add-policy-vote-to-divisions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `policydivisions` ADD COLUMN `policy_vote` enum('aye', 'aye3', 'no', 'no3', 'both', 'absent', '') default '';

--- a/db/0008-add-party-policy.sql
+++ b/db/0008-add-party-policy.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `partypolicy` (
+  `id` int(11) NOT NULL auto_increment,
+  `house` int(11) default NULL,
+  `party` varchar(100) collate latin1_spanish_ci NOT NULL default '',
+  `policy_id` varchar(100) NOT NULL default '',
+  `score` float NOT NULL default 0,
+  PRIMARY KEY  (`id`),
+  UNIQUE KEY `party_policy` (`party`, `house`, `policy_id`),
+  KEY `party` (`party`),
+  KEY `policy_id` (`policy_id`)
+);
+ALTER TABLE `partypolicy` COLLATE latin1_spanish_ci;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -143,6 +143,7 @@ CREATE TABLE `policydivisions` (
   `no_text` text,
   `division_date` date NOT NULL default '1000-01-01',
   `division_number` int(11),
+  `policy_vote` enum('aye', 'aye3', 'no', 'no3', 'both', 'absent', '') default '',
   `lastupdate` timestamp NOT NULL default CURRENT_TIMESTAMP on update CURRENT_TIMESTAMP,
   UNIQUE KEY `policy_division` (`division_id`, `policy_id`),
   KEY `division_id` (`division_id`)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -159,6 +159,19 @@ CREATE TABLE `persondivisionvotes` (
   KEY `person_id` (`person_id`)
 );
 
+CREATE TABLE `partypolicy` (
+  `id` int(11) NOT NULL auto_increment,
+  `house` int(11) default NULL,
+  `party` varchar(100) collate latin1_spanish_ci NOT NULL default '',
+  `policy_id` varchar(100) NOT NULL default '',
+  `score` float NOT NULL default 0,
+  PRIMARY KEY  (`id`),
+  UNIQUE KEY `party_policy` (`party`, `house`, `policy_id`),
+  KEY `party` (`party`),
+  KEY `policy_id` (`policy_id`)
+);
+ALTER TABLE `partypolicy` COLLATE latin1_spanish_ci;
+
 CREATE TABLE `moffice` (
   `moffice_id` varchar(100) NOT NULL,
   `dept` varchar(255) NOT NULL default '',

--- a/scripts/generate_party_positions.php
+++ b/scripts/generate_party_positions.php
@@ -7,9 +7,6 @@ $policies = new MySociety\TheyWorkForYou\Policies;
 
 $party_count = 0;
 foreach ( $parties as $party ) {
-    if ( !$party ) {
-        continue;
-    }
     $party = new MySociety\TheyWorkForYou\Party($party);
 
     $positions = $party->calculateAllPolicyPositions($policies);

--- a/scripts/generate_party_positions.php
+++ b/scripts/generate_party_positions.php
@@ -1,0 +1,26 @@
+<?php
+
+include_once dirname(__FILE__) . '/../www/includes/easyparliament/init.php';
+
+$parties = MySociety\TheyWorkForYou\Party::getParties();
+$policies = new MySociety\TheyWorkForYou\Policies;
+
+$party_count = 0;
+foreach ( $parties as $party ) {
+    if ( !$party ) {
+        continue;
+    }
+    $party = new MySociety\TheyWorkForYou\Party($party);
+
+    $positions = $party->calculateAllPolicyPositions($policies);
+
+    if ( count( $positions ) ) {
+        $party_count++;
+    }
+
+    foreach ( $positions as $position ) {
+        $party->cache_position( $position );
+    }
+}
+
+print "cached positions for $party_count parties\n";

--- a/tests/PartyTest.php
+++ b/tests/PartyTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Test Party class
+ */
+class PartyTest extends TWFY_Database_TestCase
+{
+
+    /**
+     * Loads the member testing fixture.
+     */
+    public function getDataSet()
+    {
+        return $this->createMySQLXMLDataSet(dirname(__FILE__).'/_fixtures/party.xml');
+    }
+
+    public function testLoad() {
+        $party = new MySociety\TheyWorkForYou\Party('A Party');
+
+        $this->assertNotNull($party);
+        $this->assertEquals( 'A Party', $party->name );
+    }
+
+    public function testCalculatePositions() {
+        $party = new MySociety\TheyWorkForYou\Party('A Party');
+        $policies = new MySociety\TheyWorkForYou\Policies();
+
+        $positions = $party->calculateAllPolicyPositions($policies);
+
+        $expectedResults = array(
+            '810' => array(
+                'policy_id' => 810,
+                'position' => 'voted a mixture of for and against',
+                'score' => 0.5,
+                'desc' => 'greater <b>regulation of gambling</b>'
+            )
+        );
+
+        $this->assertEquals($expectedResults, $positions);
+    }
+
+}

--- a/tests/PartyTest.php
+++ b/tests/PartyTest.php
@@ -21,11 +21,36 @@ class PartyTest extends TWFY_Database_TestCase
         $this->assertEquals( 'A Party', $party->name );
     }
 
-    public function testCalculatePositions() {
-        $party = new MySociety\TheyWorkForYou\Party('A Party');
-        $policies = new MySociety\TheyWorkForYou\Policies();
+    public function testGetPolicyPositions() {
+        $positions = $this->getAllPositions('getAllPolicyPositions');
 
-        $positions = $party->calculateAllPolicyPositions($policies);
+        $expectedPositions = array(
+            '363' => array(
+                'position' => 'almost always voted against',
+                'score' => '0.9',
+                'desc' => 'introducing <b>foundation hospitals</b>',
+                'policy_id' => 363
+            )
+        );
+
+        $this->assertEquals($expectedPositions, $positions);
+
+    }
+
+    public function testGetRestrictedPositions() {
+        $party = new MySociety\TheyWorkForYou\Party('A Party');
+        $policies = new MySociety\TheyWorkForYou\Policies(6667);
+
+        $positions = $party->getAllPolicyPositions($policies);
+
+        $expectedPositions = array();
+
+        $this->assertEquals($expectedPositions, $positions);
+
+    }
+
+    public function testCalculatePositions() {
+        $positions = $this->getAllPositions('calculateAllPolicyPositions');
 
         $expectedResults = array(
             '810' => array(
@@ -37,6 +62,14 @@ class PartyTest extends TWFY_Database_TestCase
         );
 
         $this->assertEquals($expectedResults, $positions);
+    }
+
+    private function getAllPositions($method) {
+        $party = new MySociety\TheyWorkForYou\Party('A Party');
+        $policies = new MySociety\TheyWorkForYou\Policies();
+
+        $positions = $party->$method($policies);
+        return $positions;
     }
 
 }

--- a/tests/PartyTest.php
+++ b/tests/PartyTest.php
@@ -37,6 +37,11 @@ class PartyTest extends TWFY_Database_TestCase
 
     }
 
+    public function testGetPolicyPositionsForIndependents() {
+        $positions = $this->getAllPositions('getAllPolicyPositions', 'Independent');
+        $this->assertEquals(array(), $positions);
+    }
+
     public function testGetRestrictedPositions() {
         $party = new MySociety\TheyWorkForYou\Party('A Party');
         $policies = new MySociety\TheyWorkForYou\Policies(6667);
@@ -62,6 +67,14 @@ class PartyTest extends TWFY_Database_TestCase
         );
 
         $this->assertEquals($expectedResults, $positions);
+    }
+
+    public function testGetAllParties() {
+        $parties = MySociety\TheyWorkForYou\Party::getParties();
+
+        $expected = array('A Party');
+
+        $this->assertEquals($expected, $parties);
     }
 
     private function getAllPositions($method) {

--- a/tests/PartyTest.php
+++ b/tests/PartyTest.php
@@ -69,6 +69,13 @@ class PartyTest extends TWFY_Database_TestCase
         $this->assertEquals($expectedResults, $positions);
     }
 
+    public function testCalculatePositionsPolicyAbsent() {
+        $party = new MySociety\TheyWorkForYou\Party('Labour/Co-operative');
+        list($desc, $score) = $party->calculate_policy_position(900, true);
+
+        $this->assertEquals(-1, $score);
+    }
+
     public function testLabourCoOp() {
         $party = new MySociety\TheyWorkForYou\Party('Labour/Co-operative');
 

--- a/tests/PartyTest.php
+++ b/tests/PartyTest.php
@@ -3,7 +3,7 @@
 /**
  * Test Party class
  */
-class PartyTest extends TWFY_Database_TestCase
+class PartyTest extends FetchPageTestCase
 {
 
     /**
@@ -12,6 +12,11 @@ class PartyTest extends TWFY_Database_TestCase
     public function getDataSet()
     {
         return $this->createMySQLXMLDataSet(dirname(__FILE__).'/_fixtures/party.xml');
+    }
+
+    private function fetch_page($vars)
+    {
+        return $this->base_fetch_page('', $vars, 'www/docs/mp');
     }
 
     public function testLoad() {
@@ -121,4 +126,28 @@ class PartyTest extends TWFY_Database_TestCase
         return $positions;
     }
 
+    public function testMPPartyPolicyTextWhenDiffers()
+    {
+        $page = $this->fetch_page( array( 'pid' => 2, 'url' => '/mp/2/test_current-mp/test_westminster_constituency' ) );
+        $this->assertContains('Test Current-MP', $page);
+        $this->assertContains('is a A Party MP', $page);
+        $this->assertContains('sometimes <b>differs</b> from their party', $page);
+    }
+
+    public function testMPPartyPolicyWherePartyMissingPositions()
+    {
+        $page = $this->fetch_page( array( 'pid' => 3, 'url' => '/mp/3/test_current-mp/test_westminster_constituency' ) );
+        $this->assertContains('Test Current-MP', $page);
+        $this->assertContains('is a A Party MP', $page);
+        $this->assertNotContains('Most A Party MPs voted </b>', $page);
+    }
+
+    public function testMPPartyPolicyTextWhenAgrees()
+    {
+        $page = $this->fetch_page( array( 'pid' => 6, 'url' => '/mp/6/test_further-mp/test_westminster_constituency' ) );
+        $this->assertContains('Test Further-MP', $page);
+        $this->assertContains('is a Labour MP', $page);
+        $this->assertContains('This is a selection of Miss Test Further-MP&rsquo;s votes', $page);
+        $this->assertNotContains('sometimes <b>differs</b> from their party', $page);
+    }
 }

--- a/tests/PartyTest.php
+++ b/tests/PartyTest.php
@@ -69,16 +69,45 @@ class PartyTest extends TWFY_Database_TestCase
         $this->assertEquals($expectedResults, $positions);
     }
 
+    public function testLabourCoOp() {
+        $party = new MySociety\TheyWorkForYou\Party('Labour/Co-operative');
+
+        $this->assertEquals('Labour', $party->name);
+    }
+
     public function testGetAllParties() {
         $parties = MySociety\TheyWorkForYou\Party::getParties();
 
-        $expected = array('A Party');
+        $expected = array('A Party', 'Labour', 'Labour/Co-operative');
 
         $this->assertEquals($expected, $parties);
     }
 
-    private function getAllPositions($method) {
-        $party = new MySociety\TheyWorkForYou\Party('A Party');
+    public function testLabourCoOpPositionCalc() {
+        $positions = $this->getAllPositions('calculateAllPolicyPositions', 'Labour');
+
+        $expectedResults = array(
+            '810' => array(
+                'policy_id' => 810,
+                'position' => 'voted a mixture of for and against',
+                'score' => 0.5,
+                'desc' => 'greater <b>regulation of gambling</b>'
+            )
+        );
+
+        $this->assertEquals($expectedResults, $positions);
+
+        $party = new MySociety\TheyWorkForYou\Party('Labour/Co-operative');
+        $party->cache_position( $positions['810'] );
+
+        $position = $party->policy_position(810);
+        $expected = ('voted a mixture of for and against');
+
+        $this->assertEquals($expected, $position);
+    }
+
+    private function getAllPositions($method, $party = 'A Party') {
+        $party = new MySociety\TheyWorkForYou\Party($party);
         $policies = new MySociety\TheyWorkForYou\Policies();
 
         $positions = $party->$method($policies);

--- a/tests/_fixtures/party.xml
+++ b/tests/_fixtures/party.xml
@@ -81,6 +81,30 @@
 			<field name="person_id">3</field>
 			<field name="lastupdate">2013-08-07 15:06:19</field>
 		</row>
+		<row>
+			<field name="member_id">3</field>
+			<field name="house">1</field>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="party">Independent</field>
+			<field name="entered_house">2000-01-01</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">4</field>
+			<field name="lastupdate">2013-08-07 15:06:19</field>
+		</row>
+		<row>
+			<field name="member_id">4</field>
+			<field name="house">1</field>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="party">Crossbench</field>
+			<field name="entered_house">2000-01-01</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">5</field>
+			<field name="lastupdate">2013-08-07 15:06:19</field>
+		</row>
 	</table_data>
 	<table_data name="person_names">
 		<row>
@@ -104,8 +128,24 @@
 			<field name="family_name">Current-MP</field>
 			<field name="start_date">2000-01-01</field>
 			<field name="end_date">9999-12-31</field>
-			<field name="person_id">2</field>
+			<field name="person_id">3</field>
 			<field name="title">Mrs</field>
+		</row>
+		<row>
+			<field name="given_name">Test</field>
+			<field name="family_name">Another-MP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">4</field>
+			<field name="title">Mr</field>
+		</row>
+		<row>
+			<field name="given_name">Test</field>
+			<field name="family_name">YetAnother-MP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">5</field>
+			<field name="title">Miss</field>
 		</row>
 	</table_data>
 	<table_data name="memberinfo">

--- a/tests/_fixtures/party.xml
+++ b/tests/_fixtures/party.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0"?>
+<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<database name="twfy_testing">
+	<table_data name="alerts">
+	</table_data>
+	<table_data name="anonvotes">
+	</table_data>
+	<table_data name="api_key">
+	</table_data>
+	<table_data name="api_stats">
+	</table_data>
+	<table_data name="bills">
+	</table_data>
+	<table_data name="campaigners">
+	</table_data>
+	<table_data name="campaigners_sent_email">
+	</table_data>
+	<table_data name="commentreports">
+	</table_data>
+	<table_data name="comments">
+	</table_data>
+	<table_data name="consinfo">
+		<row>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="data_key">test_constituency_key</field>
+			<field name="data_value">Test Constituency Value</field>
+		</row>
+	</table_data>
+	<table_data name="constituency">
+	</table_data>
+	<table_data name="editqueue">
+	</table_data>
+	<table_data name="epobject">
+	</table_data>
+	<table_data name="future">
+	</table_data>
+	<table_data name="future_people">
+	</table_data>
+	<table_data name="gidredirect">
+	</table_data>
+	<table_data name="glossary">
+	</table_data>
+	<table_data name="hansard">
+	</table_data>
+	<table_data name="indexbatch">
+	</table_data>
+	<table_data name="member">
+		<row>
+			<field name="member_id">0</field>
+			<field name="house">0</field>
+			<field name="constituency"></field>
+			<field name="party"></field>
+			<field name="entered_house">1952-02-06</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">accession</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">1</field>
+			<field name="lastupdate">2013-08-07 11:02:49</field>
+		</row>
+		<row>
+			<field name="member_id">1</field>
+			<field name="house">1</field>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="party">A Party</field>
+			<field name="entered_house">2000-01-01</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">2</field>
+			<field name="lastupdate">2013-08-07 15:06:19</field>
+		</row>
+		<row>
+			<field name="member_id">2</field>
+			<field name="house">1</field>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="party">A Party</field>
+			<field name="entered_house">2000-01-01</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">3</field>
+			<field name="lastupdate">2013-08-07 15:06:19</field>
+		</row>
+	</table_data>
+	<table_data name="person_names">
+		<row>
+			<field name="given_name">Elizabeth</field>
+			<field name="family_name">the Second, by the Grace of God, of the United Kingdom of Great Britain and Northern Ireland and of Her other Realms and Territories Queen, Head of the Commonwealth, Defender of the Faith</field>
+			<field name="start_date">1952-02-06</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">1</field>
+			<field name="title">Queen</field>
+		</row>
+		<row>
+			<field name="given_name">Test</field>
+			<field name="family_name">Current-MP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">2</field>
+			<field name="title">Mrs</field>
+		</row>
+		<row>
+			<field name="given_name">Test</field>
+			<field name="family_name">Current-MP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">2</field>
+			<field name="title">Mrs</field>
+		</row>
+	</table_data>
+	<table_data name="memberinfo">
+		<row>
+			<field name="member_id">15</field>
+			<field name="data_key">test_member_key</field>
+			<field name="data_value">Test Member Value</field>
+		</row>
+	</table_data>
+	<table_data name="mentions">
+	</table_data>
+	<table_data name="moffice">
+	</table_data>
+	<table_data name="pbc_members">
+	</table_data>
+	<table_data name="personinfo">
+		<row>
+			<field name="person_id">16</field>
+			<field name="data_key">test_person_key</field>
+			<field name="data_value">Test Person Value</field>
+		</row>
+	</table_data>
+  <table_data name="policydivisions">
+      <row>
+          <field name="division_id">1</field>
+          <field name="house">commons</field>
+          <field name="policy_id">810</field>
+          <field name="division_title">A division</field>
+          <field name="direction">Majority</field>
+          <field name="policy_vote">aye</field>
+      </row>
+  </table_data>
+  <table_data name="persondivisionvotes">
+      <row>
+          <field name="division_id">1</field>
+          <field name="person_id">2</field>
+          <field name="vote">aye</field>
+      </row>
+      <row>
+          <field name="division_id">1</field>
+          <field name="person_id">3</field>
+          <field name="vote">no</field>
+      </row>
+  </table_data>
+  <table_data name="partypolicy">
+      <row>
+          <field name="party">A Party</field>
+          <field name="policy_id">363</field>
+          <field name="house">1</field>
+          <field name="score">0.9</field>
+      </row>
+  </table_data>
+	<table_data name="postcode_lookup">
+      <row>
+          <field name="postcode">KY16 8YG</field>
+          <field name="name">North East Fife|North East Fife|Mid Scotland and Fife</field>
+      </row>
+      <row>
+          <field name="postcode">BT17 0XD</field>
+          <field name="name">Belfast West|Belfast West</field>
+      </row>
+	</table_data>
+	<table_data name="search_query_log">
+	</table_data>
+	<table_data name="survey">
+	</table_data>
+	<table_data name="titles">
+	</table_data>
+	<table_data name="titles_ignored">
+	</table_data>
+	<table_data name="trackbacks">
+	</table_data>
+	<table_data name="users">
+	</table_data>
+	<table_data name="uservotes">
+	</table_data>
+	<table_data name="video_timestamps">
+	</table_data>
+	<table_data name="editorial">
+	</table_data>
+</database>
+</mysqldump>

--- a/tests/_fixtures/party.xml
+++ b/tests/_fixtures/party.xml
@@ -171,6 +171,14 @@
 			<field name="person_id">5</field>
 			<field name="title">Miss</field>
 		</row>
+		<row>
+			<field name="given_name">Test</field>
+			<field name="family_name">Further-MP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">6</field>
+			<field name="title">Miss</field>
+		</row>
 	</table_data>
 	<table_data name="memberinfo">
 		<row>
@@ -178,6 +186,1497 @@
 			<field name="data_key">test_member_key</field>
 			<field name="data_value">Test Member Value</field>
 		</row>
+		<row>
+			<field name="member_id">1</field>
+			<field name="data_key">public_whip_dreammp363_distance</field>
+			<field name="data_value">0.27</field>
+		</row>
+		<row>
+			<field name="member_id">1</field>
+			<field name="data_key">public_whip_dreammp363_both_voted</field>
+			<field name="data_value">1</field>
+		</row>
+
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1049_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1049_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1065_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1065_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1050_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1050_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6702_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6702_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1120_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1120_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6710_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6710_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1105_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1105_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6707_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6707_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6721_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6721_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6705_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6705_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6672_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6672_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6711_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6711_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6681_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6681_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6703_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6703_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1027_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1027_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1053_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1053_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6688_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6688_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6691_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6691_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1109_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1109_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6670_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6670_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6677_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6677_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1132_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1132_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp837_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp837_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6671_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6671_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6699_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6699_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6718_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6718_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6706_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6706_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6673_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6673_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1136_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1136_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6715_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6715_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1030_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1030_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1074_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1074_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1079_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1079_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1084_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1084_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6695_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6695_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6719_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6719_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6716_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6716_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp984_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp984_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6698_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6698_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6697_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6697_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1110_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1110_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1113_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1113_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp811_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp811_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6696_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6696_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1124_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1124_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6684_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6684_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6686_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6686_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6678_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6678_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6720_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6720_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1052_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1052_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6676_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6676_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6709_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6709_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6667_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6667_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6682_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6682_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6680_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6680_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp363_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp363_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp826_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp826_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6690_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6690_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6692_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6692_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1071_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1071_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6674_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6674_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1051_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1051_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6687_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6687_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6679_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6679_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6708_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6708_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp996_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp996_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6685_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6685_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6694_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6694_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1087_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp1087_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp975_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp975_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp810_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp810_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6683_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6683_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6693_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6693_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6704_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">2</field>
+            <field name="data_key">public_whip_dreammp6704_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1049_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1049_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1065_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1065_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1050_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1050_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6702_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6702_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1120_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1120_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6710_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6710_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1105_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1105_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6707_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6707_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6721_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6721_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6705_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6705_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6672_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6672_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6711_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6711_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6681_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6681_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6703_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6703_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1027_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1027_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1053_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1053_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6688_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6688_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6691_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6691_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1109_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1109_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6670_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6670_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6677_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6677_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1132_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1132_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp837_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp837_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6671_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6671_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6699_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6699_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6718_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6718_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6706_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6706_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6673_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6673_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1136_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1136_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6715_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6715_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1030_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1030_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1074_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1074_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1079_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1079_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1084_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1084_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6695_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6695_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6719_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6719_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6716_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6716_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp984_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp984_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6698_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6698_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6697_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6697_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1110_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1110_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1113_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1113_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp811_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp811_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6696_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6696_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1124_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1124_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6684_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6684_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6686_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6686_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6678_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6678_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6720_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6720_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1052_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1052_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6676_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6676_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6709_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6709_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6667_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6667_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6682_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6682_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6680_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6680_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp363_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp363_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp826_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp826_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6690_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6690_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6692_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6692_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1071_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1071_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6674_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6674_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1051_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1051_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6687_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6687_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6679_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6679_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6708_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6708_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp996_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp996_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6685_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6685_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6694_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6694_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1087_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp1087_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp975_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp975_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp810_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp810_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6683_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6683_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6693_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6693_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6704_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="member_id">5</field>
+            <field name="data_key">public_whip_dreammp6704_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
 	</table_data>
 	<table_data name="mentions">
 	</table_data>
@@ -191,6 +1690,18 @@
 			<field name="data_key">test_person_key</field>
 			<field name="data_value">Test Person Value</field>
 		</row>
+	</table_data>
+	<table_data name="policies">
+      <row>
+          <field name="policy_id">363</field>
+          <field name="title">Test Policy</field>
+          <field name="description">A policy to test policies</field>
+          <field name="image">/image/test-policy-image.png</field>
+          <field name="image_attrib">test policy attribution</field>
+          <field name="image_license">test license</field>
+          <field name="image_license_url">http://example.org/license</field>
+          <field name="image_source">http://example.org/source</field>
+      </row>
 	</table_data>
   <table_data name="policydivisions">
       <row>

--- a/tests/_fixtures/party.xml
+++ b/tests/_fixtures/party.xml
@@ -201,6 +201,14 @@
           <field name="direction">Majority</field>
           <field name="policy_vote">aye</field>
       </row>
+      <row>
+          <field name="division_id">2</field>
+          <field name="house">commons</field>
+          <field name="policy_id">900</field>
+          <field name="division_title">A division</field>
+          <field name="direction">Majority</field>
+          <field name="policy_vote">absent</field>
+      </row>
   </table_data>
   <table_data name="persondivisionvotes">
       <row>
@@ -220,6 +228,11 @@
       </row>
       <row>
           <field name="division_id">1</field>
+          <field name="person_id">7</field>
+          <field name="vote">no</field>
+      </row>
+      <row>
+          <field name="division_id">2</field>
           <field name="person_id">7</field>
           <field name="vote">no</field>
       </row>

--- a/tests/_fixtures/party.xml
+++ b/tests/_fixtures/party.xml
@@ -105,6 +105,30 @@
 			<field name="person_id">5</field>
 			<field name="lastupdate">2013-08-07 15:06:19</field>
 		</row>
+		<row>
+			<field name="member_id">5</field>
+			<field name="house">1</field>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="party">Labour</field>
+			<field name="entered_house">2000-01-01</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">6</field>
+			<field name="lastupdate">2013-08-07 15:06:19</field>
+		</row>
+		<row>
+			<field name="member_id">6</field>
+			<field name="house">1</field>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="party">Labour/Co-operative</field>
+			<field name="entered_house">2000-01-01</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">7</field>
+			<field name="lastupdate">2013-08-07 15:06:19</field>
+		</row>
 	</table_data>
 	<table_data name="person_names">
 		<row>
@@ -187,6 +211,16 @@
       <row>
           <field name="division_id">1</field>
           <field name="person_id">3</field>
+          <field name="vote">no</field>
+      </row>
+      <row>
+          <field name="division_id">1</field>
+          <field name="person_id">6</field>
+          <field name="vote">aye</field>
+      </row>
+      <row>
+          <field name="division_id">1</field>
+          <field name="person_id">7</field>
           <field name="vote">no</field>
       </row>
   </table_data>

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -467,8 +467,13 @@ switch ($pagetype) {
         // generate party policy diffs
         $party = new MySociety\TheyWorkForYou\Party($MEMBER->party());
         $positions = new MySociety\TheyWorkForYou\PolicyPositions( $policiesList, $MEMBER );
-        $party_positions = $party->getAllPolicyPositions($policiesList);
-        $policy_diffs = $MEMBER->getPartyPolicyDiffs($party, $policiesList, $positions, true);
+        if ( $party ) {
+            $party_positions = $party->getAllPolicyPositions($policiesList);
+            $policy_diffs = $MEMBER->getPartyPolicyDiffs($party, $policiesList, $positions, true);
+        } else {
+            $party_positions = null;
+            $policy_diffs = null;
+        }
 
         $data['sorted_diffs'] = $policy_diffs;
         $data['party_positions'] = $party_positions;

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -467,13 +467,8 @@ switch ($pagetype) {
         // generate party policy diffs
         $party = new MySociety\TheyWorkForYou\Party($MEMBER->party());
         $positions = new MySociety\TheyWorkForYou\PolicyPositions( $policiesList, $MEMBER );
-        if ( $party ) {
-            $party_positions = $party->getAllPolicyPositions($policiesList);
-            $policy_diffs = $MEMBER->getPartyPolicyDiffs($party, $policiesList, $positions, true);
-        } else {
-            $party_positions = null;
-            $policy_diffs = null;
-        }
+        $party_positions = $party->getAllPolicyPositions($policiesList);
+        $policy_diffs = $MEMBER->getPartyPolicyDiffs($party, $policiesList, $positions, true);
 
         $data['sorted_diffs'] = $policy_diffs;
         $data['party_positions'] = $party_positions;

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -464,6 +464,17 @@ switch ($pagetype) {
         // Generate limited voting record list
         $data['policyPositions'] = new MySociety\TheyWorkForYou\PolicyPositions($policies, $MEMBER, 6);
 
+        // generate party policy diffs
+        $party = new MySociety\TheyWorkForYou\Party($MEMBER->party());
+        $positions = new MySociety\TheyWorkForYou\PolicyPositions( $policiesList, $MEMBER );
+        $party_positions = $party->getAllPolicyPositions($policiesList);
+        $policy_diffs = $MEMBER->getPartyPolicyDiffs($party, $policiesList, $positions, true);
+
+        $data['sorted_diffs'] = $policy_diffs;
+        $data['party_positions'] = $party_positions;
+        $data['positions'] = $positions->positionsById;
+        $data['policies'] = $policiesList->getPolicies();
+
         // Send the output for rendering
         MySociety\TheyWorkForYou\Renderer::output('mp/profile', $data);
 

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -55,11 +55,39 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                 <?php if (count($policyPositions->positions) > 0): ?>
                 <div class="panel">
                     <a name="votes"></a>
-                    <h2 data-magellan-destination="votes">A selection of <?= $full_name ?>'s votes</h2>
+                    <h2 data-magellan-destination="votes"><?= $full_name ?>&rsquo;s voting in Parliament</h2>
 
-                    <p><a href="<?= $member_url ?>/votes">See full list of topics voted on</a></p>
 
-                    <?php if (count($policyPositions->positions) > 0): ?>
+                    <?php if (count($sorted_diffs) > 0): ?>
+
+                        <p>
+                        <?= $full_name ?> is a <?= $party ?> MP, and so on the <b>vast majority</b> of issues votes the <b>same way</b> as other <?= $party ?> MPs.
+                        </p>
+
+                        <p>
+                        However, <?= $full_name ?> sometimes <b>differs</b> from their party collegues, such as:
+                        </p>
+
+                        <ul class="vote-descriptions">
+                          <?php foreach ($sorted_diffs as $policy_id => $score): ?>
+                            <li>
+                                <?= ucfirst(strip_tags($policies[$policy_id])) ?>. <?= $full_name ?> <b><?= $positions[$policy_id]['position'] ?></b>. Most <?= $party ?> MPs <b><?= $party_positions[$policy_id]['position'] ?></b>.
+                                <a class="vote-description__source" href="<?= $member_url?>/divisions?policy=<?= $policy_id ?>">Show votes</a>
+                            </li>
+                          <?php endforeach; ?>
+                        </ul>
+
+                        <p>We have <b>lots more</b> plain English analysis of <?= $full_name ?>&rsquo;s voting record  on issues like health, welfare, taxation and more. Visit <a href="<?= $member_url ?>/votes"><?= $full_name ?>&rsquo;s full vote analysis page</a> for more.</p>
+
+                    <?php elseif (count($policyPositions->positions) > 0 ): ?>
+                        <p>
+                        <?= $full_name ?> is a <?= $party ?> MP, and so on the <b>vast majority</b> of issues votes the <b>same way</b> as other <?= $party ?> MPs.
+                        </p>
+
+
+                        <p>
+                        This is a selection of <?= $full_name ?>&rsquo;s votes.
+                        </p>
 
                         <ul class="vote-descriptions">
                           <?php foreach ($policyPositions->positions as $key_vote): ?>
@@ -70,9 +98,8 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                           <?php endforeach; ?>
                         </ul>
 
-                        <p>New: more <a href="<?= $member_url ?>/votes">analysis of votes</a> on <a href="<?= $member_url ?>/votes#health">health</a>, <a href="<?= $member_url ?>/votes#welfare">welfare</a>, <a href="<?= $member_url ?>/votes#foreign">foreign policy</a>, <a href="<?= $member_url ?>/votes#social">social issues</a>, <a href="<?= $member_url ?>/votes#taxation">taxation</a> and more.</p>
-
-                    <?php else: ?>
+                        <p>We have <b>lots more</b> plain English analysis of <?= $full_name ?>&rsquo;s voting record  on issues like health, welfare, taxation and more. Visit <a href="<?= $member_url ?>/votes"><?= $full_name ?>&rsquo;s full vote analysis page</a> for more.</p>
+                    <?php elseif (count($policyPositions->positions) == 0 ): ?>
 
                         <p>No votes to display.</p>
 

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -52,7 +52,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                 </div>
                 <?php endif; ?>
 
-                <?php if (count($policyPositions->positions) > 0): ?>
+                <?php if (count($policyPositions->positions) > 0 || count($sorted_diffs) > 0): ?>
                 <div class="panel">
                     <a name="votes"></a>
                     <h2 data-magellan-destination="votes"><?= $full_name ?>&rsquo;s voting in Parliament</h2>

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -80,9 +80,11 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                         <p>We have <b>lots more</b> plain English analysis of <?= $full_name ?>&rsquo;s voting record  on issues like health, welfare, taxation and more. Visit <a href="<?= $member_url ?>/votes"><?= $full_name ?>&rsquo;s full vote analysis page</a> for more.</p>
 
                     <?php elseif (count($policyPositions->positions) > 0 ): ?>
+                        <?php if ( $party_positions !== null ) { ?>
                         <p>
                         <?= $full_name ?> is a <?= $party ?> MP, and so on the <b>vast majority</b> of issues votes the <b>same way</b> as other <?= $party ?> MPs.
                         </p>
+                        <?php } ?>
 
 
                         <p>


### PR DESCRIPTION
This imports the policy vote from PublicWhip and then uses all the votes of current party members to calculate the party's position on a policy. It then compares that with an MP's position and if it is in opposition then it displays that policy on the MP's profile page.

Connects to #910