### PR TITLE
Advanced search terms lost on pagination links

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -5,7 +5,7 @@ namespace MySociety\TheyWorkForYou;
 
 class Search {
 
-    private $searchstring;
+    protected $searchstring;
     private $searchkeyword;
 
     public function __construct() {
@@ -41,7 +41,7 @@ class Search {
                 $data['template'] = 'search/by-person';
             } else {
                 $search = new Search\Normal();
-                $data = $search->search($this->searchstring);
+                $data = $search->search();
                 $data['template'] = 'search/results';
             }
         }

--- a/classes/Search/Normal.php
+++ b/classes/Search/Normal.php
@@ -5,8 +5,6 @@ namespace MySociety\TheyWorkForYou\Search;
 
 class Normal extends \MySociety\TheyWorkForYou\Search {
 
-    private $searchstring;
-
     private function get_sort_args() {
         $pagenum = get_http_var('p');
         if (!is_numeric($pagenum)) {
@@ -40,10 +38,8 @@ class Normal extends \MySociety\TheyWorkForYou\Search {
         return array($members, $cons, $mp_types, $glossary);
     }
 
-    public function search($searchstring) {
+    public function search() {
         global $DATA, $this_page, $SEARCHENGINE;
-
-        $this->searchstring = $searchstring;
 
         $SEARCHENGINE = new \SEARCHENGINE($this->searchstring);
 


### PR DESCRIPTION
The advanced search terms weren't registered as session vars for the search page so the URL constructor was throwing them away.

Fixes #956 