### PR TITLE
amends h1 line-height

### DIFF
--- a/www/docs/style/sass/app.scss
+++ b/www/docs/style/sass/app.scss
@@ -77,6 +77,7 @@ strong, b {
 
 h1 {
     letter-spacing: 0.02em;
+    line-height: 1.15em;
 }
 
 h1,


### PR DESCRIPTION
The line-height for H1's feel a bit too loose when wrapped.
This sets a 1.15em rule in app.scss

![twfy-h1-leading](https://cloud.githubusercontent.com/assets/1971632/10241056/4bfab7a0-6916-11e5-9aa3-e098df260978.png)
