### PR TITLE
Automatically generate code documentation via Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .bundle
 vendor
 www/docs/docs
+www/docs/docs-cache
 www/docs/style/*.css
 www/docs/style/stylesheets
 .vagrant

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: php
 
-sudo: required
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - graphviz
 
 php:
   - "5.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,4 @@ script:
 after_script:
  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi;'
  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi;'
- - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.4" ] && [ "$TRAVIS_BRANCH" == "travis-auto-docs" ]; then bash build-docs.sh; fi;'
+ - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.4" ] && [ "$TRAVIS_BRANCH" == "master" ]; then bash build-docs.sh; fi;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ notifications:
 env:
   global:
     - TWFY_TEST_DB_HOST="127.0.0.1" TWFY_TEST_DB_USER="root" TWFY_TEST_DB_PASS="" TWFY_TEST_DB_NAME="twfy_test"
-    - secure: ch+B3ulBovVGeKCdCX7rxQmmnS9jPf6V5wQlbv/wLahbttD9zucgEfeUOFcrSwqovAoi9S57dwwFpC99FJtgTPWwkERCZ94Y68RbwZ04ocFjLL/slln+O41cEpXmElA5Cz2qo0Phi2tfAR3Tj6LLN+5CvSo9HHf9p8zB3G8rcuA=
+    - secure: MhpIz8iPjYyVYzAZKzXVD1gJ44XwkM5q/ysr92e827c2VoDmDeZy4TgKA7HuKsw02ou4AwsR4mQFWhKxd21SruhAZhOQBMCqP3+5UwnXISf8vqowfFH9Ml9iLzeWI2Sdz8c0nEO4rs9ObMZa2VWzrJyd49ZPt7zex1x1JYJ8OeM=
 
 before_script:
  - mysql -e "create database IF NOT EXISTS twfy_test;" -uroot

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-sudo: false
+sudo: required
 
 php:
   - "5.4"
@@ -23,7 +23,10 @@ notifications:
     use_notice: true
     skip_join: true
 
-env: TWFY_TEST_DB_HOST="127.0.0.1" TWFY_TEST_DB_USER="root" TWFY_TEST_DB_PASS="" TWFY_TEST_DB_NAME="twfy_test"
+env:
+  global:
+    - TWFY_TEST_DB_HOST="127.0.0.1" TWFY_TEST_DB_USER="root" TWFY_TEST_DB_PASS="" TWFY_TEST_DB_NAME="twfy_test"
+    - secure: ch+B3ulBovVGeKCdCX7rxQmmnS9jPf6V5wQlbv/wLahbttD9zucgEfeUOFcrSwqovAoi9S57dwwFpC99FJtgTPWwkERCZ94Y68RbwZ04ocFjLL/slln+O41cEpXmElA5Cz2qo0Phi2tfAR3Tj6LLN+5CvSo9HHf9p8zB3G8rcuA=
 
 before_script:
  - mysql -e "create database IF NOT EXISTS twfy_test;" -uroot
@@ -38,3 +41,4 @@ script:
 after_script:
  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi;'
  - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.4" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi;'
+ - bash -c 'if [ "$TRAVIS_PHP_VERSION" == "5.4" ] && [ "$TRAVIS_BRANCH" == "travis-auto-docs" ]; then bash build-docs.sh; fi;'

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 set -e # exit with nonzero exit code if anything fails
 
-# install graphviz to generate diagrams
-sudo apt-get update -qq
-sudo apt-get install -qq graphviz
-
 # clear and re-create the out directory
 rm -rf www/docs/docs || exit 0;
 mkdir www/docs/docs;

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e # exit with nonzero exit code if anything fails
+
+# install graphviz to generate diagrams
+sudo apt-get update -qq
+sudo apt-get install -qq graphviz
+
+# clear and re-create the out directory
+rm -rf www/docs/docs || exit 0;
+mkdir www/docs/docs;
+
+# run our compile script, discussed above
+./vendor/bin/phpdoc
+
+# go to the out directory and create a *new* Git repo
+cd www/docs/docs
+git init
+
+# inside this git repo we'll pretend to be a new user
+git config user.name "Travis CI"
+git config user.email "travis@mysociety.org"
+
+# The first and only commit to this new Git repo contains all the
+# files present with the commit message "Deploy documentation to GitHub Pages".
+git add .
+git commit -m "Deploy documentation to GitHub Pages"
+
+# Force push from the current repo's master branch to the remote
+# repo's gh-pages branch. (All previous history on the gh-pages branch
+# will be lost, since we are overwriting it.) We redirect any output to
+# /dev/null to hide any sensitive credential data that might otherwise be exposed.
+git push --force --quiet "https://${GH_TOKEN}@github.com/mysociety/theyworkforyou.git" master:gh-pages > /dev/null 2>&1

--- a/phpdoc.dist.xml
+++ b/phpdoc.dist.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <phpdoc>
+  <title>TheyWorkForYou</title>
   <parser>
-    <target>www/docs/docs</target>
+    <target>www/docs/docs-cache</target>
   </parser>
   <transformer>
     <target>www/docs/docs</target>
   </transformer>
+  <transformations>
+    <template name="clean" />
+  </transformations>
   <files>
     <directory>.</directory>
     <ignore>vendor/</ignore>
     <ignore>commonlib/</ignore>
+    <ignore>tests/</ignore>
   </files>
 </phpdoc>


### PR DESCRIPTION
Make Travis also generate code documentation and push it to [GitHub Pages](http://mysociety.github.io/theyworkforyou/) whenever `master` is updated.

**Heads up!** Before this gets merged:

* [x] Make sure the branch is actually set to `master`, rather than `travis-auto-docs`, or we'll never generate any useful documentation and things will be sad.
* [x] Swap out the access token, so it won't all break in future when my account no longer has push permissions to this repo.