### PR TITLE
Make Wales page look less of an afterthought

### DIFF
--- a/www/docs/wales/index.php
+++ b/www/docs/wales/index.php
@@ -1,27 +1,7 @@
 <?php
 
+$this_page = "wales_overview";
+
 include_once '../../includes/easyparliament/init.php';
 
-$this_page = 'wales_overview';
-
-$PAGE->page_start();
-$PAGE->stripe_start();
-?>
-<h1>We need you!</h1>
-
-<p>It'd be fantastic if TheyWorkForYou also covered the
-Welsh Assembly, as we do with the
-<a href="/ni/">Northern Ireland Assembly</a> and the
-<a href="/scotland/">Scottish Parliament</a>, but we don't
-currently have the time or resources ourselves &mdash; in fact,
-both those assemblies were mainly done by volunteers.</p>
-
-<p>If you're interested in volunteering to help out, please
-<a href="https://groups.google.com/a/mysociety.org/forum/#!forum/theyworkforyou">join
-the mailing list</a>.</p>
-
-<p>Visit <a href="http://www.assemblywales.org/">the official Welsh Assembly website</a>.</p>
-
-<?php
-$PAGE->stripe_end();
-$PAGE->page_end();
+MySociety\TheyWorkForYou\Renderer::output('wales/index', array());

--- a/www/includes/easyparliament/templates/html/wales/index.php
+++ b/www/includes/easyparliament/templates/html/wales/index.php
@@ -1,0 +1,33 @@
+<div class="full-page__row">
+    <div class="business-section">
+        <div class="business-section__header">
+            <h1 class="business-section__header__title">Welsh Assembly</h1>
+        </div>
+
+        <div class="business-section__primary">
+            <h1>We need you!</h1>
+
+            <p>It&rsquo;d be fantastic if TheyWorkForYou also covered the
+            Welsh Assembly, as we do with the
+            <a href="/ni/">Northern Ireland Assembly</a> and the
+            <a href="/scotland/">Scottish Parliament</a>.
+
+            <p>But we don&rsquo;t currently have the time or resources
+            to add the Welsh Assembly ourselves. In fact, because the
+            code that runs TheyWorkForYou is
+            <a href="https://github.com/mysociety/theyworkforyou">open
+            source</a>, both Scotland and Northern Ireland were mainly
+            added by volunteers.</p>
+        </div>
+
+        <div class="business-section__secondary">
+            <h2>Next steps</h2>
+
+            <p>If you can help us add the Welsh Assembly to TheyWorkForYou,
+            <a href="https://groups.google.com/a/mysociety.org/forum/#!forum/theyworkforyou">join
+            our discussion list</a> and say hello.</p>
+
+            <p>If not, maybe you can get the information you need on <a href="http://www.assemblywales.org/">the official Welsh Assembly website</a>.</p>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
As spotted by @droom in #1003 – the "Wales" page was pretty poor, considering its position in the country switcher effectively makes it a top level page.

So this gives it a layout in keeping with the other national assembly sections.

![screen shot 2015-10-21 at 16 57 26](https://cloud.githubusercontent.com/assets/739624/10642286/d8884d24-7814-11e5-9296-f2f43ee2a799.png)
