### PR TITLE
Add Contact link to main nav

### DIFF
--- a/classes/Renderer/Header.php
+++ b/classes/Renderer/Header.php
@@ -240,10 +240,10 @@ class Header
         // we're within that section.
         $nav_items = array (
             array('home'),
-            array('hansard', 'mps', 'peers', 'alldebatesfront', 'wranswmsfront', 'pbc_front', 'calendar_summary'),
-            array('sp_home', 'spoverview', 'msps', 'spdebatesfront', 'spwransfront'),
-            array('ni_home', 'nioverview', 'mlas'),
-            array('wales_home'),
+            array('hansard', 'mps', 'peers', 'alldebatesfront', 'wranswmsfront', 'pbc_front', 'calendar_summary', 'contact'),
+            array('sp_home', 'spoverview', 'msps', 'spdebatesfront', 'spwransfront', 'contact'),
+            array('ni_home', 'nioverview', 'mlas', 'contact'),
+            array('wales_home', 'contact'),
         );
 
         $this->data['assembly_nav_links'] = array();

--- a/www/docs/style/sass/layout/_header.scss
+++ b/www/docs/style/sass/layout/_header.scss
@@ -129,6 +129,7 @@ $site-header-height: 48px;
     &:before {
         content: "";
         display: block;
+        font-size: 18px;
         border: 0.4em solid transparent;
         border-top-color: $colour_mid_grey;
         float: right;
@@ -184,6 +185,7 @@ $site-header-height: 48px;
         display: table-cell;
         vertical-align: top;
         width: 100%; // occupy as much space as is left over after the logo
+        font-size: 16px; // slightly narrower text, now it's all lined up horizontally
 
         // Yes, even if the nav was hidden by javascript
         // in mobile mode, we want to show it again now.

--- a/www/includes/easyparliament/metadata.php
+++ b/www/includes/easyparliament/metadata.php
@@ -305,6 +305,10 @@ $this->page = array (
     ),
 
     'contact' => array (
+        'menu'			=> array (
+            'text'			=> 'Contact',
+            'title'			=> '',
+        ),
         'title'			=> 'Contact',
         'url'			=> 'contact/'
     ),


### PR DESCRIPTION
Fixes #1053.

Nav text is now 16px rather than 18px, to make room for the extra menu item.

![screen shot 2016-04-04 at 10 54 29](https://cloud.githubusercontent.com/assets/739624/14244568/b3192b8c-fa53-11e5-90af-11b1beed3cc6.png)