### PR TITLE
Fix party stance text for single member parties

### DIFF
--- a/classes/Party.php
+++ b/classes/Party.php
@@ -27,6 +27,28 @@ class Party {
         $this->db = new \ParlDB;
     }
 
+    public function getCurrentMemberCount($house) {
+        $member_count = $this->db->query(
+            "SELECT count(*) as num_members
+            FROM member
+            WHERE
+                party = :party
+                AND house = :house
+                AND entered_house <= :date
+                AND left_house >= :date",
+            array(
+                ':party' => $this->name,
+                ':house' => $house,
+                ':date' => date('Y-m-d'),
+            )
+        );
+        if ( $member_count->rows ) {
+            $num_members = $member_count->field(0, 'num_members');
+            return $num_members;
+        } else {
+            return 0;
+        }
+    }
 
     public function getAllPolicyPositions($policies) {
         $positions = $this->fetchPolicyPositionsByMethod($policies, "policy_position");

--- a/tests/PartyTest.php
+++ b/tests/PartyTest.php
@@ -26,6 +26,11 @@ class PartyTest extends FetchPageTestCase
         $this->assertEquals( 'A Party', $party->name );
     }
 
+    public function testCountMembers() {
+        $party = new MySociety\TheyWorkForYou\Party('A Party');
+        $this->assertEquals( $party->getCurrentMemberCount(HOUSE_TYPE_COMMONS), 2 );
+    }
+
     public function testGetPolicyPositions() {
         $positions = $this->getAllPositions('getAllPolicyPositions');
 
@@ -90,7 +95,7 @@ class PartyTest extends FetchPageTestCase
     public function testGetAllParties() {
         $parties = MySociety\TheyWorkForYou\Party::getParties();
 
-        $expected = array('A Party', 'Labour', 'Labour/Co-operative');
+        $expected = array('A Party', 'Labour', 'Labour/Co-operative', 'A Second Party');
 
         $this->assertEquals($expected, $parties);
     }
@@ -132,6 +137,13 @@ class PartyTest extends FetchPageTestCase
         $this->assertContains('Test Current-MP', $page);
         $this->assertContains('is a A Party MP', $page);
         $this->assertContains('sometimes <b>differs</b> from their party', $page);
+    }
+
+    public function testSingleMemberPartyPolicyText()
+    {
+        $page = $this->fetch_page( array( 'pid' => 7, 'url' => '/mp/7/test_second-party-mp/test_westminster_constituency' ) );
+        $this->assertContains('Test Second-Party-MP', $page);
+        $this->assertNotContains('is a A Second Party MP', $page);
     }
 
     public function testMPPartyPolicyWherePartyMissingPositions()

--- a/tests/_fixtures/party.xml
+++ b/tests/_fixtures/party.xml
@@ -129,6 +129,18 @@
 			<field name="person_id">7</field>
 			<field name="lastupdate">2013-08-07 15:06:19</field>
 		</row>
+		<row>
+			<field name="member_id">7</field>
+			<field name="house">1</field>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="party">A Second Party</field>
+			<field name="entered_house">2000-01-01</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">7</field>
+			<field name="lastupdate">2013-08-07 15:06:19</field>
+		</row>
 	</table_data>
 	<table_data name="person_names">
 		<row>
@@ -177,6 +189,14 @@
 			<field name="start_date">2000-01-01</field>
 			<field name="end_date">9999-12-31</field>
 			<field name="person_id">6</field>
+			<field name="title">Miss</field>
+		</row>
+		<row>
+			<field name="given_name">Test</field>
+			<field name="family_name">Second-Party-MP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">7</field>
 			<field name="title">Miss</field>
 		</row>
 	</table_data>
@@ -2435,6 +2455,21 @@
             <field name="data_key">public_whip_dreammp6704_has_strong_vote</field>
             <field name="data_value">1</field>
         </row>
+        <row>
+          <field name="person_id">7</field>
+          <field name="data_key">public_whip_dreammp363_distance</field>
+          <field name="data_value">0.77</field>
+        </row>
+        <row>
+          <field name="person_id">7</field>
+          <field name="data_key">public_whip_dreammp363_both_voted</field>
+          <field name="data_value">1</field>
+        </row>
+        <row>
+          <field name="person_id">7</field>
+          <field name="data_key">public_whip_dreammp363_has_strong_vote</field>
+          <field name="data_value">1</field>
+        </row>
 	</table_data>
 	<table_data name="policies">
       <row>
@@ -2496,6 +2531,12 @@
   <table_data name="partypolicy">
       <row>
           <field name="party">A Party</field>
+          <field name="policy_id">363</field>
+          <field name="house">1</field>
+          <field name="score">0.9</field>
+      </row>
+      <row>
+          <field name="party">A Second Party</field>
           <field name="policy_id">363</field>
           <field name="house">1</field>
           <field name="score">0.9</field>

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -477,6 +477,9 @@ switch ($pagetype) {
         $policy_diffs = $MEMBER->getPartyPolicyDiffs($party, $policiesList, $positions, true);
 
         $data['sorted_diffs'] = $policy_diffs;
+        # house hard coded as this is only used for the party position
+        # comparison which is Commons only
+        $data['party_member_count'] = $party->getCurrentMemberCount(HOUSE_TYPE_COMMONS);
         $data['party_positions'] = $party_positions;
         $data['positions'] = $positions->positionsById;
         $data['policies'] = $policiesList->getPolicies();

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -80,7 +80,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                     <h2 data-magellan-destination="votes"><?= $full_name ?>&rsquo;s voting in Parliament</h2>
 
 
-                    <?php if (count($sorted_diffs) > 0): ?>
+                    <?php if (count($sorted_diffs) > 0 && $party_member_count > 1): ?>
 
                         <p>
                         <?= $full_name ?> is a <?= $party ?> MP, and on the <b>vast majority</b> of issues votes the <b>same way</b> as other <?= $party ?> MPs.
@@ -102,12 +102,11 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                         <p>We have <b>lots more</b> plain English analysis of <?= $full_name ?>&rsquo;s voting record  on issues like health, welfare, taxation and more. Visit <a href="<?= $member_url ?>/votes"><?= $full_name ?>&rsquo;s full vote analysis page</a> for more.</p>
 
                     <?php elseif (count($policyPositions->positions) > 0 ): ?>
-                        <?php if (count($party_positions)) { ?>
+                        <?php if (count($party_positions) && $party_member_count > 1) { ?>
                         <p>
                         <?= $full_name ?> is a <?= $party ?> MP, and on the <b>vast majority</b> of issues votes the <b>same way</b> as other <?= $party ?> MPs.
                         </p>
                         <?php } ?>
-
 
                         <p>
                         This is a selection of <?= $full_name ?>&rsquo;s votes.


### PR DESCRIPTION
Add a getCurrentMemberCount method to party class and use that to check
if a party has only one member, and if so do not print a differs
from/votes the same as bit.

Fixes #1019