### PR TITLE
Improvements to vote summary wording and buttons

### DIFF
--- a/classes/PolicyPositions.php
+++ b/classes/PolicyPositions.php
@@ -108,11 +108,13 @@ class PolicyPositions {
 
                 // Make sure the dream actually exists
                 if (!empty($dream_info)) {
-                    $this->positions[] = array( 'policy_id' => $policy[0], 'desc' => $dream_info['full_sentence'] );
+                    $this->positions[] = array(
+                        'policy_id' => $policy[0],
+                        'desc' => $dream_info['full_sentence']
+                    );
                     $this->positionsById[$policy[0]] = array(
                         'policy_id' => $policy[0],
-                        'desc' => $dream_info['full_sentence'],
-                        'voted' => $dream_info['voted']
+                        'desc' => $dream_info['full_sentence']
                     );
                     $i++;
                 }
@@ -131,29 +133,41 @@ class PolicyPositions {
 
     }
 
-    private function displayDreamComparison($dreamid, $desc, $inverse=false) {
+    /**
+     * displayDreamComparison
+     *
+     * Returns an array with one key: "full_sentence".
+     *
+     * The "full_sentence" element is a string, beginning with a lower case
+     * letter, suitable for either displaying after a person’s name, eg:
+     *
+     *     "Lord Lordson consistently voted against [some policy]"
+     *
+     * or being passed into ucfirst() and displayed as a sentence on its
+     * own, where the person's name is implied by context, eg:
+     *
+     *     "Consistently voted against [some policy]"
+     *
+     */
+
+    private function displayDreamComparison($dreamid, $policy_description, $inverse=false) {
         $out = array();
 
         $extra_info = $this->member->extra_info();
 
         if (isset($extra_info["public_whip_dreammp${dreamid}_distance"])) {
             if ($extra_info["public_whip_dreammp${dreamid}_both_voted"] == 0) {
-                $english = 'never voted';
-                $dmpdesc = 'Has <strong>never voted</strong> on';
+                $consistency = 'has never voted on';
             } else {
                 $dmpscore = floatval($extra_info["public_whip_dreammp${dreamid}_distance"]);
-                $score_text = "<!-- distance $dreamid: $dmpscore -->";
                 if ($inverse)
                     $dmpscore = 1.0 - $dmpscore;
-                $english = score_to_strongly($dmpscore);
-                $dmpdesc = $score_text . ' Voted <strong>' . $english . '</strong>';
-
-                // How many votes Dream MP and MP both voted (and didn't abstain) in
-                // $extra_info["public_whip_dreammp${dreamid}_both_voted"];
+                $consistency = score_to_strongly($dmpscore);
             }
-            $dmpdesc .= ' ' . $desc;
-            $out = array( 'full_sentence' => $dmpdesc, 'voted' => $english );
+            $full_sentence = $consistency . ' ' . $policy_description;
+            $out = array( 'full_sentence' => $full_sentence );
         }
+
         return $out;
     }
 

--- a/tests/DivisionsTest.php
+++ b/tests/DivisionsTest.php
@@ -50,7 +50,7 @@ class DivisionsTest extends FetchPageTestCase
 
     public function testPolicyDirection() {
         $page = $this->fetch_division_page();
-        $this->assertContains('voted strongly against introducing <b>foundation', $page);
+        $this->assertContains('almost always voted against introducing <b>foundation', $page);
     }
 
     public function testVotedAgainst() {

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -566,10 +566,16 @@
     line-height: 1.5em;
     padding-top: 0.5em;
     padding-bottom: 0.5em;
-    padding-right: 5em;
+    padding-right: 6.5em; // leave space for "Show votes" .vote-description__source button
 
     &:first-child {
       border-top: 1px solid $borders;
+    }
+
+    @media (min-height: 800px) {
+        // Bit of extra space around "Show votes" buttons if there's space
+        padding-top: 0.7em;
+        padding-bottom: 0.7em;
     }
   }
 
@@ -617,8 +623,8 @@
   line-height: 2em;
 
   @include radius(1em);
-  background-color: transparent;
-  color: #cfcabb; // light desaturated taupe colour
+  background-color: $body-bg;
+  color: $body-font-color;
   font-size: 14px;
   text-decoration: none;
 
@@ -631,7 +637,7 @@
     background-color: $links;
     color: #fff;
 
-    &::after {
+    &:after {
       background-image: url(/images/external-link-icon-white.png);
     }
 

--- a/www/includes/easyparliament/templates/html/mp/divisions.php
+++ b/www/includes/easyparliament/templates/html/mp/divisions.php
@@ -34,31 +34,6 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
                 <?php $displayed_votes = FALSE; ?>
                 <?php if ( isset($policydivisions) && $policydivisions ) { ?>
-                    <?php if ( $answered_q ) { ?>
-                        <p class="panel panel--feedback">
-                            Thanks for the feedback.
-                        </p>
-                    <?php } else { ?>
-                        <form method="post" action="<?= OPTION_SURVEY_URL ?>" class="panel panel--feedback">
-                            <input type="hidden" name="sourceidentifier" value="divisions-suggestions">
-                            <input type="hidden" name="datetime" value="<?=time() ?>">
-                            <input type="hidden" name="subgroup" value="0">
-
-                            <input type="hidden" name="user_code" value="<?=$user_code ?>">
-                            <input type="hidden" name="auth_signature" value="<?=$auth_signature ?>">
-
-                            <input type="hidden" name="came_from" value="<?=$page_url ?>">
-                            <input type="hidden" name="return_url" value="<?=$page_url ?>">
-                            <p>
-                                <strong>This page is new!</strong>
-                                Is there anything else you&rsquo;d like to see on it?
-                            </p>
-                            <p>
-                                <input type="text" name="policy-page-suggestion" placeholder="I want to see&hellip;">
-                                <input type="submit" class="button small" value="Make it happen!">
-                            </p>
-                        </form>
-                    <?php } ?>
 
                     <?php if ($has_voting_record) { ?>
 

--- a/www/includes/easyparliament/templates/html/mp/divisions.php
+++ b/www/includes/easyparliament/templates/html/mp/divisions.php
@@ -86,8 +86,15 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                             <?php if ( isset($policy['position']) ) { ?>
                                 <div class="panel">
                                     <h3 class="policy-vote-overall-stance">
-                                        <?= $full_name ?> <?= $policy['position']['voted'] == 'never voted' ? $policy['position']['voted'] . ' on' : 'voted ' .$policy['position']['voted'] ?> <?= $policy['desc'] ?>
+                                        <?= $full_name . ' ' . $policy['position']['desc'] ?>
                                     </h3>
+
+                                    <?php $pw_url = 'http://www.publicwhip.org.uk/mp.php?mpid=' . $member_id . '&amp;dmp=' . $policy['policy_id']; ?>
+                                    <p>
+                                        TheyWorkForYou has automatically calculated this MP&rsquo;s stance based on all
+                                        of their votes on the topic. <a href="<?= $pw_url ?>">You can browse the source
+                                        data on PublicWhip.org.uk</a>.
+                                    </p>
 
                                     <?php if ( DEVSITE ) { ?>
                                     <p class="policy-vote-agree-disagree">

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -64,8 +64,8 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                         <ul class="vote-descriptions">
                           <?php foreach ($policyPositions->positions as $key_vote): ?>
                             <li>
-                                <?= $key_vote['desc'] ?>
-                                <a class="vote-description__source" href="<?= $member_url?>/divisions?policy=<?= $key_vote['policy_id'] ?>">Details</a>
+                                <?= ucfirst($key_vote['desc']) ?>
+                                <a class="vote-description__source" href="<?= $member_url?>/divisions?policy=<?= $key_vote['policy_id'] ?>">Show votes</a>
                             </li>
                           <?php endforeach; ?>
                         </ul>

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -57,8 +57,8 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                             <ul class="vote-descriptions">
                               <?php foreach ($segment['votes']->positions as $key_vote): ?>
                                 <li>
-                                    <?= $key_vote['desc'] ?>
-                                    <a class="vote-description__source" href="<?= $member_url?>/divisions?policy=<?= $key_vote['policy_id'] ?>">Details</a>
+                                    <?= ucfirst($key_vote['desc']) ?>
+                                    <a class="vote-description__source" href="<?= $member_url?>/divisions?policy=<?= $key_vote['policy_id'] ?>">Show votes</a>
                                 </li>
                               <?php endforeach; ?>
                             </ul>

--- a/www/includes/easyparliament/templates/html/topic/topic.php
+++ b/www/includes/easyparliament/templates/html/topic/topic.php
@@ -142,7 +142,7 @@
 
                                 <?php foreach ($positions as $position): ?>
 
-                                <li><?= $position['desc'] ?><a class="dream_details" href="http://www.publicwhip.org.uk/mp.php?mpid=<?= $member_id ?>&dmp=<?= $position['policy_id'] ?>">Details</a></li>
+                                <li><?= ucfirst($position['desc']) ?><a class="dream_details" href="http://www.publicwhip.org.uk/mp.php?mpid=<?= $member_id ?>&dmp=<?= $position['policy_id'] ?>">Show votes</a></li>
 
                                 <?php endforeach; ?>
 

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -1083,19 +1083,19 @@ function _major_summary_title($major, $data, $LISTURL, $daytext) {
 function score_to_strongly($dmpscore) {
     $dmpdesc = "unknown about";
     if ($dmpscore > 0.95 && $dmpscore <= 1.0)
-        $dmpdesc = "very strongly against";
+        $dmpdesc = "consistently voted against";
     elseif ($dmpscore > 0.85)
-        $dmpdesc = "strongly against";
+        $dmpdesc = "almost always voted against";
     elseif ($dmpscore > 0.6)
-        $dmpdesc = "moderately against";
+        $dmpdesc = "generally voted against";
     elseif ($dmpscore > 0.4)
-        $dmpdesc = "a mixture of for and against";
+        $dmpdesc = "voted a mixture of for and against";
     elseif ($dmpscore > 0.15)
-        $dmpdesc = "moderately for";
+        $dmpdesc = "generally voted for";
     elseif ($dmpscore > 0.05)
-        $dmpdesc = "strongly for";
+        $dmpdesc = "almost always voted for";
     elseif ($dmpscore >= 0.0)
-        $dmpdesc = "very strongly for";
+        $dmpdesc = "consistently voted for";
     return $dmpdesc;
 }
 


### PR DESCRIPTION
Connects to #558.

* "Generally", "Almost always", and "Consistently" rather than "Moderately", "Strongly", "Very strongly".
* Explanation of how votes are summarised on topic vote summary page.
* Chunkier buttons next to vote summaries, also reworded from "Details" to "Show votes".

![screen shot 2015-07-03 at 09 56 01](https://cloud.githubusercontent.com/assets/739624/8495996/bc31f550-2169-11e5-9e48-0ec078f433ac.png)
