### PR TITLE
Replace legacy className() constructors with future-proof __construct()

### DIFF
--- a/www/includes/data.php
+++ b/www/includes/data.php
@@ -73,7 +73,7 @@ class DATA {
 
 
 
-    public function Data() {
+    public function __construct() {
 
         include_once METADATAPATH;	// defined in config.php
 

--- a/www/includes/easyparliament/comment.php
+++ b/www/includes/easyparliament/comment.php
@@ -41,7 +41,7 @@ class COMMENT {
     public $exists = false;
 
 
-    public function COMMENT($comment_id='') {
+    public function __construct($comment_id='') {
 
         $this->db = new ParlDB;
 

--- a/www/includes/easyparliament/commentlist.php
+++ b/www/includes/easyparliament/commentlist.php
@@ -31,7 +31,7 @@ include_once INCLUDESPATH . 'dbtypes.php';
 
 class COMMENTLIST {
 
-    public function COMMENTLIST() {
+    public function __construct() {
         global $this_page;
 
         $this->db = new ParlDB;

--- a/www/includes/easyparliament/commentreport.php
+++ b/www/includes/easyparliament/commentreport.php
@@ -40,7 +40,7 @@ class COMMENTREPORT {
     public $email = '';
 
 
-    public function COMMENTREPORT($report_id='') {
+    public function __construct($report_id='') {
         // Pass it a report id and it gets and sets this report's data.
 
         $this->db = new ParlDB;

--- a/www/includes/easyparliament/commentreportlist.php
+++ b/www/includes/easyparliament/commentreportlist.php
@@ -12,7 +12,7 @@
 
 class COMMENTREPORTLIST {
 
-    public function COMMENTREPORTLIST() {
+    public function __construct() {
         $this->db = new ParlDB;
     }
 

--- a/www/includes/easyparliament/editqueue.php
+++ b/www/includes/easyparliament/editqueue.php
@@ -46,7 +46,7 @@ class EDITQUEUE {
 
     public $pending_count = '';
 
-    public function EDITQUEUE() {
+    public function __construct() {
         $this->db = new ParlDB;
     }
 

--- a/www/includes/easyparliament/glossary.php
+++ b/www/includes/easyparliament/glossary.php
@@ -37,7 +37,7 @@ class GLOSSARY {
     public $current_letter;
 
     // constructor...
-    public function GLOSSARY($args=array()) {
+    public function __construct($args=array()) {
     // We can optionally start the glossary with one of several arguments
     //		1. glossary_id - treat the glossary as a single term
     //		2. glossary_term - search within glossary for a term

--- a/www/includes/easyparliament/init.php
+++ b/www/includes/easyparliament/init.php
@@ -80,7 +80,7 @@ include_once (INCLUDESPATH."data.php");
 include_once (INCLUDESPATH."mysql.php");
 
 Class ParlDB extends MySQL {
-    public function ParlDB() {
+    public function __construct() {
         $this->init (OPTION_TWFY_DB_HOST, OPTION_TWFY_DB_USER, OPTION_TWFY_DB_PASS, OPTION_TWFY_DB_NAME);
     }
 }

--- a/www/includes/easyparliament/people.php
+++ b/www/includes/easyparliament/people.php
@@ -10,7 +10,7 @@ $PEOPLE->display('mps');
 
 class PEOPLE {
 
-    public function PEOPLE() {
+    public function __construct() {
         $this->db = new ParlDB;
     }
 

--- a/www/includes/easyparliament/searchengine.php
+++ b/www/includes/easyparliament/searchengine.php
@@ -39,7 +39,7 @@ class SEARCHENGINE {
     public $valid = false;
     public $error;
 
-    public function SEARCHENGINE($query) {
+    public function __construct($query) {
         if (!defined('XAPIANDB') || !XAPIANDB)
             return null;
 

--- a/www/includes/easyparliament/searchlog.php
+++ b/www/includes/easyparliament/searchlog.php
@@ -27,7 +27,7 @@ into being more popular.
 class SEARCHLOG {
 
 
-    public function SEARCHLOG() {
+    public function __construct() {
         $this->SEARCHURL = new URL('search');
 
         $this->db = new ParlDB;

--- a/www/includes/easyparliament/trackback.php
+++ b/www/includes/easyparliament/trackback.php
@@ -35,7 +35,7 @@ class TRACKBACK {
     // But switching this to true will mark all incoming trackbacks as invisible.
 
 
-    public function TRACKBACK() {
+    public function __construct() {
 
         $this->db = new ParlDB;
 

--- a/www/includes/easyparliament/user.php
+++ b/www/includes/easyparliament/user.php
@@ -80,7 +80,7 @@ class USER {
     //      Alter THEUSER->update_self() to update with the new vars, if appropriate.
     //      Change things in the add/edit/view user page.
 
-    public function USER() {
+    public function __construct() {
         $this->db = new ParlDB;
     }
 
@@ -818,7 +818,7 @@ class THEUSER extends USER {
     public $loggedin = false;
 
 
-    public function THEUSER() {
+    public function __construct() {
         // This function is run automatically when a THEUSER
         // object is instantiated.
 

--- a/www/includes/url.php
+++ b/www/includes/url.php
@@ -55,7 +55,7 @@ v1.3	2003-11-25
 
 class URL {
 
-    public function URL($pagename) {
+    public function __construct($pagename) {
         // Initialise.
         global $DATA;
 


### PR DESCRIPTION
Old-style constructors will throw warnings in PHP 7, and will not be supported in PHP 8. This is mostly to keep the build logs free of warnings so we can see what is actually broken.

[Before](https://travis-ci.org/mysociety/theyworkforyou/jobs/76981612) vs [after](https://travis-ci.org/mysociety/theyworkforyou/jobs/76988009).

**NB:** You probably also want to merge the changes in commonlib, since nothing should be running on PHP 4.