### PR TITLE
stop duplication of speaker: part of search strings

### DIFF
--- a/classes/Search.php
+++ b/classes/Search.php
@@ -122,7 +122,6 @@ class Search {
         $urls = array();
 
         $url = new \URL($this_page);
-        $url->insert(array('q' => $this->searchstring));
         $url->insert(array('o' => 'r'));
         $urls['relevance'] = $url->generate();
         $url->insert(array('o' => 'o'));


### PR DESCRIPTION
The URL creation already pulls in the search string so we don't need to
re-add it, especially as doing so means on the next page the pid is
added again.

Fixes #1105