### PR TITLE
Homepage spacing tweaks

### DIFF
--- a/www/docs/style/sass/pages/_home.scss
+++ b/www/docs/style/sass/pages/_home.scss
@@ -410,23 +410,6 @@ input.homepage-search__button {
     }
 }
 
-.button--show-all {
-    background-color: $colour_off_white;
-    color: $colour_dark_grey;
-    font-weight: normal;
-    &:hover,
-    &:active,
-    &:focus {
-        background-color: $colour_light_grey;
-        color: $colour_dark_grey;
-    }
-}
-
-.button--full-width {
-    width: 100%;
-    text-align: center;
-}
-
 .homepage-upcoming {
     border-top: 1px solid $colour_off_white;
 

--- a/www/docs/style/sass/pages/_home.scss
+++ b/www/docs/style/sass/pages/_home.scss
@@ -429,12 +429,15 @@ input.homepage-search__button {
 
 .homepage-upcoming {
     border-top: 1px solid $colour_off_white;
+
     @media (min-width: $medium-screen) {
         border-top: 0;
     }
+
     h3 {
         font-size: 1em;
         color: $colour_dark_grey;
+        margin-top: 1.5em;
     }
 
     .hidden {
@@ -445,7 +448,6 @@ input.homepage-search__button {
 .upcoming__controls {
     text-align: center;
     background-color: $colour_off_white;
-    margin-bottom: 2em;
     border-radius: $global-radius;
 }
 
@@ -471,7 +473,7 @@ input.homepage-search__button {
 .controls__prev {
     border-radius: $global-radius 0 0 $global-radius;
     border-right: 1px solid $colour_light_grey;
-      padding: 0.75em 1em 0.75em 0.75em;
+    padding: 0.75em 1em 0.75em 0.75em;
 }
 
 .controls__current {
@@ -481,22 +483,24 @@ input.homepage-search__button {
 
 .upcoming__list {
     @extend .unstyled-list;
+    margin-bottom: 0;
+
     li {
-        margin-bottom: 1.5em;
+        margin-bottom: 0.75em;
     }
 }
 
 .upcoming__title {
     font-size: 1em;
     font-weight: normal;
-    line-height: 1.5em;
     margin-bottom: 0.1em;
     font-size: emCalc(16);
 }
 
 .upcoming__more {
     color: $brand;
-    font-size: emCalc(16);
+    font-size: emCalc(14);
+
     &:after {
         content: " →";
         color: $colour_mid_grey;

--- a/www/includes/easyparliament/templates/html/index.php
+++ b/www/includes/easyparliament/templates/html/index.php
@@ -139,9 +139,20 @@
                                             if ( isset( $events[$i] ) ) { ?>
                                         <li>
                                             <h4 class="upcoming__title"><a href="<?= $events[$i]['link_external'] ?>"><?= $events[$i]['title'] ?></a></h4>
-                                            <p class="meta"><?= $events[$i]['debate_type'] ?>
-                                            <?= isset($events[$i]['time_start']) && $events[$i]['time_start'] != '00:00:00' ? '; ' . format_time($events[$i]['time_start'], 'g:i a') : '' ?>
-                                            <?= isset($events[$i]['time_end']) && $events[$i]['time_end'] != '00:00:00' ? ' - ' . format_time($events[$i]['time_end'], 'g:i a') : '' ?></p>
+                                            <p class="meta"><?php
+                                                $meta_items = array();
+                                                $meta_items[] = $events[$i]['debate_type'];
+                                                if( isset($events[$i]['time_start']) && $events[$i]['time_start'] != '00:00:00' ){
+                                                    $times = format_time($events[$i]['time_start'], 'g:i a');
+
+                                                    if( isset($events[$i]['time_end']) && $events[$i]['time_end'] != '00:00:00' ){
+                                                        $times = $times . ' - ' . format_time($events[$i]['time_end'], 'g:i a');
+                                                    }
+                                                    $meta_items[] = $times;
+                                                }
+                                                // Removes "empty" items, and joins them with a semicolon
+                                                echo implode('; ', array_filter($meta_items));
+                                            ?></p>
                                         </li>
                                         <?php } ?>
                                         <?php } ?>

--- a/www/includes/easyparliament/templates/html/index.php
+++ b/www/includes/easyparliament/templates/html/index.php
@@ -90,22 +90,11 @@
                 <div class="row nested-row">
                     <div class="homepage-recently homepage-content-section">
                         <h2>Recently in Parliament</h2>
-                        <ul class="recently__list">
-                            <?php $max_count = count($debates['recent']) > 3 ? 3 : count($debates['recent']);
-                            for ( $i = 0; $i < $max_count; $i++ ) {
-                                $recent = $debates['recent'][$i];
+                        <ul class="recently__list"><?php
+                            foreach ( $debates['recent'] as $recent ) {
                                 include 'homepage/recent-debates.php';
-                            } ?>
-                        </ul>
-                        <?php if ( $max_count >= 3 ) { ?>
-                        <ul class="recently__list recently__list-more">
-                            <?php for ( $i = 3; $i < count($debates['recent']); $i++ ) {
-                                $recent = $debates['recent'][$i];
-                                include 'homepage/recent-debates.php';
-                            } ?>
-                        </ul>
-                        <a href="#" class="button button--show-all button--full-width">Show more</a>
-                        <?php } ?>
+                            }
+                        ?></ul>
                     </div>
                     <div class="homepage-upcoming homepage-content-section">
                         <h2>Upcoming</h2>

--- a/www/includes/easyparliament/templates/html/ni/index.php
+++ b/www/includes/easyparliament/templates/html/ni/index.php
@@ -84,22 +84,11 @@
                 <div class="row nested-row">
                     <div class="homepage-recently homepage-content-section">
                         <h2>Recently in the Northern Ireland Assembly</h2>
-                        <ul class="recently__list">
-                            <?php $max_count = count($debates['recent']) > 3 ? 3 : count($debates['recent']);
-                            for ( $i = 0; $i < $max_count; $i++ ) {
-                                $recent = $debates['recent'][$i];
-                                include dirname(__FILE__) . '/../homepage/recent-debates.php';
-                            } ?>
-                        </ul>
-                        <?php if ( $max_count >= 3 ) { ?>
-                        <ul class="recently__list recently__list-more">
-                            <?php for ( $i = 3; $i < count($debates['recent']); $i++ ) {
-                                $recent = $debates['recent'][$i];
-                                include dirname(__FILE__) . '/../homepage/recent-debates.php';
-                            } ?>
-                        </ul>
-                        <a href="#" class="button button--show-all button--full-width" onclick="$('.recently__list-more').show(); return false;">Show more</a>
-                        <?php } ?>
+                        <ul class="recently__list"><?php
+                            foreach ( $debates['recent'] as $recent ) {
+                                include 'homepage/recent-debates.php';
+                            }
+                        ?></ul>
                     </div>
                     <div class="homepage-upcoming homepage-content-section">
                         <h2>What is the Northern Ireland Assembly?</h2>

--- a/www/includes/easyparliament/templates/html/scotland/index.php
+++ b/www/includes/easyparliament/templates/html/scotland/index.php
@@ -101,22 +101,11 @@
                 <div class="row nested-row">
                     <div class="homepage-recently homepage-content-section">
                         <h2>Recently in Parliament</h2>
-                        <ul class="recently__list">
-                            <?php $max_count = count($debates['recent']) > 3 ? 3 : count($debates['recent']);
-                            for ( $i = 0; $i < $max_count; $i++ ) {
-                                $recent = $debates['recent'][$i];
-                                include dirname(__FILE__) . '/../homepage/recent-debates.php';
-                            } ?>
-                        </ul>
-                        <?php if ( $max_count >= 3 ) { ?>
-                        <ul class="recently__list recently__list-more">
-                            <?php for ( $i = 3; $i < count($debates['recent']); $i++ ) {
-                                $recent = $debates['recent'][$i];
-                                include dirname(__FILE__) . '/../homepage/recent-debates.php';
-                            } ?>
-                        </ul>
-                        <a href="#" class="button button--show-all button--full-width" onclick="$('.recently__list-more').show(); return false;">Show more</a>
-                        <?php } ?>
+                        <ul class="recently__list"><?php
+                            foreach ( $debates['recent'] as $recent ) {
+                                include 'homepage/recent-debates.php';
+                            }
+                        ?></ul>
                     </div>
                     <div class="homepage-upcoming homepage-content-section">
                         <h2>What is the Scottish Parliament?</h2>


### PR DESCRIPTION
Fixes #887.

Pretty uncontentious changes. Sorts out the weird vertical spacing in the "Upcoming" section on the homepage, and also unfolds the "Recently" section so that all the items are shown on pageload, which has the benefit of evening up the length of that section with the "Upcoming" one next to it.

@dracos could you check this works locally for you? I don't have enough data in my VM to fill the Recently and Upcoming sections.