### PR TITLE
Improve printed output

### DIFF
--- a/www/docs/style/sass/_print.scss
+++ b/www/docs/style/sass/_print.scss
@@ -1,0 +1,101 @@
+// Note: TWFY already includes the HTML5 Boilerplate print
+// styles via /foundation/scss/foundation/components/_type.scss
+
+// We use !important quite a bit in here, to quickly override
+// much more specific selectors in the non-print stylesheet.
+
+@media print {
+    @page {
+      margin: 1cm;
+    }
+
+    .banner,
+    .ms-header,
+    .site-header,
+    #footer,
+    .minisurvey,
+    .hero__mp-search,
+    .debate-header .cta,
+    .debate-navigation,
+    .debate-speech__speaker a:after,
+    .debate-speech__meta__link.time:after,
+    .debate-speech__question-answered .button,
+    .person-header .person-buttons,
+    .person-header .person-search,
+    .search-page__section--search,
+    .search-result-display-options,
+    .people-list-alphabet,
+    .business-section .calendar,
+    .business-list__excerpt a[href^="/"]:after,
+    .search-section,
+    .search-result-pagination,
+    .search-result + hr,
+    .person-panels .in-page-nav,
+    .homepage-panels .panel--inverted {
+        display: none !important;
+    }
+
+    .search-page__section__primary {
+        border: none !important;
+    }
+
+    .debate-speech__speaker-and-content,
+    .debate-speech__links,
+    .homepage-content-section,
+    .hero__site-intro,
+    .search-page__section__primary,
+    .search-page__section__secondary,
+    .business-section__primary,
+    .business-section__secondary,
+    .primary-content__unit {
+        width: auto !important;
+        float: none !important;
+    }
+
+    .panel,
+    .hero__site-intro,
+    .hero__site-intro__wrap,
+    .search-page__section__primary,
+    .search-page__section__secondary,
+    .business-section__header,
+    .business-section__primary,
+    .business-section__secondary,
+    .person-header,
+    .person-panels {
+        padding: 0 !important;
+    }
+
+    input {
+        border-radius: 0.3em !important;
+    }
+
+    input.homepage-search__input,
+    input.search-section__input,
+    .button {
+        border: 1px solid #ccc;
+    }
+
+    a[href]:after,
+    abbr[title]:after {
+        display: inline-block;
+        font-weight: normal;
+        font-style: italic;
+        margin-left: 0.3em;
+    }
+
+    .search-result .hi {
+        border: 1px solid #ccc;
+        padding: 0.1em 0.4em;
+        border-radius: 0.3em;
+    }
+
+    .person-header .person-header__content {
+        .person-constituency {
+            position: static;
+        }
+
+        .person-name {
+            width: auto;
+        }
+    }
+}

--- a/www/docs/style/sass/app.scss
+++ b/www/docs/style/sass/app.scss
@@ -220,3 +220,5 @@ form {
 
 @import "parts/policies";
 @import "parts/regional-headers";
+
+@import "print";


### PR DESCRIPTION
Interactive elements like search boxes and buttons are hidden. Floated columns/sidebars are unfloated, and section padding is removed. Plus a bunch of other small improvements.

Fixes #892.

Here are a few example pages, from different browsers. If you can spot something that's been removed and shouldn't have been, or something that still needs to change, leave a comment.

### Homepage (chrome, firefox, safari)

![screen shot 2015-10-28 at 14 36 27](https://cloud.githubusercontent.com/assets/739624/10791682/59d4bd38-7d81-11e5-8316-c9cd5e1fd400.png)

### MPs page (chrome, firefox, safari)

![screen shot 2015-10-28 at 14 38 25](https://cloud.githubusercontent.com/assets/739624/10791736/945df7c6-7d81-11e5-90b6-277de98a7931.png)

### Business listing page (chrome, firefox, safari)

![screen shot 2015-10-28 at 14 40 08](https://cloud.githubusercontent.com/assets/739624/10791796/da94b82e-7d81-11e5-934e-1da734108ead.png)

### Debate page (chrome, firefox, safari)

![screen shot 2015-10-28 at 14 48 21](https://cloud.githubusercontent.com/assets/739624/10792294/063ad272-7d84-11e5-95ae-cd76b5946d0c.png)
