### PR TITLE
add content disposition to set filename for person CSV

### DIFF
--- a/classes/People.php
+++ b/classes/People.php
@@ -113,6 +113,7 @@ class People extends \PEOPLE {
     }
 
     public function sendAsCSV($data) {
+        header('Content-Disposition: attachment; filename=' . $this->type . '.csv');
         header('Content-Type: text/csv');
         $out = fopen('php://output', 'w');
 


### PR DESCRIPTION
Means that when you click on the Download list as CSV link on the people
pages then it downloads a file rather than just spewing out the CSV into
the browser.

Fixes #654