### PR TITLE
WIP display MP's EU referendum stance on profile page

### DIFF
--- a/classes/Member.php
+++ b/classes/Member.php
@@ -110,6 +110,15 @@ class Member extends \MEMBER {
         return $date_entered;
     }
 
+
+    public function getEUStance() {
+        if (array_key_exists('eu_ref_stance', $this->extra_info())) {
+            return $this->extra_info()['eu_ref_stance'];
+        }
+
+        return FALSE;
+    }
+
     /**
     * Image
     *

--- a/scripts/mpinfoin.pl
+++ b/scripts/mpinfoin.pl
@@ -20,6 +20,8 @@ use LWP::UserAgent;
 use HTML::Entities;
 use Data::Dumper;
 use Syllable;
+use JSON;
+use File::Slurp;
 
 use vars qw(@policyids);
 
@@ -42,6 +44,8 @@ foreach (@ARGV) {
         $action{'rankings'} = 1;
     } elsif ($_ eq 'speaker_candidates') {
         $action{'speaker_candidates'} = 1;
+    } elsif ($_ eq 'eu_ref_position') {
+        $action{'eu_ref_position'} = 1;
     } elsif ($_ eq 'verbose') {
         $verbose = 1;
     } else {
@@ -57,6 +61,7 @@ if (scalar(@ARGV) == 0) {
     $action{'wtt'} = 1;
     $action{'rankings'} = 1;
     $action{'speaker_candidates'} = 1;
+    $action{'eu_ref_position'} = 1;
 }
 
 # Fat old hashes intotwixt all the XML is loaded and colated before being squirted to the DB
@@ -162,6 +167,13 @@ if ($action{'expenses'}) {
     $twig->parsefile($pwmembers . "expenses200203.xml", ErrorContext => 2);
     $twig->parsefile($pwmembers . "expenses200102.xml", ErrorContext => 2);
     makerankings_expenses();
+}
+
+if ($action{'eu_ref_position'}) {
+    my $positions = decode_json(read_file($pwmembers . 'eu_ref_positions.json'));
+    foreach my $id (keys(%{$positions})) {
+        $personinfohash->{$id}->{'eu_ref_stance'} = $positions->{$id};
+    }
 }
 
 # Get any data from the database

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -319,6 +319,7 @@ $data['topics_of_interest'] = person_topics($MEMBER);
 $data['current_offices'] = $MEMBER->offices('current');
 $data['previous_offices'] = $MEMBER->offices('previous');
 $data['register_interests'] = person_register_interests($MEMBER, $MEMBER->extra_info);
+$data['eu_stance'] = $MEMBER->getEUStance();
 
 # People who are or were MPs and Lords potentially have voting records, except Sinn Fein MPs
 $data['has_voting_record'] = ( ($MEMBER->house(HOUSE_TYPE_COMMONS) && $MEMBER->party() != 'SF') || $MEMBER->house(HOUSE_TYPE_LORDS) );

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -44,15 +44,21 @@ $display_wtt_stats_banner = '2015';
             </div>
             <div class="primary-content__unit">
 
-              <?php if (array_key_exists($display_wtt_stats_banner, $wtt_strings)): ?>
+              <?php if ($eu_stance): ?>
                 <div class="panel panel--responsiveness">
                     <a name="responsiveness"></a>
-                    <h2>Does <strong><?= $full_name ?></strong> respond to constituents&rsquo; emails?</h2>
+                    <h2>
+                        <? if ($eu_stance == 'Leave' || $eu_stance == 'Remain') { ?>
+                        <strong><?= $full_name ?></strong> campaigned to <?= $eu_stance == 'Leave' ? 'leave' : 'remain in' ?> the European Union
+                        <? } else { ?>
+                        We don't know whether <strong><?= $full_name ?></strong> campaigned to leave, or stay in the European Union
+                        <? } ?>
+                    </h2>
                     <p>
-                        According to our <?= $display_wtt_stats_banner ?> survey, <?= $full_name ?> responded to a
-                        <strong><?= $wtt_strings[$display_wtt_stats_banner] ?></strong> proportion of messages
-                        sent by constituents on WriteToThem.com.
-                        <a href="https://www.writetothem.com/stats/<?= $display_wtt_stats_banner ?>/zeitgeist">See the results in context</a>
+                        Let your MP know how <em>you</em> feel - <a href="https://www.writetothem.com/<?php
+                                if ($the_users_mp) {
+                                    echo "?a=WMC&amp;pc=" . _htmlentities(urlencode($user_postcode));
+                                } ?>" onclick="trackLinkClick(this, 'Links', 'WriteToThem', 'Person'); return false;"><img src="/style/img/envelope.png">email them now</a>.
                     </p>
                 </div>
               <?php endif; ?>


### PR DESCRIPTION
Replace the WTT stats banner with one that displays how an MP campaigned in the EU referendum along with a link to contact your MP using WTT. If the page is for the user's MP then we link directly to that page on WTT, otherwise the front page.

Uses the BBC's data on how MP's campaigned/stood in the EU referendum.

Fixes #1112