### PR TITLE
Acknowledge browserstack in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,8 @@ and located at `/vendor/bin/phpunit` should run correctly.
 [![Scrutinizer Quality Score](https://img.shields.io/scrutinizer/g/mysociety/theyworkforyou.svg)](https://scrutinizer-ci.com/g/mysociety/theyworkforyou/)
 
 [![mySociety Installability](http://img.shields.io/badge/installability-bronze-8c7853.svg)](http://mysociety.github.io/installation-standards.html)
+
+## Acknowledgements
+
+Thanks to [Browserstack](https://www.browserstack.com/) who let us use their
+web-based cross-browser testing tools for this project.


### PR DESCRIPTION
Browserstack gives us free cross-browser / cross-device testing, in exchange for an acknowledgement in the README of projects for which we use it.

I just noticed, the TheyWorkForYou README is missing the acknowledgement.