### PR TITLE
Only display MP policy position if voted in strong division

### DIFF
--- a/classes/Member.php
+++ b/classes/Member.php
@@ -383,7 +383,7 @@ class Member extends \MEMBER {
         }
 
         foreach ( $positions->positionsById as $policy_id => $details ) {
-            if ( $details['score'] != -1 && isset($party_positions[$policy_id])) {
+            if ( $details['has_strong'] && $details['score'] != -1 && isset($party_positions[$policy_id])) {
                 $mp_score = $details['score'];
                 $party_score = $party_positions[$policy_id]['score'];
 

--- a/classes/PolicyPositions.php
+++ b/classes/PolicyPositions.php
@@ -106,17 +106,28 @@ class PolicyPositions {
 
                 $dream_info = $this->displayDreamComparison($policy[0], $policy[1]);
 
+                // don't return votes where they haven't voted on a strong division
+                // if we're limiting the number of votes
+                if ( $limit && !empty($dream_info) && !$dream_info['has_strong'] ) {
+                    continue;
+                }
+
+
                 // Make sure the dream actually exists
                 if (!empty($dream_info)) {
                     $this->positions[] = array(
                         'policy_id' => $policy[0],
+                        'policy' => $policy[1],
                         'desc' => $dream_info['full_sentence'],
+                        'has_strong' => $dream_info['has_strong'],
                         'position' => $dream_info['position']
                     );
                     $this->positionsById[$policy[0]] = array(
                         'policy_id' => $policy[0],
+                        'policy' => $policy[1],
                         'desc' => $dream_info['full_sentence'],
                         'position' => $dream_info['position'],
+                        'has_strong' => $dream_info['has_strong'],
                         'score' => $dream_info['score'],
                     );
                     $i++;
@@ -168,8 +179,12 @@ class PolicyPositions {
                     $dmpscore = 1.0 - $dmpscore;
                 $consistency = score_to_strongly($dmpscore);
             }
+            $has_strong = 0;
+            if (isset($extra_info["public_whip_dreammp${dreamid}_has_strong_vote"]) && $extra_info["public_whip_dreammp${dreamid}_has_strong_vote"] == 1) {
+                $has_strong = 1;
+            }
             $full_sentence = $consistency . ' ' . $policy_description;
-            $out = array( 'full_sentence' => $full_sentence, 'score' => $dmpscore, 'position' => $consistency );
+            $out = array( 'full_sentence' => $full_sentence, 'score' => $dmpscore, 'position' => $consistency, 'has_strong' => $has_strong );
         }
 
         return $out;

--- a/tests/DivisionsTest.php
+++ b/tests/DivisionsTest.php
@@ -100,4 +100,9 @@ class DivisionsTest extends FetchPageTestCase
         $page = $this->fetch_division_page();
         $this->assertContains('including 5 less important votes', $page);
     }
+
+    public function testNotEnoughInfoStatement() {
+        return $this->fetch_page( array( 'pagetype' => 'divisions', 'pid' => 2, 'policy' => 810, 'url' => '/mp/2/test_current-mp/test_westminster_constituency/divisions' ) );
+        $this->assertContains('we don&rsquo;t have enough information to calculate Test Current-MP&rsquo;s position', $page);
+    }
 }

--- a/tests/_fixtures/divisions.xml
+++ b/tests/_fixtures/divisions.xml
@@ -181,6 +181,26 @@
 			<field name="data_key">public_whip_dreammp363_both_voted</field>
 			<field name="data_value">1</field>
 		</row>
+		<row>
+			<field name="member_id">1</field>
+			<field name="data_key">public_whip_dreammp363_has_strong_vote</field>
+			<field name="data_value">1</field>
+		</row>
+		<row>
+			<field name="member_id">1</field>
+			<field name="data_key">public_whip_dreammp810_distance</field>
+			<field name="data_value">0.87</field>
+		</row>
+		<row>
+			<field name="member_id">1</field>
+			<field name="data_key">public_whip_dreammp810_both_voted</field>
+			<field name="data_value">1</field>
+		</row>
+		<row>
+			<field name="member_id">1</field>
+			<field name="data_key">public_whip_dreammp810_has_strong_vote</field>
+			<field name="data_value">0</field>
+		</row>
 	</table_data>
 	<table_data name="mentions">
 	</table_data>

--- a/tests/_fixtures/party.xml
+++ b/tests/_fixtures/party.xml
@@ -186,1497 +186,6 @@
 			<field name="data_key">test_member_key</field>
 			<field name="data_value">Test Member Value</field>
 		</row>
-		<row>
-			<field name="member_id">1</field>
-			<field name="data_key">public_whip_dreammp363_distance</field>
-			<field name="data_value">0.27</field>
-		</row>
-		<row>
-			<field name="member_id">1</field>
-			<field name="data_key">public_whip_dreammp363_both_voted</field>
-			<field name="data_value">1</field>
-		</row>
-
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1049_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1049_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1065_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1065_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1050_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1050_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6702_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6702_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1120_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1120_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6710_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6710_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1105_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1105_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6707_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6707_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6721_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6721_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6705_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6705_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6672_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6672_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6711_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6711_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6681_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6681_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6703_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6703_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1027_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1027_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1053_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1053_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6688_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6688_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6691_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6691_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1109_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1109_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6670_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6670_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6677_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6677_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1132_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1132_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp837_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp837_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6671_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6671_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6699_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6699_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6718_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6718_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6706_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6706_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6673_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6673_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1136_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1136_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6715_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6715_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1030_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1030_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1074_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1074_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1079_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1079_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1084_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1084_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6695_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6695_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6719_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6719_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6716_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6716_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp984_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp984_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6698_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6698_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6697_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6697_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1110_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1110_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1113_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1113_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp811_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp811_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6696_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6696_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1124_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1124_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6684_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6684_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6686_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6686_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6678_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6678_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6720_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6720_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1052_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1052_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6676_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6676_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6709_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6709_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6667_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6667_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6682_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6682_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6680_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6680_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp363_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp363_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp826_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp826_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6690_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6690_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6692_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6692_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1071_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1071_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6674_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6674_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1051_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1051_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6687_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6687_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6679_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6679_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6708_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6708_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp996_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp996_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6685_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6685_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6694_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6694_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1087_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp1087_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp975_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp975_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp810_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp810_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6683_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6683_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6693_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6693_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6704_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">2</field>
-            <field name="data_key">public_whip_dreammp6704_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1049_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1049_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1065_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1065_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1050_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1050_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6702_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6702_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1120_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1120_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6710_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6710_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1105_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1105_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6707_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6707_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6721_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6721_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6705_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6705_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6672_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6672_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6711_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6711_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6681_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6681_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6703_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6703_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1027_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1027_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1053_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1053_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6688_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6688_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6691_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6691_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1109_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1109_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6670_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6670_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6677_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6677_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1132_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1132_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp837_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp837_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6671_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6671_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6699_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6699_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6718_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6718_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6706_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6706_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6673_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6673_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1136_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1136_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6715_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6715_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1030_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1030_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1074_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1074_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1079_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1079_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1084_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1084_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6695_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6695_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6719_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6719_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6716_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6716_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp984_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp984_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6698_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6698_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6697_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6697_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1110_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1110_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1113_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1113_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp811_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp811_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6696_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6696_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1124_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1124_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6684_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6684_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6686_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6686_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6678_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6678_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6720_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6720_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1052_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1052_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6676_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6676_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6709_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6709_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6667_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6667_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6682_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6682_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6680_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6680_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp363_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp363_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp826_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp826_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6690_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6690_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6692_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6692_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1071_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1071_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6674_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6674_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1051_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1051_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6687_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6687_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6679_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6679_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6708_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6708_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp996_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp996_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6685_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6685_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6694_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6694_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1087_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp1087_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp975_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp975_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp810_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp810_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6683_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6683_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6693_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6693_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6704_distance</field>
-            <field name="data_value">0.97</field>
-        </row>
-        <row>
-            <field name="member_id">5</field>
-            <field name="data_key">public_whip_dreammp6704_both_voted</field>
-            <field name="data_value">1</field>
-        </row>
 	</table_data>
 	<table_data name="mentions">
 	</table_data>
@@ -1690,6 +199,2242 @@
 			<field name="data_key">test_person_key</field>
 			<field name="data_value">Test Person Value</field>
 		</row>
+		<row>
+			<field name="person_id">2</field>
+			<field name="data_key">public_whip_dreammp363_distance</field>
+			<field name="data_value">0.27</field>
+		</row>
+		<row>
+			<field name="person_id">2</field>
+			<field name="data_key">public_whip_dreammp363_both_voted</field>
+			<field name="data_value">1</field>
+		</row>
+		<row>
+			<field name="person_id">2</field>
+			<field name="data_key">public_whip_dreammp363_has_strong_vote</field>
+			<field name="data_value">1</field>
+		</row>
+
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1049_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1049_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1065_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1065_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1050_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1050_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6702_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6702_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1120_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1120_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6710_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6710_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1105_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1105_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6707_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6707_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6721_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6721_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6705_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6705_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6672_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6672_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6711_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6711_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6681_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6681_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6703_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6703_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1027_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1027_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1053_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1053_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6688_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6688_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6691_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6691_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1109_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1109_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6670_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6670_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6677_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6677_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1132_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1132_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp837_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp837_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6671_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6671_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6699_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6699_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6718_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6718_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6706_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6706_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6673_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6673_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1136_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1136_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6715_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6715_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1030_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1030_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1074_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1074_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1079_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1079_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1084_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1084_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6695_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6695_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6719_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6719_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6716_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6716_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp984_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp984_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6698_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6698_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6697_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6697_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1110_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1110_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1113_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1113_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp811_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp811_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6696_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6696_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1124_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1124_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6684_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6684_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6686_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6686_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6678_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6678_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6720_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6720_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1052_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1052_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6676_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6676_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6709_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6709_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6667_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6667_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6682_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6682_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6680_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6680_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp363_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp363_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp826_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp826_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6690_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6690_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6692_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6692_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1071_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1071_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6674_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6674_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1051_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1051_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6687_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6687_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6679_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6679_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6708_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6708_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp996_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp996_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6685_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6685_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6694_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6694_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1087_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1087_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp975_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp975_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp810_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp810_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6683_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6683_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6693_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6693_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6704_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6704_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1049_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1049_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1065_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1065_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1050_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1050_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6702_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6702_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1120_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1120_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6710_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6710_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1105_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1105_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6707_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6707_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6721_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6721_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6705_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6705_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6672_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6672_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6711_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6711_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6681_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6681_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6703_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6703_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1027_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1027_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1053_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1053_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6688_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6688_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6691_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6691_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1109_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1109_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6670_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6670_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6677_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6677_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1132_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1132_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp837_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp837_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6671_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6671_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6699_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6699_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6718_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6718_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6706_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6706_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6673_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6673_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1136_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1136_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6715_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6715_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1030_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1030_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1074_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1074_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1079_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1079_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1084_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1084_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6695_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6695_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6719_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6719_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6716_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6716_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp984_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp984_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6698_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6698_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6697_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6697_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1110_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1110_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1113_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1113_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp811_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp811_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6696_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6696_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1124_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1124_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6684_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6684_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6686_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6686_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6678_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6678_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6720_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6720_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1052_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1052_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6676_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6676_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6709_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6709_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6667_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6667_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6682_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6682_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6680_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6680_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp363_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp363_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp826_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp826_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6690_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6690_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6692_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6692_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1071_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1071_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6674_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6674_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1051_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1051_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6687_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6687_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6679_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6679_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6708_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6708_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp996_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp996_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6685_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6685_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6694_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6694_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1087_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1087_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp975_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp975_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp810_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp810_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6683_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6683_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6693_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6693_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6704_distance</field>
+            <field name="data_value">0.97</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6704_both_voted</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1049_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1065_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1050_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6702_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1120_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6710_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1105_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6707_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6721_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6705_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6672_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6711_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6681_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6703_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1027_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1053_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6688_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6691_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1109_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6670_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6677_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1132_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp837_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6671_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6699_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6718_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6706_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6673_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1136_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6715_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1030_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1074_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1079_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1084_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6695_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6719_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6716_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp984_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6698_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6697_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1110_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1113_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp811_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6696_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1124_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6684_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6686_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6678_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6720_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1052_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6676_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6709_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6667_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6682_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6680_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp363_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp826_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6690_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6692_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1071_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6674_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1051_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6687_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6679_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6708_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp996_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6685_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6694_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp1087_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp975_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp810_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6683_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6693_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">3</field>
+            <field name="data_key">public_whip_dreammp6704_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1049_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1065_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1050_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6702_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1120_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6710_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1105_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6707_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6721_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6705_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6672_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6711_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6681_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6703_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1027_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1053_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6688_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6691_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1109_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6670_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6677_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1132_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp837_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6671_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6699_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6718_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6706_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6673_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1136_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6715_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1030_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1074_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1079_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1084_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6695_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6719_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6716_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp984_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6698_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6697_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1110_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1113_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp811_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6696_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1124_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6684_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6686_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6678_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6720_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1052_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6676_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6709_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6667_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6682_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6680_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp363_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp826_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6690_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6692_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1071_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6674_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1051_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6687_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6679_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6708_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp996_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6685_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6694_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp1087_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp975_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp810_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6683_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6693_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
+        <row>
+            <field name="person_id">6</field>
+            <field name="data_key">public_whip_dreammp6704_has_strong_vote</field>
+            <field name="data_value">1</field>
+        </row>
 	</table_data>
 	<table_data name="policies">
       <row>

--- a/www/includes/easyparliament/templates/html/mp/divisions.php
+++ b/www/includes/easyparliament/templates/html/mp/divisions.php
@@ -60,30 +60,33 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
                             <?php if ( isset($policy['position']) ) { ?>
                                 <div class="panel">
-                                    <h3 class="policy-vote-overall-stance">
-                                        <?= $full_name . ' ' . $policy['position']['desc'] ?>
-                                    </h3>
+                                    <?php if ( $policy['position']['has_strong'] ) { ?>
+                                        <h3 class="policy-vote-overall-stance">
+                                            <?= $full_name . ' ' . $policy['position']['desc'] ?>
+                                        </h3>
 
-                                    <?php $pw_url = 'http://www.publicwhip.org.uk/mp.php?mpid=' . $member_id . '&amp;dmp=' . $policy['policy_id']; ?>
-                                    <p>
-                                        TheyWorkForYou has automatically calculated this MP&rsquo;s stance based on all
-                                        of their votes on the topic. <a href="<?= $pw_url ?>">You can browse the source
-                                        data on PublicWhip.org.uk</a>.
-                                    </p>
+                                        <?php $pw_url = 'http://www.publicwhip.org.uk/mp.php?mpid=' . $member_id . '&amp;dmp=' . $policy['policy_id']; ?>
+                                        <p>
+                                            TheyWorkForYou has automatically calculated this MP&rsquo;s stance based on all
+                                            of their votes on the topic. <a href="<?= $pw_url ?>">You can browse the source
+                                            data on PublicWhip.org.uk</a>.
+                                        </p>
 
-                                    <?php if ( DEVSITE ) { ?>
-                                    <p class="policy-vote-agree-disagree">
-                                        <button class="button">I agree with this MP</button>
-                                        <button class="button button--negative">I disagree with this MP</button>
-                                    </p>
+                                        <h3 class="policy-votes-list-header"><span id="policy-votes-type">All</span> votes about <?= $policy['desc'] ?>:</h3>
+                                    <?php } else { ?>
+                                        <h3 class="policy-vote-overall-stance">
+                                            We don&rsquo;t have enough information to calculate <?= $full_name ?>&rsquo;s position on this issue
+                                        </h3>
+
+                                        <p>
+                                        However, <?= $full_name ?> has taken part in the following votes on the topic:
+                                        </p>
                                     <?php } ?>
-
-                                    <h3 class="policy-votes-list-header"><span id="policy-votes-type">All</span> votes about <?= $policy['desc'] ?>:</h3>
 
                                     <ul class="vote-descriptions policy-votes">
                                     <?php
                                         $show_all = FALSE;
-                                        if ( $policy['weak_count'] == count($policy['divisions']) ) {
+                                        if ( $policy['weak_count'] == 0 || $policy['weak_count'] == count($policy['divisions']) ) {
                                             $show_all = TRUE;
                                         }
                                     ?>

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -57,7 +57,11 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                             <ul class="vote-descriptions">
                               <?php foreach ($segment['votes']->positions as $key_vote): ?>
                                 <li>
+                                    <?php if ( $key_vote['has_strong'] || $key_vote['position'] == 'has never voted on' ) { ?>
                                     <?= ucfirst($key_vote['desc']) ?>
+                                    <?php } else {  ?>
+                                    We don&rsquo;t have enough information to calculate <?= $full_name ?>&rsquo;s position on <?= $key_vote['policy'] ?>.
+                                    <?php } ?>
                                     <?php if ( $key_vote['position'] != 'has never voted on' ) { ?>
                                     <a class="vote-description__source" href="<?= $member_url?>/divisions?policy=<?= $key_vote['policy_id'] ?>">Show votes</a>
                                     <?php } ?>


### PR DESCRIPTION
When we import the division votes we look at MPs who've voted in strong
divisions and if so set a flag for the current policy accordingly. We
then use this flag to decide if we should say what an MP's position on
an issue is. If they've not voted in a strong division we fall back to
saying we don't have enough information to decide, but still allow users
to see the votes for that policy.

Also, don't include policies without strong votes on the front page or
the differs from party stats.

Fixes #947