### PR TITLE
Limit line lengths on static pages

### DIFF
--- a/www/docs/style/sass/pages/_static.scss
+++ b/www/docs/style/sass/pages/_static.scss
@@ -4,4 +4,12 @@
     .panel > h1:first-child {
         margin-top: 0;
     }
+
+    .panel > * {
+        max-width: 700px; // avoids unmanageable line lengths
+    }
+
+    ol {
+        margin-left: 2em; // restore left padding on ordered list items
+    }
 }


### PR DESCRIPTION
Fixes #921.

A really minimal fix that sets a hard limit for the length of lines on `.static-page` pages.

![screen shot 2015-10-20 at 17 00 20](https://cloud.githubusercontent.com/assets/739624/10613217/2a5ed1fa-774c-11e5-9703-3cbb58a93b92.png)

It's still a *bit* wide, but reducing it further would mean doing extra work to stop the headings wrapping etc. This is a good compromise, and much easier to read than the full width lines that are there now.