### PR TITLE
Better position in header; searching of offices

### DIFF
--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -250,12 +250,6 @@ $former_offices = $MEMBER->offices('previous', TRUE);
 // If this person has named non-committee offices, they override the default
 if (count($current_offices) > 0) {
     $position = $current_offices[0];
-} elseif (count($former_offices) > 0) {
-    # only use the position if it's current, i.e.
-    # it does not have an end date
-    if (!$former_offices[0]->to_date) {
-        $position = $former_offices[0];
-    }
 }
 
 // Finally, if this is a Votes page, replace the page description with

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -219,49 +219,39 @@ if ($MEMBER->house(HOUSE_TYPE_SCOTLAND)) {
     $title .= ' MSP, '.$MEMBER->constituency();
 }
 
+$positions = array();
+
 // Position if this is a member of the Commons
 if ($MEMBER->house(HOUSE_TYPE_COMMONS)) {
-    if (!$MEMBER->current_member(1)) {
-        $position_former = 'Former MP';
-        if ($MEMBER->constituency()) $position_former .= ', ' . $MEMBER->constituency();
-    } else {
-        $position_current = 'MP';
-        if ($MEMBER->constituency()) $position_current .= ', ' . $MEMBER->constituency();
-    }
+    $position = $MEMBER->current_member(HOUSE_TYPE_COMMONS) ? 'MP' : 'Former MP';
+    if ($MEMBER->constituency()) $position .= ', ' . $MEMBER->constituency();
+    $positions[] = $position;
 }
 
 // Position if this is a member of NIA
 if ($MEMBER->house(HOUSE_TYPE_NI)) {
-    if (!$MEMBER->current_member(HOUSE_TYPE_NI)) {
-        $position_former = 'Former MLA';
-        if ($MEMBER->constituency()) $position_former .= ', ' . $MEMBER->constituency();
-    } else {
-        $position_current = 'MLA';
-        if ($MEMBER->constituency()) $position_current .= ', ' . $MEMBER->constituency();
-    }
+    $position = $MEMBER->current_member(HOUSE_TYPE_NI) ? 'MLA' : 'Former MLA';
+    if ($MEMBER->constituency()) $position .= ', ' . $MEMBER->constituency();
+    $positions[] = $position;
 }
 
 // Position if this is a member of Scottish Parliament
 if ($MEMBER->house(HOUSE_TYPE_SCOTLAND)) {
-    if (!$MEMBER->current_member(HOUSE_TYPE_SCOTLAND)) {
-        $position_former = 'Former MSP';
-    } else {
-        $position_current = 'MSP, '.$MEMBER->constituency();
-    }
+    $position = $MEMBER->current_member(HOUSE_TYPE_SCOTLAND) ? 'MSP' : 'Former MSP';
+    $position .= ', ' . $MEMBER->constituency();
+    $positions[] = $position;
 }
+
+$position = implode('; ', $positions);
 
 $current_offices = $MEMBER->offices('current', TRUE);
 $former_offices = $MEMBER->offices('previous', TRUE);
 
