### PR TITLE
Avoid advanced search options flash on page load

### DIFF
--- a/www/docs/style/sass/pages/_search.scss
+++ b/www/docs/style/sass/pages/_search.scss
@@ -61,6 +61,10 @@
 }
 
 .search-page__section--options {
+  html.js & {
+    display: none; // hide advanced options so they can be shown on-demand by javascript
+  }
+
   h4 {
     font-weight: inherit;
     font-size: 1.1em;

--- a/www/includes/easyparliament/templates/html/search/by-person.php
+++ b/www/includes/easyparliament/templates/html/search/by-person.php
@@ -1,7 +1,9 @@
 <div class="full-page">
     <div class="full-page__row search-page">
 
-        <?php include 'form.php'; ?>
+        <form class="js-search-form-without-options">
+            <?php include 'form_main.php'; ?>
+        </form>
 
         <div class="search-page__section search-page__section--results">
             <div class="search-page__section__primary">
@@ -93,6 +95,11 @@
 
             <?php include 'sidebar.php' ?>
         </div>
+
+        <form class="js-search-form-with-options">
+            <?php include 'form_main.php'; ?>
+            <?php include 'form_options.php'; ?>
+        </form>
 
     </div>
 </div>

--- a/www/includes/easyparliament/templates/html/search/by-person.php
+++ b/www/includes/easyparliament/templates/html/search/by-person.php
@@ -7,45 +7,79 @@
 
         <div class="search-page__section search-page__section--results">
             <div class="search-page__section__primary">
-            <h2>Who says <em class="current-search-term"><?= _htmlentities($searchstring) ?></em> the most?</h2>
+                <h2>Who says <em class="current-search-term"><?= _htmlentities($searchstring) ?></em> the most?</h2>
 
-            <?php if ( isset($error) ) {
-                if ( $error == 'No results' && isset( $house ) && $house != 0 ) { ?>
-                <ul class="search-result-display-options">
-                    <li>
-                        <?php if ( $house == 1 ) { ?>No results for MPs only<?php }
-                        else if ( $house == 2 ) { ?>No results for Peers only<?php }
-                        else if ( $house == 4 ) { ?>No results for MSPs only<?php }
-                        else if ( $house == 3 ) { ?>No results for MLAs only<?php } ?> |
-                        <a href="<?= $this_url->generate('html') ?>">Show results for all speakers</a></li>
-                </ul>
+              <?php if ( isset($error) ) { ?>
+                <?php if ( $error == 'No results' && isset( $house ) && $house != 0 ) { ?>
+                  <ul class="search-result-display-options">
+                      <li>
+                        <?php if ( $house == 1 ) { ?>
+                          No results for MPs only
+                        <?php } else if ( $house == 2 ) { ?>
+                          No results for Peers only
+                        <?php } else if ( $house == 4 ) { ?>
+                          No results for MSPs only
+                        <?php } else if ( $house == 3 ) { ?>
+                          No results for MLAs only
+                        <?php } ?>
+                          |
+                          <a href="<?= $this_url->generate('html') ?>">Show results for all speakers</a>
+                      </li>
+                  </ul>
                 <?php } else { ?>
-                <p class="search-results-legend"><?= $error ?></p>
+                  <p class="search-results-legend"><?= $error ?></p>
                 <?php } ?>
-            <?php } ?>
+              <?php } ?>
 
-            <?php if ( $wtt ) { ?>
+              <?php if ( $wtt ) { ?>
                 <p><strong>Now, try reading what a couple of these Lords are saying,
                 to help you find someone appropriate. When you've found someone,
                 hit the "I want to write to this Lord" button on their results page
                 to go back to WriteToThem.
                 </strong></p>
-            <?php } ?>
+              <?php } ?>
 
-            <?php if ( isset($speakers) && count($speakers) ) { ?>
-                <?php if ( !$wtt ) { ?>
-                <ul class="search-result-display-options">
-                    <li>Results grouped by person</li>
-                    <li><?php if ( $house == 0 ) { ?>Show All<?php } else { ?><a href="<?= $this_url->generate('html') ?>">Show All</a><?php } ?> |
-                        <?php if ( $house == 1 ) { ?>MPs only<?php } else { ?><a href="<?= $this_url->generate('html', array('house'=>1)) ?>">MPs only</a><?php } ?> |
-                        <?php if ( $house == 2 ) { ?>Peers only<?php } else { ?><a href="<?= $this_url->generate('html', array('house'=>2)) ?>">Lords only</a><?php } ?> |
-                        <?php if ( $house == 4 ) { ?>MSPs only<?php } else { ?><a href="<?= $this_url->generate('html', array('house'=>4)) ?>">MSPs only</a><?php } ?> |
-                        <?php if ( $house == 3 ) { ?>MLAs only<?php } else { ?><a href="<?= $this_url->generate('html', array('house'=>3)) ?>">MLAs only</a><?php } ?></li>
-                    <li><a href="<?= $ungrouped_url->generate() ?>">Ungroup results</a></li>
-                </ul>
+              <?php if ( isset($speakers) && count($speakers) ) { ?>
 
-                <p class="search-results-legend">The <?= isset($limit_reached) ? '5000 ' : '' ?>most recent mentions of the exact phrase <em class="current-search-term"><?= _htmlentities($searchstring) ?></em>, grouped by speaker name.</p>
-                <?php } ?>
+                  <?php if ( !$wtt ) { ?>
+                    <ul class="search-result-display-options">
+                        <li>Results grouped by person</li>
+                        <li>
+                          <?php if ( $house == 0 ) { ?>
+                            Show All
+                          <?php } else { ?>
+                            <a href="<?= $this_url->generate('html') ?>">Show All</a>
+                          <?php } ?>
+                            |
+                          <?php if ( $house == 1 ) { ?>
+                            MPs only
+                          <?php } else { ?>
+                            <a href="<?= $this_url->generate('html', array('house'=>1)) ?>">MPs only</a>
+                          <?php } ?>
+                            |
+                          <?php if ( $house == 2 ) { ?>
+                            Peers only
+                          <?php } else { ?>
+                            <a href="<?= $this_url->generate('html', array('house'=>2)) ?>">Lords only</a>
+                          <?php } ?>
+                            |
+                          <?php if ( $house == 4 ) { ?>
+                            MSPs only
+                          <?php } else { ?>
+                            <a href="<?= $this_url->generate('html', array('house'=>4)) ?>">MSPs only</a>
+                          <?php } ?>
+                            |
+                          <?php if ( $house == 3 ) { ?>
+                            MLAs only
+                          <?php } else { ?>
+                            <a href="<?= $this_url->generate('html', array('house'=>3)) ?>">MLAs only</a>
+                          <?php } ?>
+                        </li>
+                        <li><a href="<?= $ungrouped_url->generate() ?>">Ungroup results</a></li>
+                    </ul>
+
+                    <p class="search-results-legend">The <?= isset($limit_reached) ? '5000 ' : '' ?>most recent mentions of the exact phrase <em class="current-search-term"><?= _htmlentities($searchstring) ?></em>, grouped by speaker name.</p>
+                  <?php } ?>
 
                 <table class="search-results-grouped">
                     <thead>
@@ -56,41 +90,44 @@
                         </tr>
                     </thead>
                     <tbody>
-                    <?php foreach ( $speakers as $pid => $speaker ) { ?>
+                      <?php foreach ( $speakers as $pid => $speaker ) { ?>
+
                         <?php if ( $wtt && $pid == 0 ) { continue; } // skip heading count for WTT lords list ?>
+
                         <tr>
                             <td><?= $speaker['count'] ?></td>
                             <td>
-                                <?php if ( $pid ) { ?>
-                                    <?php if ( !$wtt || $speaker['left'] == '9999-12-31' ) { ?>
-                                    <a href="/search/?q=<?= _htmlentities($searchstring) ?>&amp;pid=<?= $pid ?><?= isset($wtt) && $speaker['left'] == '9999-12-31' ? '&amp;wtt=2' : '' ?>">
-                                    <?php } ?>
-                                    <?= isset($speaker['name']) ? $speaker['name'] : 'N/A' ?>
-                                    <?php if ( !$wtt || $speaker['left'] == '9999-12-31' ) { ?>
-                                    </a>
-                                    <?php } ?>
+                              <?php if ( $pid ) { ?>
+                                <?php if ( !$wtt || $speaker['left'] == '9999-12-31' ) { ?>
+                                  <a href="/search/?q=<?= _htmlentities($searchstring) ?>&amp;pid=<?= $pid ?><?= isset($wtt) && $speaker['left'] == '9999-12-31' ? '&amp;wtt=2' : '' ?>">
+                                <?php } ?>
+                                <?= isset($speaker['name']) ? $speaker['name'] : 'N/A' ?>
+                                <?php if ( !$wtt || $speaker['left'] == '9999-12-31' ) { ?>
+                                  </a>
+                                <?php } ?>
                                 <?php if ( isset($speaker['party']) ) { ?>
-                                <span class="search-results-grouped__speaker-party">(<?= $speaker['party'] ?>)</span>
+                                  <span class="search-results-grouped__speaker-party">(<?= $speaker['party'] ?>)</span>
                                 <?php } ?>
                                 <?php if ( $house != 2 ) { ?>
-                                <?= isset($speaker['office']) ? ' - ' . join('; ', $speaker['office']) : '' ?>
+                                  <?= isset($speaker['office']) ? ' - ' . join('; ', $speaker['office']) : '' ?>
                                 <?php } ?>
-                                <?php } else { ?>
+                              <?php } else { // no $pid ?>
                                 <?= $speaker['name'] ?>
-                                <?php } ?>
+                              <?php } ?>
                             </td>
                             <td>
-                            <?php if ( format_date($speaker['pmindate'], 'M Y') == format_date($speaker['pmaxdate'], 'M Y') ) { ?>
-                            <?= format_date($speaker['pmindate'], 'M Y') ?>
-                            <?php } else { ?>
-                            <?= format_date($speaker['pmindate'], 'M Y') ?>&nbsp;&ndash;&nbsp;<?= format_date($speaker['pmaxdate'], 'M Y') ?>
-                            <?php } ?>
+                              <?php if ( format_date($speaker['pmindate'], 'M Y') == format_date($speaker['pmaxdate'], 'M Y') ) { ?>
+                                <?= format_date($speaker['pmindate'], 'M Y') ?>
+                              <?php } else { ?>
+                                <?= format_date($speaker['pmindate'], 'M Y') ?>&nbsp;&ndash;&nbsp;<?= format_date($speaker['pmaxdate'], 'M Y') ?>
+                              <?php } ?>
                             </td>
                         </tr>
-                    <?php } ?>
+                      <?php } ?>
                     </tbody>
                 </table>
-            <?php } ?>
+              <?php } // end of isset($speakers) ?>
+
             </div>
 
             <?php include 'sidebar.php' ?>

--- a/www/includes/easyparliament/templates/html/search/form_main.php
+++ b/www/includes/easyparliament/templates/html/search/form_main.php
@@ -1,27 +1,27 @@
-            <div class="search-page__section search-page__section--search">
-                <div class="search-page__section__primary">
-                    <p class="search-page-main-inputs">
-                        <input type="text" name="q" value="<?= _htmlentities($search_keyword) ?>" class="form-control">
-                        <input type="submit" class="button" value="Search">
-                    </p>
-                    <?php if (isset($warnings) ) { ?>
-                    <p class="error">
-                        <?= $warnings ?>
-                    </p>
-                    <?php } ?>
-                    <p>
-                        <ul class="search-result-display-options">
-                        <li><a href="#options" class="search-options-toggle js-toggle-search-options">Advanced search</a></li>
-                        <?php if ( $is_adv ) { ?>
-                            <?= $search_phrase ? '<li>Exactly: ' . _htmlentities($search_phrase) . '</li>' : '' ?>
-                            <?= $search_exclude ? '<li>Excluding: ' . _htmlentities($search_exclude) . '</li>' : '' ?>
-                            <?= $search_from ? '<li>From: ' . _htmlentities($search_from) . '</li>' : '' ?>
-                            <?= $search_to ? '<li>To: ' . _htmlentities($search_to) . '</li>' : '' ?>
-                            <?= $search_person ? '<li>Person: ' . _htmlentities($search_person) . '</li>' : '' ?>
-                            <?= $search_section ? '<li>Section: ' . _htmlentities($search_section_pretty) . '</li>' : '' ?>
-                            <?= $search_column ? '<li>Column: ' . _htmlentities($search_column) . '</li>' : '' ?>
-                        <?php } ?>
-                        </ul>
-                    </p>
-                </div>
-            </div>
+<div class="search-page__section search-page__section--search">
+    <div class="search-page__section__primary">
+        <p class="search-page-main-inputs">
+            <input type="text" name="q" value="<?= _htmlentities($search_keyword) ?>" class="form-control">
+            <input type="submit" class="button" value="Search">
+        </p>
+      <?php if (isset($warnings) ) { ?>
+        <p class="error">
+            <?= $warnings ?>
+        </p>
+      <?php } ?>
+        <p>
+            <ul class="search-result-display-options">
+                <li><a href="#options" class="search-options-toggle js-toggle-search-options">Advanced search</a></li>
+              <?php if ( $is_adv ) { ?>
+                <?= $search_phrase ? '<li>Exactly: ' . _htmlentities($search_phrase) . '</li>' : '' ?>
+                <?= $search_exclude ? '<li>Excluding: ' . _htmlentities($search_exclude) . '</li>' : '' ?>
+                <?= $search_from ? '<li>From: ' . _htmlentities($search_from) . '</li>' : '' ?>
+                <?= $search_to ? '<li>To: ' . _htmlentities($search_to) . '</li>' : '' ?>
+                <?= $search_person ? '<li>Person: ' . _htmlentities($search_person) . '</li>' : '' ?>
+                <?= $search_section ? '<li>Section: ' . _htmlentities($search_section_pretty) . '</li>' : '' ?>
+                <?= $search_column ? '<li>Column: ' . _htmlentities($search_column) . '</li>' : '' ?>
+              <?php } ?>
+            </ul>
+        </p>
+    </div>
+</div>

--- a/www/includes/easyparliament/templates/html/search/form_main.php
+++ b/www/includes/easyparliament/templates/html/search/form_main.php
@@ -1,0 +1,27 @@
+            <div class="search-page__section search-page__section--search">
+                <div class="search-page__section__primary">
+                    <p class="search-page-main-inputs">
+                        <input type="text" name="q" value="<?= _htmlentities($search_keyword) ?>" class="form-control">
+                        <input type="submit" class="button" value="Search">
+                    </p>
+                    <?php if (isset($warnings) ) { ?>
+                    <p class="error">
+                        <?= $warnings ?>
+                    </p>
+                    <?php } ?>
+                    <p>
+                        <ul class="search-result-display-options">
+                        <li><a href="#options" class="search-options-toggle js-toggle-search-options">Advanced search</a></li>
+                        <?php if ( $is_adv ) { ?>
+                            <?= $search_phrase ? '<li>Exactly: ' . _htmlentities($search_phrase) . '</li>' : '' ?>
+                            <?= $search_exclude ? '<li>Excluding: ' . _htmlentities($search_exclude) . '</li>' : '' ?>
+                            <?= $search_from ? '<li>From: ' . _htmlentities($search_from) . '</li>' : '' ?>
+                            <?= $search_to ? '<li>To: ' . _htmlentities($search_to) . '</li>' : '' ?>
+                            <?= $search_person ? '<li>Person: ' . _htmlentities($search_person) . '</li>' : '' ?>
+                            <?= $search_section ? '<li>Section: ' . _htmlentities($search_section_pretty) . '</li>' : '' ?>
+                            <?= $search_column ? '<li>Column: ' . _htmlentities($search_column) . '</li>' : '' ?>
+                        <?php } ?>
+                        </ul>
+                    </p>
+                </div>
+            </div>

--- a/www/includes/easyparliament/templates/html/search/form_options.php
+++ b/www/includes/easyparliament/templates/html/search/form_options.php
@@ -1,135 +1,135 @@
-            <div class="search-page__section search-page__section--options" id="options">
-                <div class="search-page__section__primary">
-                    <h2>Advanced search</h2>
+<div class="search-page__section search-page__section--options" id="options">
+    <div class="search-page__section__primary">
+        <h2>Advanced search</h2>
 
-                    <h4>Find this exact word or phrase</h4>
-                    <div class="search-option">
-                        <div class="search-option__control">
-                            <input name="phrase" type="text" value="<?= _htmlentities($search_phrase) ?>" class="form-control">
-                        </div>
-                        <div class="search-option__hint">
-                            <p>You can also do this from the main search box by
+        <h4>Find this exact word or phrase</h4>
+        <div class="search-option">
+            <div class="search-option__control">
+                <input name="phrase" type="text" value="<?= _htmlentities($search_phrase) ?>" class="form-control">
+            </div>
+            <div class="search-option__hint">
+                <p>You can also do this from the main search box by
 putting exact words in quotes: like <code>"cycling"</code> or <code>"hutton
 report"</code></p>
-                            <p>By default, we show words related to your search
+                <p>By default, we show words related to your search
 term, like &ldquo;cycle&rdquo; and &ldquo;cycles&rdquo; in a search for
 <code>cycling</code>. Putting the word in quotes, like <code>"cycling"</code>,
 will stop this.</p>
 
-                        </div>
-                    </div>
+            </div>
+        </div>
 
-                    <h4>Excluding these words</h4>
-                    <div class="search-option">
-                        <div class="search-option__control">
-                            <input name="exclude" type="text" value="<?= _htmlentities($search_exclude) ?>" class="form-control">
-                        </div>
-                        <div class="search-option__hint">
-                            <p>You can also do this from the main search box by
+        <h4>Excluding these words</h4>
+        <div class="search-option">
+            <div class="search-option__control">
+                <input name="exclude" type="text" value="<?= _htmlentities($search_exclude) ?>" class="form-control">
+            </div>
+            <div class="search-option__hint">
+                <p>You can also do this from the main search box by
 putting a minus sign before words you don&rsquo;t want: like <code>hunting
 -fox</code></p>
-                            <p>We also support <a href="/help/#searching">a
+                <p>We also support <a href="/help/#searching">a
 bunch of boolean search modifiers</a>, like <code>AND</code> and
 <code>NEAR</code>, for precise searching.</p>
-                        </div>
-                    </div>
+            </div>
+        </div>
 
-                    <h4>Date range</h4>
-                    <div class="search-option">
-                        <div class="search-option__control search-option__control--date-range">
-                            <input name="from" type="date" value="<?= _htmlentities($search_from) ?>" class="form-control">
-                            <span>to</span>
-                            <input name="to" type="date" value="<?= _htmlentities($search_to) ?>" class="form-control">
-                        </div>
-                        <div class="search-option__hint">
-                            <p>You can give a <strong>start date, an end date,
+        <h4>Date range</h4>
+        <div class="search-option">
+            <div class="search-option__control search-option__control--date-range">
+                <input name="from" type="date" value="<?= _htmlentities($search_from) ?>" class="form-control">
+                <span>to</span>
+                <input name="to" type="date" value="<?= _htmlentities($search_to) ?>" class="form-control">
+            </div>
+            <div class="search-option__hint">
+                <p>You can give a <strong>start date, an end date,
 or both</strong> to restrict results to a particular date range. A missing end
 date implies the current date, and a missing start date implies the oldest date
 we have in the system. Dates can be entered in any format you wish, e.g.
 <code>3rd March 2007</code> or <code>17/10/1989</code></p>
-                        </div>
-                    </div>
+            </div>
+        </div>
 
-                    <h4>Person</h4>
-                    <div class="search-option">
-                        <div class="search-option__control">
-                            <input name="person" type="text" value="<?= _htmlentities($search_person) ?>" class="form-control">
-                        </div>
-                        <div class="search-option__hint">
-                            <p>Enter a name here to restrict results to contributions only by that person.</p>
-                        </div>
-                    </div>
+        <h4>Person</h4>
+        <div class="search-option">
+            <div class="search-option__control">
+                <input name="person" type="text" value="<?= _htmlentities($search_person) ?>" class="form-control">
+            </div>
+            <div class="search-option__hint">
+                <p>Enter a name here to restrict results to contributions only by that person.</p>
+            </div>
+        </div>
 
-                    <h4>Section</h4>
-                    <div class="search-option">
-                        <div class="search-option__control">
-                            <select name="section">
-                                <option></option>
-                                <optgroup label="UK Parliament">
-                                    <option value="uk"<?= $search_section == 'uk' ? ' selected' : '' ?>>All UK</option>
-                                    <option value="debates"<?= $search_section == 'debates' ? ' selected' : '' ?>>House of Commons debates</option>
-                                    <option value="whall"<?= $search_section == 'whall' ? ' selected' : '' ?>>Westminster Hall debates</option>
-                                    <option value="lords"<?= $search_section == 'lords' ? ' selected' : '' ?>>House of Lords debates</option>
-                                    <option value="wrans"<?= $search_section == 'wrans' ? ' selected' : '' ?>>Written answers</option>
-                                    <option value="wms"<?= $search_section == 'wms' ? ' selected' : '' ?>>Written ministerial statements</option>
-                                    <option value="standing"<?= $search_section == 'standing' ? ' selected' : '' ?>>Bill Committees</option>
-                                    <option value="future"<?= $search_section == 'future' ? ' selected' : '' ?>>Future Business</option>
-                                </optgroup>
-                                <optgroup label="Northern Ireland Assembly">
-                                    <option value="ni"<?= $search_section == 'ni' ? ' selected' : '' ?>>Debates</option>
-                                </optgroup>
-                                <optgroup label="Scottish Parliament">
-                                    <option value="scotland"<?= $search_section == 'scotland' ? ' selected' : '' ?>>All Scotland</option>
-                                    <option value="sp"<?= $search_section == 'sp' ? ' selected' : '' ?>>Debates</option>
-                                    <option value="spwrans"<?= $search_section == 'spwrans' ? ' selected' : '' ?>>Written answers</option>
-                                </optgroup>
-                             </select>
-                        </div>
-                        <div class="search-option__hint">
-                            <p>Restrict results to a particular parliament or assembly that we cover (e.g. the Scottish Parliament), or a particular type of data within an institution, such as Commons Written Answers.</p>
-                        </div>
-                    </div>
+        <h4>Section</h4>
+        <div class="search-option">
+            <div class="search-option__control">
+                <select name="section">
+                    <option></option>
+                    <optgroup label="UK Parliament">
+                        <option value="uk"<?= $search_section == 'uk' ? ' selected' : '' ?>>All UK</option>
+                        <option value="debates"<?= $search_section == 'debates' ? ' selected' : '' ?>>House of Commons debates</option>
+                        <option value="whall"<?= $search_section == 'whall' ? ' selected' : '' ?>>Westminster Hall debates</option>
+                        <option value="lords"<?= $search_section == 'lords' ? ' selected' : '' ?>>House of Lords debates</option>
+                        <option value="wrans"<?= $search_section == 'wrans' ? ' selected' : '' ?>>Written answers</option>
+                        <option value="wms"<?= $search_section == 'wms' ? ' selected' : '' ?>>Written ministerial statements</option>
+                        <option value="standing"<?= $search_section == 'standing' ? ' selected' : '' ?>>Bill Committees</option>
+                        <option value="future"<?= $search_section == 'future' ? ' selected' : '' ?>>Future Business</option>
+                    </optgroup>
+                    <optgroup label="Northern Ireland Assembly">
+                        <option value="ni"<?= $search_section == 'ni' ? ' selected' : '' ?>>Debates</option>
+                    </optgroup>
+                    <optgroup label="Scottish Parliament">
+                        <option value="scotland"<?= $search_section == 'scotland' ? ' selected' : '' ?>>All Scotland</option>
+                        <option value="sp"<?= $search_section == 'sp' ? ' selected' : '' ?>>Debates</option>
+                        <option value="spwrans"<?= $search_section == 'spwrans' ? ' selected' : '' ?>>Written answers</option>
+                    </optgroup>
+                 </select>
+            </div>
+            <div class="search-option__hint">
+                <p>Restrict results to a particular parliament or assembly that we cover (e.g. the Scottish Parliament), or a particular type of data within an institution, such as Commons Written Answers.</p>
+            </div>
+        </div>
 
-                    <h4>Column</h4>
-                    <div class="search-option">
-                        <div class="search-option__control">
-                            <input name="column" type="text" value="<?= _htmlentities($search_column) ?>" class="form-control">
-                        </div>
-                        <div class="search-option__hint">
-                            <p>If you know the actual Hansard column number of
+        <h4>Column</h4>
+        <div class="search-option">
+            <div class="search-option__control">
+                <input name="column" type="text" value="<?= _htmlentities($search_column) ?>" class="form-control">
+            </div>
+            <div class="search-option__hint">
+                <p>If you know the actual Hansard column number of
 the information you are interested in (perhaps you&rsquo;re looking up a paper
 reference), you can restrict results to that; you can also use
 <code>column:123</code> in the main search box.</p>
-                        </div>
-                    </div>
-
-                    <p><input type="submit" class="button" value="Search"></p>
-                </div>
             </div>
+        </div>
 
-        <script type="text/javascript">
-        $(function(){
-          // Move advanced search options to appear *before* results.
-          // (This means non-javascript users don't have to scroll past it
-          // to see their search results.)
-          $('.js-search-form-without-options').replaceWith( $('.js-search-form-with-options') );
+        <p><input type="submit" class="button" value="Search"></p>
+    </div>
+</div>
 
-          // Show/hide advanced search options.
-          $('.js-toggle-search-options').on('click', function(e){
-            e.preventDefault();
-            var id = $(this).attr('href'); // #options
-            if($(id).is(':visible')){
-              $('.js-toggle-search-options[href="' + id + '"]').removeClass('toggled');
-              $(id).slideUp(250, function(){
-                // Disable the inputs *after* they're hidden (less distracting).
-                $(id).find(':input').attr('disabled', 'disabled');
-              });
-            } else {
-              $('.js-toggle-search-options[href="' + id + '"]').addClass('toggled');
-              $(id).find(':input:disabled').removeAttr('disabled');
-              $(id).slideDown(250);
-            }
-          });
-          <?= $is_adv ? '' : '$("#options").find(":input").attr("disabled", "disabled");' ?>
-        });
-        </script>
+<script type="text/javascript">
+$(function(){
+  // Move advanced search options to appear *before* results.
+  // (This means non-javascript users don't have to scroll past it
+  // to see their search results.)
+  $('.js-search-form-without-options').replaceWith( $('.js-search-form-with-options') );
+
+  // Show/hide advanced search options.
+  $('.js-toggle-search-options').on('click', function(e){
+    e.preventDefault();
+    var id = $(this).attr('href'); // #options
+    if($(id).is(':visible')){
+      $('.js-toggle-search-options[href="' + id + '"]').removeClass('toggled');
+      $(id).slideUp(250, function(){
+        // Disable the inputs *after* they're hidden (less distracting).
+        $(id).find(':input').attr('disabled', 'disabled');
+      });
+    } else {
+      $('.js-toggle-search-options[href="' + id + '"]').addClass('toggled');
+      $(id).find(':input:disabled').removeAttr('disabled');
+      $(id).slideDown(250);
+    }
+  });
+  <?= $is_adv ? '' : '$("#options").find(":input").attr("disabled", "disabled");' ?>
+});
+</script>

--- a/www/includes/easyparliament/templates/html/search/form_options.php
+++ b/www/includes/easyparliament/templates/html/search/form_options.php
@@ -1,32 +1,3 @@
-        <form>
-            <div class="search-page__section search-page__section--search">
-                <div class="search-page__section__primary">
-                    <p class="search-page-main-inputs">
-                        <input type="text" name="q" value="<?= _htmlentities($search_keyword) ?>" class="form-control">
-                        <input type="submit" class="button" value="Search">
-                    </p>
-                    <?php if (isset($warnings) ) { ?>
-                    <p class="error">
-                        <?= $warnings ?>
-                    </p>
-                    <?php } ?>
-                    <p>
-                        <ul class="search-result-display-options">
-                        <li><a href="#options" class="search-options-toggle js-toggle-search-options">Advanced search</a></li>
-                        <?php if ( $is_adv ) { ?>
-                            <?= $search_phrase ? '<li>Exactly: ' . _htmlentities($search_phrase) . '</li>' : '' ?>
-                            <?= $search_exclude ? '<li>Excluding: ' . _htmlentities($search_exclude) . '</li>' : '' ?>
-                            <?= $search_from ? '<li>From: ' . _htmlentities($search_from) . '</li>' : '' ?>
-                            <?= $search_to ? '<li>To: ' . _htmlentities($search_to) . '</li>' : '' ?>
-                            <?= $search_person ? '<li>Person: ' . _htmlentities($search_person) . '</li>' : '' ?>
-                            <?= $search_section ? '<li>Section: ' . _htmlentities($search_section_pretty) . '</li>' : '' ?>
-                            <?= $search_column ? '<li>Column: ' . _htmlentities($search_column) . '</li>' : '' ?>
-                        <?php } ?>
-                        </ul>
-                    </p>
-                </div>
-            </div>
-
             <div class="search-page__section search-page__section--options" id="options">
                 <div class="search-page__section__primary">
                     <h2>Advanced search</h2>
@@ -135,17 +106,24 @@ reference), you can restrict results to that; you can also use
                     <p><input type="submit" class="button" value="Search"></p>
                 </div>
             </div>
-        </form>
 
         <script type="text/javascript">
         $(function(){
+          // Move advanced search options to appear *before* results.
+          // (This means non-javascript users don't have to scroll past it
+          // to see their search results.)
+          $('.js-search-form-without-options').replaceWith( $('.js-search-form-with-options') );
+
+          // Show/hide advanced search options.
           $('.js-toggle-search-options').on('click', function(e){
             e.preventDefault();
-            var id = $(this).attr('href');
+            var id = $(this).attr('href'); // #options
             if($(id).is(':visible')){
               $('.js-toggle-search-options[href="' + id + '"]').removeClass('toggled');
-              $(id).find(':input').attr('disabled', 'disabled');
-              $(id).slideUp(250);
+              $(id).slideUp(250, function(){
+                // Disable the inputs *after* they're hidden (less distracting).
+                $(id).find(':input').attr('disabled', 'disabled');
+              });
             } else {
               $('.js-toggle-search-options[href="' + id + '"]').addClass('toggled');
               $(id).find(':input:disabled').removeAttr('disabled');
@@ -153,7 +131,5 @@ reference), you can restrict results to that; you can also use
             }
           });
           <?= $is_adv ? '' : '$("#options").find(":input").attr("disabled", "disabled");' ?>
-
-          $( $('.js-toggle-search-options').attr('href') ).hide();
         });
         </script>

--- a/www/includes/easyparliament/templates/html/search/results.php
+++ b/www/includes/easyparliament/templates/html/search/results.php
@@ -5,118 +5,115 @@
             <?php include 'form_main.php'; ?>
         </form>
 
-        <?php if ( $searchstring && !isset($warnings) ) { ?>
+      <?php if ( $searchstring && !isset($warnings) ) { ?>
         <div class="search-page__section search-page__section--results">
             <div class="search-page__section__primary">
-                <?php if ( $cons ) { ?>
-                    <?php if ( count($cons) > 1 ) {
-                        $types = array();
-                        if ( $mp_types['mp'] > 0 ) {
-                            $types[] = 'MPs';
-                        }
-                        if ( $mp_types['former'] > 0 ) {
-                            $types[] = 'former MPs';
-                        }
-                        $desc = ucfirst(implode(' and ', $types));
-                    ?>
-                    <h2><?= $desc ?> in constituencies matching <em class="current-search-term"><?= _htmlentities($searchstring) ?></em></h2>
-                    <?php } else { ?>
-                    <h2><?= $mp_types['former'] ? 'Former ' : '' ?>MP for <em class="current-search-term"><?= _htmlentities($searchstring) ?></em></h2>
-                    <?php } ?>
-                    <?php foreach ( $cons as $member ) { ?>
-                        <?php include('person.php'); ?>
-                    <?php } ?>
+              <?php if ( $cons ) { ?>
+                <?php if ( count($cons) > 1 ) {
+                    $types = array();
+                    if ( $mp_types['mp'] > 0 ) {
+                        $types[] = 'MPs';
+                    }
+                    if ( $mp_types['former'] > 0 ) {
+                        $types[] = 'former MPs';
+                    }
+                    $desc = ucfirst(implode(' and ', $types));
+                ?>
+                  <h2><?= $desc ?> in constituencies matching <em class="current-search-term"><?= _htmlentities($searchstring) ?></em></h2>
+                <?php } else { // count($cons) <= 1 ?>
+                  <h2><?= $mp_types['former'] ? 'Former ' : '' ?>MP for <em class="current-search-term"><?= _htmlentities($searchstring) ?></em></h2>
                 <?php } ?>
+                <?php foreach ( $cons as $member ) { ?>
+                  <?php include('person.php'); ?>
+                <?php } ?>
+              <?php } ?>
 
-                <?php if ( $members ) { ?>
+              <?php if ( $members ) { ?>
                 <h2>People matching <em class="current-search-term"><?= _htmlentities($searchstring) ?></em></h2>
-
                 <?php foreach ( $members as $member ) { ?>
                     <?php include('person.php'); ?>
                 <?php } ?>
-
                 <hr>
-                <?php } ?>
+              <?php } ?>
 
-                <?php if ($glossary) { ?>
+              <?php if ($glossary) { ?>
                 <h2>Glossary items matching <em class="current-search-term"><?= _htmlentities($searchstring) ?></em></h2>
-
-                  <?php foreach ( $glossary as $item ) { ?>
+                <?php foreach ( $glossary as $item ) { ?>
                     <?php include('glossary.php'); ?>
+                <?php } ?>
+                <hr>
+              <?php } ?>
+
+              <?php if ( isset($pid) && $wtt == 2 ) { ?>
+                <p>I want to <a href="https://www.writetothem.com/lords/?pid=<?= $pid ?>">write to <?= $wtt_lord_name ?></a></p>
+              <?php } ?>
+
+              <?php if ( isset($error) ) { ?>
+                There was an error &ndash; <?= $error ?> &ndash; searching for <em class="current-search-term"><?= _htmlentities($searchstring) ?></em>.
+              <?php } else { ?>
+                <h2>
+                  <?php if ( $pagination_links ) { ?>
+                    Results <?= $pagination_links['first_result'] ?>&ndash;<?= $pagination_links['last_result'] ?> of <?= $info['total_results'] ?>
+                  <?php } else if ( $info['total_results'] == 1 ) { ?>
+                    The only result
+                  <?php } else if ( $info['total_results'] == 0 ) { ?>
+                    There were no results
+                  <?php } else { ?>
+                    All <?= $info['total_results'] ?> results
+                  <?php } ?>
+                    for <em class="current-search-term"><?= _htmlentities($searchdescription) ?></em>
+                </h2>
+
+                  <?php if ( $info['spelling_correction'] ) { ?>
+                    <p>Did you mean <a href="/search/?q=<?= urlencode($info['spelling_correction']) ?>"><?= _htmlentities( $info['spelling_correction_display'] ) ?></a>?</p>
+                  <?php } ?>
+
+                  <?php if ( $info['total_results'] ) { ?>
+                    <ul class="search-result-display-options">
+                      <?php if ( $sort_order == 'relevance' ) { ?>
+                        <li>Sorted by relevance</li>
+                        <li>Sort by date: <a href="<?= $urls['newest'] ?>">newest</a> / <a href="<?= $urls['oldest'] ?>">oldest</a></li>
+                      <?php } else if ( $sort_order == 'oldest' ) { ?>
+                        <li>Sort by <a href="<?= $urls['relevance'] ?>">relevance</a></li>
+                        <li>Sorted by date: <a href="<?= $urls['newest'] ?>">newest</a> / oldest</li>
+                      <?php } else { ?>
+                        <li>Sort by <a href="<?= $urls['relevance'] ?>">relevance</a></li>
+                        <li>Sorted by date: newest / <a href="<?= $urls['oldest'] ?>">oldest</a></li>
+                      <?php } ?>
+                        <li><a href="<?= $urls['by-person'] ?>">Group by person</a></li>
+                    </ul>
+                  <?php } ?>
+
+                  <?php foreach ( $rows as $result ) { ?>
+                    <div class="search-result search-result--generic">
+                        <h3 class="search-result__title"><a href="<?= $result['listurl'] ?>"><?= $result['parent']['body'] ?></a> (<?= format_date($result['hdate'], SHORTDATEFORMAT) ?>)</h3>
+                        <p class="search-result__description"><?= isset($result['speaker']) ? $result['speaker']['name'] . ': ' : '' ?><?= $result['extract'] ?></p>
+                    </div>
                   <?php } ?>
 
                 <hr>
-                <?php } ?>
 
-                <?php if ( isset($pid) && $wtt == 2 ) { ?>
-                    <p>I want to <a href="https://www.writetothem.com/lords/?pid=<?= $pid ?>">write to <?= $wtt_lord_name ?></a></p>
-                <?php } ?>
-
-                <?php if ( isset($error) ) { ?>
-                    There was an error &ndash; <?= $error ?> &ndash; searching for <em class="current-search-term"><?= _htmlentities($searchstring) ?></em>.
-                <?php } else { ?>
-                    <h2>
-                    <?php if ( $pagination_links ) { ?>
-                    Results <?= $pagination_links['first_result'] ?>&ndash;<?= $pagination_links['last_result'] ?> of <?= $info['total_results'] ?>
-                    <?php } else if ( $info['total_results'] == 1 ) { ?>
-                    The only result
-                    <?php } else if ( $info['total_results'] == 0 ) { ?>
-                    There were no results
-                    <?php } else { ?>
-                    All <?= $info['total_results'] ?> results
-                    <?php } ?>
-                    for <em class="current-search-term"><?= _htmlentities($searchdescription) ?></em></h2>
-
-                    <?php if ( $info['spelling_correction'] ) { ?>
-                    <p>Did you mean <a href="/search/?q=<?= urlencode($info['spelling_correction']) ?>"><?= _htmlentities( $info['spelling_correction_display'] ) ?></a>?</p>
-                    <?php } ?>
-
-                    <?php if ( $info['total_results'] ) { ?>
-                    <ul class="search-result-display-options">
-                        <?php if ( $sort_order == 'relevance' ) { ?>
-                        <li>Sorted by relevance</li>
-                        <li>Sort by date: <a href="<?= $urls['newest'] ?>">newest</a> / <a href="<?= $urls['oldest'] ?>">oldest</a></li>
-                        <?php } else if ( $sort_order == 'oldest' ) { ?>
-                        <li>Sort by <a href="<?= $urls['relevance'] ?>">relevance</a></li>
-                        <li>Sorted by date: <a href="<?= $urls['newest'] ?>">newest</a> / oldest</li>
-                        <?php } else { ?>
-                        <li>Sort by <a href="<?= $urls['relevance'] ?>">relevance</a></li>
-                        <li>Sorted by date: newest / <a href="<?= $urls['oldest'] ?>">oldest</a></li>
-                        <?php } ?>
-                        <li><a href="<?= $urls['by-person'] ?>">Group by person</a></li>
-                    </ul>
-                    <?php } ?>
-
-                    <?php foreach ( $rows as $result ) { ?>
-                    <div class="search-result search-result--generic">
-                    <h3 class="search-result__title"><a href="<?= $result['listurl'] ?>"><?= $result['parent']['body'] ?></a> (<?= format_date($result['hdate'], SHORTDATEFORMAT) ?>)</h3>
-                        <p class="search-result__description"><?= isset($result['speaker']) ? $result['speaker']['name'] . ': ' : '' ?><?= $result['extract'] ?></p>
-                    </div>
-                    <?php } ?>
-
-                    <hr>
-
-                    <?php if ( $pagination_links ) { ?>
+                  <?php if ( $pagination_links ) { ?>
                     <div class="search-result-pagination">
-                        <?php if ( isset($pagination_links['prev']) ) { ?>
+                      <?php if ( isset($pagination_links['prev']) ) { ?>
                         <a href="<?= $pagination_links['firstpage']['url'] ?>" title="First page">&lt;&lt;</a>
                         <a href="<?= $pagination_links['prev']['url'] ?>" title="Previous page">&lt;</a>
-                        <?php }
-                        foreach ( $pagination_links['nums'] as $link ) { ?>
+                      <?php } ?>
+                      <?php foreach ( $pagination_links['nums'] as $link ) { ?>
                         <a href="<?= $link['url'] ?>"<?= $link['current'] ? ' class="search-result-pagination__current-page"' : '' ?>><?= $link['page'] ?></a>
-                        <?php }
-                        if ( isset($pagination_links['next']) ) { ?>
+                      <?php } ?>
+                      <?php if ( isset($pagination_links['next']) ) { ?>
                         <a href="<?= $pagination_links['next']['url'] ?>" title="Next page">&gt;</a>
                         <a href="<?= $pagination_links['lastpage']['url'] ?>" title="Final page">&gt;&gt;</a>
-                        <?php } ?>
+                      <?php } ?>
                     </div>
-                    <?php } ?>
-                <?php } ?>
+                  <?php } ?>
+              <?php } # end of !isset($error) ?>
             </div>
 
             <?php include 'sidebar.php' ?>
         </div>
-        <?php } ?>
+      <?php } ?>
 
         <form class="js-search-form-with-options">
             <?php include 'form_main.php'; ?>

--- a/www/includes/easyparliament/templates/html/search/results.php
+++ b/www/includes/easyparliament/templates/html/search/results.php
@@ -1,7 +1,9 @@
 <div class="full-page">
     <div class="full-page__row search-page <?php if ( !$searchstring ) { ?>search-page--blank<?php } ?>">
 
-        <?php include 'form.php'; ?>
+        <form class="js-search-form-without-options">
+            <?php include 'form_main.php'; ?>
+        </form>
 
         <?php if ( $searchstring && !isset($warnings) ) { ?>
         <div class="search-page__section search-page__section--results">
@@ -115,6 +117,11 @@
             <?php include 'sidebar.php' ?>
         </div>
         <?php } ?>
+
+        <form class="js-search-form-with-options">
+            <?php include 'form_main.php'; ?>
+            <?php include 'form_options.php'; ?>
+        </form>
 
     </div>
 </div>


### PR DESCRIPTION
Fixes #1001.

The FOUC is basically fixed by just the addition of [these 4 lines of CSS](https://github.com/mysociety/theyworkforyou/blob/7f6f1ae0e5de03ab4c2e51c01c2690e01dcf6932/www/docs/style/sass/pages/_search.scss#L64-L66) and the removal of [this line of JavaScript](https://github.com/mysociety/theyworkforyou/commit/898e27481ef40db92be5efbd9cd754a409821002#diff-96906dac833d9062f945ce65fb284a39L157).

But we also took the opportunity to improve the UX for users without JavaScript enabled (moving the advanced search inputs to the end of the page by default), and to tidy up the indentation in the search templates.

Unlike https://github.com/mysociety/theyworkforyou/issues/1034, there is no way for non-javascript users to show and hide the advanced options – they are just *always* visible at the end of the page.