### PR TITLE
swap search term and glossary highlighting order

### DIFF
--- a/classes/SectionView/SectionView.php
+++ b/classes/SectionView/SectionView.php
@@ -159,6 +159,12 @@ class SectionView {
             $bodies[] = $body;
         }
 
+        if ($SEARCHENGINE) {
+            // We have some search terms to highlight.
+            twfy_debug_timestamp('Before highlight');
+            $bodies = $SEARCHENGINE->highlight($bodies);
+            twfy_debug_timestamp('After highlight');
+        }
         // Do all this unless the glossary is turned off in the URL
         if (get_http_var('ug') != 1) {
             // And glossary phrases
@@ -169,12 +175,6 @@ class SectionView {
             $bodies = $GLOSSARY->glossarise($bodies, 1);
 
             twfy_debug_timestamp('After glossarise');
-        }
-        if ($SEARCHENGINE) {
-            // We have some search terms to highlight.
-            twfy_debug_timestamp('Before highlight');
-            $bodies = $SEARCHENGINE->highlight($bodies);
-            twfy_debug_timestamp('After highlight');
         }
 
         $first_speech = null;

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -98,7 +98,7 @@ class SearchTest extends FetchPageTestCase
     }
 
     /**
-     * Test that glossarising a single word works as expected.
+     * Test that search term highlighting skips tag attributes
      *
      * @group xapian
      */
@@ -203,7 +203,7 @@ class SearchTest extends FetchPageTestCase
      * @group xapian
      */
     public function testSearchPageSpellCorrect() {
-        $page = $this->fetch_page( array( 's' => 'plice' ) );
+        $page = $this->fetch_page( array( 'q' => 'plice' ) );
         $this->assertContains('Did you mean <a href="/search/?q=place">place', $page);
     }
 
@@ -217,4 +217,21 @@ class SearchTest extends FetchPageTestCase
         $this->assertContains('Who says splice the most', $page);
         $this->assertContains('No results', $page);
     }
+
+    /**
+     * Test that search highlighting with phrases skips words contained in link title attributes.
+     *
+     * @group xapian
+     */
+    public function testSearchPhraseHighlightingInTags() {
+        $SEARCHENGINE = new SEARCHENGINE('"Shabana"');
+
+        $expected_text = '<p pid="b.893.4/1">On a point of order, Mr <a href="/glossary/?gl=21" title="The Speaker is an MP who has been elected to act as Chairman during debates..." class="glossary">Speaker</a>. In yesterday&#8217;s Finance Bill debate, <a href="/mp/?m=40084" title="Our page on Shabana Mahmood - \'the hon. Member for Birmingham, Ladywood (Shabana Mahmood)\'"><span class="hi">Shabana</span> Mahmood</a> said that the tax gap was 32 billion when the previous Government left office and that it has now gone up to 35 billion. Official Her Majesty&#8217;s Revenue and Customs figures show the tax gap was actually 42 billion when Labour left office, so there has been a fall of 7 billion under this Government';
+        $text = '<p pid="b.893.4/1">On a point of order, Mr <a href="/glossary/?gl=21" title="The Speaker is an MP who has been elected to act as Chairman during debates..." class="glossary">Speaker</a>. In yesterday&#8217;s Finance Bill debate, <a href="/mp/?m=40084" title="Our page on Shabana Mahmood - \'the hon. Member for Birmingham, Ladywood (Shabana Mahmood)\'">Shabana Mahmood</a> said that the tax gap was 32 billion when the previous Government left office and that it has now gone up to 35 billion. Official Her Majesty&#8217;s Revenue and Customs figures show the tax gap was actually 42 billion when Labour left office, so there has been a fall of 7 billion under this Government';
+        $this->assertEquals(
+            $expected_text,
+            $SEARCHENGINE->highlight($text)
+        );
+    }
+
 }

--- a/tests/SectionTest.php
+++ b/tests/SectionTest.php
@@ -116,6 +116,20 @@ class SectionTest extends FetchPageTestCase
         }
     }
 
