### PR TITLE
Stop imposing max-width to limit lines on legacy pages

### DIFF
--- a/www/docs/style/sass/pages/_static.scss
+++ b/www/docs/style/sass/pages/_static.scss
@@ -13,3 +13,10 @@
         margin-left: 2em; // restore left padding on ordered list items
     }
 }
+
+// Reset 700px limit on legacy pages (which mostly handle their own layout)
+.legacy-page {
+    .panel > * {
+        max-width: none;
+    }
+}


### PR DESCRIPTION
Fixes #1009.

Not pretty, but it's better than before.

![screen shot 2015-12-04 at 15 22 12](https://cloud.githubusercontent.com/assets/739624/11593194/dbc6e1b4-9a9a-11e5-9edc-bc1ceec8aae2.png)