-// If this person has current named *priority* offices, they override the defaults
-
-if (count($current_offices) > 0){
-    $position_current = implode('<br>', $current_offices);
-}
-
-// If this person has former named *priority* offices, they override the defaults
-if (count($former_offices) > 0){
-    $position_former = implode('<br>', $former_offices);
+// If this person has named non-committee offices, they override the default
+if (count($current_offices) > 0) {
+    $position = $current_offices[0];
+} elseif (count($former_offices) > 0) {
+    $position = $former_offices[0];
 }
 
 // Finally, if this is a Votes page, replace the page description with
@@ -285,17 +275,7 @@ $data['full_name'] = $MEMBER->full_name();
 $data['person_id'] = $MEMBER->person_id();
 $data['member_id'] = $MEMBER->member_id();
 
-if (isset($position_current)) {
-    $data['current_position'] = $position_current;
-} else {
-    $data['current_position'] = NULL;
-}
-
-if (isset($position_former)) {
-    $data['former_position'] = $position_former;
-} else {
-    $data['former_position'] = NULL;
-}
+$data['header_position'] = $position;
 
 $data['constituency'] = $MEMBER->constituency();
 $data['party'] = $MEMBER->party_text();

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -251,7 +251,11 @@ $former_offices = $MEMBER->offices('previous', TRUE);
 if (count($current_offices) > 0) {
     $position = $current_offices[0];
 } elseif (count($former_offices) > 0) {
-    $position = $former_offices[0];
+    # only use the position if it's current, i.e.
+    # it does not have an end date
+    if (!$former_offices[0]->to_date) {
+        $position = $former_offices[0];
+    }
 }
 
 // Finally, if this is a Votes page, replace the page description with

--- a/www/includes/easyparliament/member.php
+++ b/www/includes/easyparliament/member.php
@@ -361,7 +361,7 @@ class MEMBER {
         }
         $this->extra_info = array();
 
-        $q = $this->db->query('SELECT * FROM moffice WHERE person=:person_id ORDER BY from_date DESC',
+        $q = $this->db->query('SELECT * FROM moffice WHERE person=:person_id ORDER BY from_date DESC, moffice_id',
                               array(':person_id' => $this->person_id));
         for ($row=0; $row<$q->rows(); $row++) {
             $this->extra_info['office'][] = $q->row($row);

--- a/www/includes/easyparliament/templates/html/mp/header.php
+++ b/www/includes/easyparliament/templates/html/mp/header.php
@@ -12,10 +12,8 @@
                           <?php } ?>
                             <div class="mp-name-and-position">
                                 <h1><?= $full_name ?></h1>
-                              <?php if ($current_position) { ?>
-                                 <p><?= $current_position ?></p>
-                              <?php } else if ($former_position) { ?>
-                                 <p><?= $former_position ?></p>
+                              <?php if ($header_position) { ?>
+                                 <p><?= $header_position ?></p>
                               <?php } ?>
                             </div>
                         </div>

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -933,15 +933,19 @@ function prettify_office($pos, $dept) {
             => 'Minister for energy, Department of Trade and Industry',
         'Minister of State (Pensions), Department for Work and Pensions'
             => 'Minister for pensions, Department for Work and Pensions',
-        'Parliamentary Secretary to the Treasury, HM Treasury'
-            => 'Chief Whip (technically Parliamentary Secretary to the Treasury)',
-        "Treasurer of Her Majesty's Household, HM Household"
-            => "Deputy Chief Whip (technically Treasurer of Her Majesty's Household)",
-        'Comptroller, HM Household' => 'Government Whip (technically Comptroller, HM Household)',
-        'Vice Chamberlain, HM Household' => 'Government Whip (technically Vice Chamberlain, HM Household)',
-        'Lords Commissioner, HM Treasury' => 'Government Whip (technically a Lords Commissioner, HM Treasury)',
-        'Assistant Whip, HM Treasury' => 'Assistant Whip (funded by HM Treasury)',
-        'Lords in Waiting, HM Household' => 'Government Whip (technically a Lord in Waiting, HM Household)',
+        'Parliamentary Secretary to the Treasury, HM Treasury' => 'Chief Whip',
+        'The Parliamentary Secretary to the Treasury' => 'Chief Whip',
+        "Treasurer of Her Majesty's Household, HM Household" => "Deputy Chief Whip",
+        "The Treasurer of Her Majesty's Household, HM Household" => "Deputy Chief Whip",
+        'Comptroller, HM Household' => 'Government Whip',
+        'Vice Chamberlain, HM Household' => 'Government Whip',
+        "The Vice-Chamberlain of Her Majesty's Household" => 'Government Whip',
+        'Lords Commissioner, HM Treasury' => 'Government Whip',
+        "The Lord Commissioner of Her Majesty's Treasury" => 'Government Whip',
+        'Assistant Whip, HM Treasury' => 'Assistant Whip',
+        'Lords in Waiting, HM Household' => 'Government Whip',
+        'Lords in Waiting (HM Household)' => 'Government Whip',
+        'Baronesses in Waiting, HM Household' => 'Government Whip',
     );
     if ($pos) { # Government post, or Chairman of Select Committee
         $pretty = $pos;


### PR DESCRIPTION
This fixes #1056, and starts on #1055 (it does a search of any office positions ordered by from date descending, so you now get too much and it doesn't push exact matches to the top, so JH is at least there, but fifth).