+    /**
+     * Test that applying search highlighting and glossary linking to the same
+     * term doesn't break the layout
+     *
+     * see issue 912 for details
+     *
+     * @group xapian
+     */
+    public function testGlossaryAndSearchHighlights() {
+            $page = $this->fetch_page( array( 'type' => 'lords', 's' => 'constituency', 'id' => '2014-02-02b.1.3' ) );
+            $this->assertContains("constituency", $page);
+            $this->assertContains("<span class=\"hi\"><a href=\"/glossary/?gl=1\" title=\"In a general election, each Constituency chooses an MP to represent them....\" class=\"glossary\">constituency</a></span>", $page);
+    }
+
     public function testGidRedirect() {
         $page = $this->fetch_page( array( 'type' => 'wrans', 'id' => '2014-01-01a.187335.h' ) );
         $this->assertRegexp("#Location: .*?/wrans/\?id=2014-01-01b\.1\.2#", $page);

--- a/tests/_fixtures/section.xml
+++ b/tests/_fixtures/section.xml
@@ -53,6 +53,9 @@
 	<row> <field name="epobject_id">10100</field> <field name="body">HeadingA</field> </row>
 	<row> <field name="epobject_id">10101</field> <field name="body">SubheadingA</field> </row>
 	<row> <field name="epobject_id">10102</field> <field name="body">SpeechA</field> </row>
+	<row> <field name="epobject_id">10103</field> <field name="body">HeadingA</field> </row>
+	<row> <field name="epobject_id">10104</field> <field name="body">SubheadingA</field> </row>
+	<row> <field name="epobject_id">10105</field> <field name="body">This is some text with a glossary item - constituency - that is also a search term</field> </row>
 	</table_data>
 	<table_data name="gidredirect">
 	<row>
@@ -440,6 +443,45 @@
 		<field name="hdate">2014-01-01</field>
 		<field name="htime">14:30:00</field>
 	</row>
+	<row>
+		<field name="epobject_id">10103</field>
+		<field name="gid">uk.org.publicwhip/lords/2014-02-02b.1.1</field>
+		<field name="htype">10</field>
+		<field name="person_id">0</field>
+		<field name="major">101</field>
+		<field name="minor">0</field>
+		<field name="section_id">0</field>
+		<field name="subsection_id">0</field>
+		<field name="hpos">1</field>
+		<field name="hdate">2014-02-02</field>
+		<field name="htime">14:30:00</field>
+	</row>
+	<row>
+		<field name="epobject_id">10104</field>
+		<field name="gid">uk.org.publicwhip/lords/2014-02-02b.1.2</field>
+		<field name="htype">11</field>
+		<field name="person_id">0</field>
+		<field name="major">101</field>
+		<field name="minor">0</field>
+		<field name="section_id">10103</field>
+		<field name="subsection_id">0</field>
+		<field name="hpos">2</field>
+		<field name="hdate">2014-02-02</field>
+		<field name="htime">14:30:00</field>
+	</row>
+	<row>
+		<field name="epobject_id">10105</field>
+		<field name="gid">uk.org.publicwhip/lords/2014-02-02b.1.3</field>
+		<field name="htype">12</field>
+		<field name="person_id">1</field>
+		<field name="major">101</field>
+		<field name="minor">0</field>
+		<field name="section_id">10103</field>
+		<field name="subsection_id">10104</field>
+		<field name="hpos">3</field>
+		<field name="hdate">2014-02-02</field>
+		<field name="htime">14:30:00</field>
+	</row>
 	</table_data>
 	<table_data name="member">
 	<row>
@@ -493,6 +535,79 @@
 		<field name="bill_id">1</field>
 		<field name="sitting">01-0</field>
 		<field name="attending">0</field>
+	</row>
+	</table_data>
+	<table_data name="editqueue">
+	<row>
+		<field name="edit_id">1</field>
+		<field name="user_id">1</field>
+		<field name="edit_type">2</field>
+		<field name="epobject_id_l" xsi:nil="true" />
+		<field name="epobject_id_h" xsi:nil="true" />
+		<field name="glossary_id">1</field>
+		<field name="time_start" xsi:nil="true" />
+		<field name="time_end" xsi:nil="true" />
+		<field name="title">Constituency</field>
+		<field name="body">In a general election, each &lt;b&gt;Constituency&lt;/b&gt; chooses an MP to represent them. MPs have a responsibility to represnt the views of the &lt;b&gt;Constituency&lt;/b&gt; in the House of Commons. There are 659 &lt;b&gt;Constituencies&lt;/b&gt;, and thus 659 MPs.
+A citizen of a &lt;b&gt;Constituency&lt;/b&gt; is known as a Constitu&lt;i&gt;ent&lt;/i&gt;</field>
+		<field name="submitted" xsi:nil="true" />
+		<field name="editor_id">2</field>
+		<field name="approved">1</field>
+		<field name="decided" xsi:nil="true" />
+		<field name="reason" xsi:nil="true" />
+	</row>
+  </table_data>
+	<table_data name="glossary">
+	<row>
+		<field name="glossary_id">1</field>
+		<field name="title">Constituency</field>
+		<field name="body">In a general election, each &lt;b&gt;Constituency&lt;/b&gt; chooses an MP to represent them. MPs have a responsibility to represnt the views of the &lt;b&gt;Constituency&lt;/b&gt; in the House of Commons. There are 659 &lt;b&gt;Constituencies&lt;/b&gt;, and thus 659 MPs.
+A citizen of a &lt;b&gt;Constituency&lt;/b&gt; is known as a Constitu&lt;i&gt;ent&lt;/i&gt;</field>
+		<field name="wikipedia" xsi:nil="true" />
+		<field name="created" xsi:nil="true" />
+		<field name="last_modified" xsi:nil="true" />
+		<field name="type">2</field>
+		<field name="visible">1</field>
+	</row>
+  </table_data>
+	<table_data name="users">
+	<row>
+		<field name="user_id">1</field>
+		<field name="firstname">User</field>
+		<field name="lastname">Test</field>
+		<field name="email"></field>
+		<field name="password"></field>
+		<field name="lastvisit">0000-00-00 00:00:00</field>
+		<field name="registrationtime">0000-00-00 00:00:00</field>
+		<field name="registrationip" xsi:nil="true" />
+		<field name="status">User</field>
+		<field name="emailpublic">0</field>
+		<field name="optin">0</field>
+		<field name="deleted">0</field>
+		<field name="postcode"></field>
+		<field name="registrationtoken"></field>
+		<field name="confirmed">1</field>
+		<field name="url"></field>
+		<field name="api_key" xsi:nil="true" />
+	</row>
+	<row>
+		<field name="user_id">2</field>
+		<field name="firstname">Moderator</field>
+		<field name="lastname">Test</field>
+		<field name="email"></field>
+		<field name="password"></field>
+		<field name="lastvisit">0000-00-00 00:00:00</field>
+		<field name="registrationtime">0000-00-00 00:00:00</field>
+		<field name="registrationip" xsi:nil="true" />
+		<field name="status">Moderator</field>
+		<field name="emailpublic">0</field>
+		<field name="optin">0</field>
+		<field name="deleted">0</field>
+		<field name="postcode"></field>
+		<field name="registrationtoken"></field>
+		<field name="confirmed">1</field>
+		<field name="url"></field>
+		<field name="api_key" xsi:nil="true" />
 	</row>
 	</table_data>
 </database>

--- a/www/includes/easyparliament/searchengine.php
+++ b/www/includes/easyparliament/searchengine.php
@@ -532,7 +532,7 @@ class SEARCHENGINE {
 
         foreach ($this->phrases as $phrase) {
             $phrasematch = join($phrase, '[^'.$this->wordchars.']+');
-            array_push($findwords, "/\b($phrasematch)\b/i");
+            array_push($findwords, "/\b($phrasematch)\b(?!(?>[^<>]*>))/i");
             $replacewords[] = "<span class=\"hi\">\\1</span>";
         }
 


### PR DESCRIPTION
Because of the way the search engine highlighting works it will add
highlighting to text that is inside tags, e.g. in the title tag of a
glossary link. The glossary highlighting doesn't do this so swap the
order we do these in.

Fixes #912