### PR TITLE
remove expenses explantion and just show links

### DIFF
--- a/classes/Member.php
+++ b/classes/Member.php
@@ -110,6 +110,26 @@ class Member extends \MEMBER {
         return $date_entered;
     }
 
+    /*
+     * Get the date the person last left the house.
+     *
+     * @param int house - identifier for the house, defaults to 1 for westminster
+     *
+     * @return string - 9999-12-31 if they are still in that house otherwise in YYYY-MM-DD format
+     */
+
+    public function getLeftDate($house = 1) {
+        $date_left = '';
+
+        $left_house = $this->left_house($house);
+
+        if ( $left_house ) {
+            $date_left = $left_house['date'];
+        }
+
+        return $date_left;
+    }
+
 
     public function getEUStance() {
         if (array_key_exists('eu_ref_stance', $this->extra_info())) {

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -316,6 +316,7 @@ $data['image'] = $MEMBER->image();
 $data['member_summary'] = person_summary_description($MEMBER);
 $data['enter_leave'] = $MEMBER->getEnterLeaveStrings();
 $data['entry_date'] = $MEMBER->getEntryDate();
+$data['leave_date'] = $MEMBER->getLeftDate();
 $data['is_new_mp'] = $MEMBER->isNew();
 $data['other_parties'] = $MEMBER->getOtherPartiesString();
 $data['other_constituencies'] = $MEMBER->getOtherConstituenciesString();
@@ -332,14 +333,19 @@ $data['eu_stance'] = $MEMBER->getEUStance();
 $data['has_voting_record'] = ( ($MEMBER->house(HOUSE_TYPE_COMMONS) && $MEMBER->party() != 'SF') || $MEMBER->house(HOUSE_TYPE_LORDS) );
 # Everyone who is currently somewhere has email alert signup, apart from current Sinn Fein MPs who are not MLAs
 $data['has_email_alerts'] = ($MEMBER->current_member_anywhere() && !($MEMBER->current_member(HOUSE_TYPE_COMMONS) && $MEMBER->party() == 'SF' && !$MEMBER->current_member(HOUSE_TYPE_NI)));
-# XXX This is current behaviour, but should probably now just be any recent MP
-$data['has_expenses'] = isset($MEMBER->extra_info['expenses2004_col1']) || isset($MEMBER->extra_info['expenses2006_col1']) || isset($MEMBER->extra_info['expenses2007_col1']) || isset($MEMBER->extra_info['expenses2008_col1']);
+$data['has_expenses'] = $data['leave_date'] > '2004-01-01';
 
-// Set the expenses URL if we know it
-if (isset($MEMBER->extra_info['expenses_url'])) {
-    $data['expenses_url_2004'] = $MEMBER->extra_info['expenses_url'];
-} else {
-    $data['expenses_url_2004'] = 'http://mpsallowances.parliament.uk/mpslordsandoffices/hocallowances/allowances%2Dby%2Dmp/';
+$data['pre_2010_expenses'] = False;
+$data['post_2010_expenses'] = $data['leave_date'] > '2010-05-05';
+
+if ($data['entry_date'] < '2010-05-05') {
+    $data['pre_2010_expenses'] = True;
+    // Set the expenses URL if we know it
+    if (isset($MEMBER->extra_info['expenses_url'])) {
+        $data['expenses_url_2004'] = $MEMBER->extra_info['expenses_url'];
+    } else {
+        $data['expenses_url_2004'] = 'http://mpsallowances.parliament.uk/mpslordsandoffices/hocallowances/allowances%2Dby%2Dmp/';
+    }
 }
 
 $data['constituency_previous_mps'] = constituency_previous_mps($MEMBER);

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -242,14 +242,13 @@ $display_wtt_stats_banner = '2015';
                     <?php if ($has_expenses): ?>
                     <h3>Expenses</h3>
 
-                    <p>Expenses data for MPs is available from 2004 onwards
-split over several locations. At the moment we don't have the time to convert
-it to a format we can display on the site so we just have to point you to where
-you can find it.</p>
-
                     <ul>
+                        <?php if ($pre_2010_expenses): ?>
                         <li><a href="<?= $expenses_url_2004 ?>">Expenses from 2004 to 2009</a></li>
+                        <?php endif; ?>
+                        <?php if ($post_2010_expenses): ?>
                         <li><a href="http://www.parliamentary-standards.org.uk/AnnualisedData.aspx">Expenses from 2010 onwards</a></li>
+                        <?php endif; ?>
                     </ul>
                     <?php endif; ?>
 


### PR DESCRIPTION
Instead of explaining why we don't have expenses for an MP just link to
the information. Also fix it so we only link to the relevant
information.

Fixes #313