### PR TITLE
only set banner_text page variable if banner content

### DIFF
--- a/tests/PageTest.php
+++ b/tests/PageTest.php
@@ -72,8 +72,8 @@ class PageTest extends FetchPageTestCase
     public function testBanner() {
         $banner = new MySociety\TheyWorkForYou\Model\Banner;
 
-        $banner->set_text('');
         $page = $this->fetch_page( array( 'url' => '/' ) );
+        $this->assertNotContains('<div class="banner">', $page);
         $this->assertNotContains('This is a banner', $page);
 
         $banner->set_text('This is a banner');
@@ -82,6 +82,7 @@ class PageTest extends FetchPageTestCase
 
         $banner->set_text('');
         $page = $this->fetch_page( array( 'url' => '/' ) );
+        $this->assertNotContains('<div class="banner">', $page);
         $this->assertNotContains('This is a banner', $page);
     }
 

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -194,7 +194,7 @@
         </div>
     </header>
 
-    <?php if ( isset($banner_text) ) { ?>
+    <?php if ( $banner_text ) { ?>
     <div class="banner">
         <div class="full-page__row">
             <div class="banner__content">


### PR DESCRIPTION
Previously if the banner_text page variable was set to anything, even an
empty string, then the banner would be displayed with no content. This
makes sure that we only set the banner_text variable if there is some
banner content.

Fixes #915