### PR TITLE
Update TWFY to use UTF-8

### DIFF
--- a/classes/Renderer.php
+++ b/classes/Renderer.php
@@ -83,7 +83,7 @@ class Renderer
         ////////////////////////////////////////////////////////////
         // Require the templates and output
 
-        header('Content-Type: text/html; charset=iso-8859-1');
+        header('Content-Type: text/html; charset=utf-8');
         require_once INCLUDESPATH . 'easyparliament/templates/html/header.php';
         require_once INCLUDESPATH . 'easyparliament/templates/html/' . $template . '.php';
         require_once INCLUDESPATH . 'easyparliament/templates/html/footer.php';

--- a/classes/Search/ParseArgs.php
+++ b/classes/Search/ParseArgs.php
@@ -127,14 +127,6 @@ class ParseArgs {
             $searchstring = $search_main;
         }
 
-        $searchstring_conv = @iconv('UTF-8', 'ISO-8859-1//TRANSLIT', $searchstring);
-        if (!$searchstring_conv) {
-            $searchstring_conv = @iconv('Windows-1252', 'ISO-8859-1//TRANSLIT', $searchstring);
-        }
-        if ($searchstring_conv) {
-            $searchstring = $searchstring_conv;
-        }
-
         return $searchstring;
     }
 

--- a/scripts/daily-api-usage.php
+++ b/scripts/daily-api-usage.php
@@ -56,7 +56,7 @@ if (!$out) exit;
 
 $headers =
     "From: TheyWorkForYou <" . CONTACTEMAIL . ">\r\n" .
-    "Content-Type: text/html; charset=iso-8859-1\r\n" .
+    "Content-Type: text/html; charset=utf-8\r\n" .
     "MIME-Version: 1.0\r\n" .
     "Content-Transfer-Encoding: 8bit\r\n";
 $subject = 'Daily TheyWorkForYou API usage';

--- a/scripts/future-fetch.py
+++ b/scripts/future-fetch.py
@@ -112,11 +112,11 @@ class Entry(object):
             self.link_calendar, self.link_external,
             self.body, self.chamber,
             self.event_date, self.time_start, self.time_end,
-            self.committee_name.encode('iso-8859-1', 'xmlcharrefreplace'),
-            self.debate_type.encode('iso-8859-1', 'xmlcharrefreplace'),
-            self.title.encode('iso-8859-1', 'xmlcharrefreplace'),
-            self.witnesses_str.encode('iso-8859-1', 'xmlcharrefreplace'),
-            self.location.encode('iso-8859-1', 'xmlcharrefreplace'),
+            self.committee_name,
+            self.debate_type,
+            self.title,
+            self.witnesses_str,
+            self.location,
             )
 
     def add(self):

--- a/scripts/json2db.pl
+++ b/scripts/json2db.pl
@@ -30,7 +30,7 @@ require 'policyids.pl';
 my $json = JSON::XS->new->latin1;
 
 my $dsn = 'DBI:mysql:database=' . mySociety::Config::get('TWFY_DB_NAME'). ':host=' . mySociety::Config::get('TWFY_DB_HOST');
-my $dbh = DBI->connect($dsn, mySociety::Config::get('TWFY_DB_USER'), mySociety::Config::get('TWFY_DB_PASS'), { RaiseError => 1, PrintError => 0 });
+my $dbh = DBI->connect($dsn, mySociety::Config::get('TWFY_DB_USER'), mySociety::Config::get('TWFY_DB_PASS'), { RaiseError => 1, PrintError => 0, , mysql_enable_utf8 => 1 });
 
 my $policycheck = $dbh->prepare("SELECT policy_id from policies where policy_id = ?");
 my $policyadd = $dbh->prepare("INSERT INTO policies (policy_id, title, description) VALUES (?, ?, ?)");
@@ -94,8 +94,7 @@ foreach my $dreamid ( @policyids ) {
             next;
         }
 
-        # JSON is UTF-8, the database and TWFY are not
-        my $text = Encode::encode( 'iso-8859-1', $motion->{motion}->{text} );
+        my $text = $motion->{motion}->{text};
         my $curr_motion = $dbh->selectrow_hashref($motioncheck, {}, $motion_id, $dreamid);
 
         if ( $curr_motion ) {
@@ -107,8 +106,8 @@ foreach my $dreamid ( @policyids ) {
         my $yes_text = '';
         my $no_text = '';
         if ( $motion->{motion}->{actions} ) {
-            $yes_text = Encode::encode( 'iso-8859-1', $motion->{motion}->{actions}->{yes} );
-            $no_text = Encode::encode( 'iso-8859-1', $motion->{motion}->{actions}->{no} );
+            $yes_text = $motion->{motion}->{actions}->{yes};
+            $no_text = $motion->{motion}->{actions}->{no};
         }
 
         if ( !defined $curr_motion ) {

--- a/scripts/load-people
+++ b/scripts/load-people
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use utf8;
 
 # Loads JSON member files into TheyWorkForYou.
 # The JSON files are stored in files here:
@@ -56,7 +57,7 @@ my ($dbh, $memberadd, $memberexist, $membercheck, $nameadd, $nameupdate, $namefe
 sub db_connect {
     #DBI->trace(1);
     my $dsn = 'DBI:mysql:database=' . mySociety::Config::get('TWFY_DB_NAME'). ':host=' . mySociety::Config::get('TWFY_DB_HOST');
-    $dbh = DBI->connect($dsn, mySociety::Config::get('TWFY_DB_USER'), mySociety::Config::get('TWFY_DB_PASS'), { RaiseError => 1, PrintError => 0 });
+    $dbh = DBI->connect($dsn, mySociety::Config::get('TWFY_DB_USER'), mySociety::Config::get('TWFY_DB_PASS'), { RaiseError => 1, PrintError => 0, mysql_enable_utf8 => 1 });
 
     $memberadd = $dbh->prepare("replace into member (member_id, person_id, house,
         constituency, party, entered_house, left_house, entered_reason, left_reason)
@@ -125,7 +126,7 @@ sub load_constituencies {
             next if $seen{$Collator->getSortKey($name)};
             $constituencyadd->execute(
                 $consid,
-                Encode::encode('iso-8859-1', $name),
+                $name,
                 $main_name,
                 $start_date,
                 $end_date,
@@ -226,9 +227,9 @@ sub load_names {
         push @names, [
             $id,
             $name->{honorific_prefix} || '',
-            Encode::encode('iso-8859-1', $name->{given_name}),
-            Encode::encode('iso-8859-1', $name->{lordname} // $name->{family_name}),
-            Encode::encode('iso-8859-1', $name->{lordofname} // ''),
+            $name->{given_name},
+            $name->{lordname} // $name->{family_name},
+            $name->{lordofname} // '',
             $start_date, $end_date,
         ];
     }
@@ -254,10 +255,6 @@ sub db_memberadd {
 
     my $q = $memberexist->execute($id);
     die "More than one existing member of same id $id" if $q > 1;
-
-    for (3..4) {
-        $params[$_] = Encode::encode('iso-8859-1', $params[$_]);
-    }
 
     if ($q == 1) {
         # Member already exists, check they are the same

--- a/scripts/mpinfoin.pl
+++ b/scripts/mpinfoin.pl
@@ -178,7 +178,7 @@ if ($action{'eu_ref_position'}) {
 
 # Get any data from the database
 my $dsn = 'DBI:mysql:database=' . mySociety::Config::get('TWFY_DB_NAME'). ':host=' . mySociety::Config::get('TWFY_DB_HOST');
-my $dbh = DBI->connect($dsn, mySociety::Config::get('TWFY_DB_USER'), mySociety::Config::get('TWFY_DB_PASS'), { RaiseError => 1, PrintError => 0 });
+my $dbh = DBI->connect($dsn, mySociety::Config::get('TWFY_DB_USER'), mySociety::Config::get('TWFY_DB_PASS'), { RaiseError => 1, PrintError => 0, , mysql_enable_utf8 => 1 });
 #DBI->trace(2);
 if ($action{'rankings'}) {
     print "Making rankings\n" if $verbose;
@@ -229,7 +229,6 @@ foreach my $person_id (keys %$personinfohash) {
 # Write to database - cons
 foreach my $constituency (keys %$consinfohash) {
     my $data = $consinfohash->{$constituency};
-    $constituency = Encode::encode('iso-8859-1', $constituency);
     foreach my $key (keys %$data) {
         my $value = $data->{$key};
         $consinfoadd->execute($constituency, $key, $value, $value);

--- a/scripts/mprss.php
+++ b/scripts/mprss.php
@@ -75,7 +75,7 @@ for ($personrow=0; $personrow<$q->rows(); $personrow++) {
 	}
 		
 	// Prepare the whole text of the RSS file.
-	$rsstext = '<?xml version="1.0" encoding="iso-8859-1"?>
+	$rsstext = '<?xml version="1.0" encoding="utf-8"?>
 <rdf:RDF
   xmlns:dc="http://purl.org/dc/elements/1.1/"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"

--- a/scripts/xml2db.pl
+++ b/scripts/xml2db.pl
@@ -437,7 +437,7 @@ sub db_connect
 {
     # Connect to database, and prepare queries
     my $dsn = 'DBI:mysql:database=' . mySociety::Config::get('TWFY_DB_NAME'). ':host=' . mySociety::Config::get('TWFY_DB_HOST');
-    $dbh = DBI->connect($dsn, mySociety::Config::get('TWFY_DB_USER'), mySociety::Config::get('TWFY_DB_PASS'), { RaiseError => 1, PrintError => 0 });
+    $dbh = DBI->connect($dsn, mySociety::Config::get('TWFY_DB_USER'), mySociety::Config::get('TWFY_DB_PASS'), { RaiseError => 1, PrintError => 0, , mysql_enable_utf8 => 1 });
 
     # epobject queries
     $epadd = $dbh->prepare("insert into epobject (title, body, type, created, modified)
@@ -1481,7 +1481,7 @@ sub add_standing_day {
             if ($currsection==0) {
                 push @preheadingspeech, $_;
             } else {
-                do_load_speech($_, 6, $bill_id, Encode::encode('iso-8859-1', $_->sprint(1)))
+                do_load_speech($_, 6, $bill_id, $_->sprint(1))
             }
         },
         'publicwhip' => sub {
@@ -1533,8 +1533,7 @@ sub load_standing_division {
 <p class=\"divisionbody_yes\">Voting yes: $out{aye}</p>
 <p class=\"divisionbody_no\">Voting no: $out{no}</p>
 ";
-    # Standing XML is UTF-8, so transcode
-    do_load_speech($division, 6, $id, Encode::encode('iso-8859-1', $text));
+    do_load_speech($division, 6, $id, $text);
 }
 
 sub loadspq {

--- a/tests/CommentTest.php
+++ b/tests/CommentTest.php
@@ -102,7 +102,7 @@ It also spans multiple lines.", $comment->body());
     {
         // this file is UTF-8 but odd comments are sent up looking like Windows-1252 so we need the
         // input text to be encoded thus otherwise the output is different
-        $text = iconv('UTF-8', 'Windows-1252', "This is a curly  ’ apostrophe. Is 2 &lt; 3 ø ø €  ’ « ö à");
+        $text = "This is a curly  ’ apostrophe. Is 2 &lt; 3 ø ø €  ’ « ö à";
 
         $this->assertEquals("This is a curly  &rsquo; apostrophe. Is 2 &lt; 3 &oslash; &oslash; &euro;  &rsquo; &laquo; &ouml; &agrave;", prepare_comment_for_display($text));
     }

--- a/www/docs/api/api_functions.php
+++ b/www/docs/api/api_functions.php
@@ -210,6 +210,8 @@ function api_output($arr, $last_mod=null) {
         $out = api_output_php($arr);
     } elseif ($output == 'rabx') {
         $out = api_output_rabx($arr);
+    } elseif ($output == 'json') {
+        $out = json_encode($arr, JSON_PRETTY_PRINT);
     } else { # JS
         header('Access-Control-Allow-Origin: *');
         $out = api_output_js($arr);
@@ -237,6 +239,9 @@ function api_header($o, $last_mod=null) {
         $type = 'text/php';
     } elseif ($o == 'rabx') {
         $type = 'application/octet-stream';
+    } elseif ($o == 'json') {
+        header('Access-Control-Allow-Origin: *');
+        $type = 'application/json';
     } else {
         header('Access-Control-Allow-Origin: *');
         $charset = 'iso-8859-1';

--- a/www/docs/api/api_functions.php
+++ b/www/docs/api/api_functions.php
@@ -204,7 +204,7 @@ function api_output($arr, $last_mod=null) {
         if ($cond) return;
     }
     if ($output == 'xml') {
-        $out = '<?xml version="1.0" encoding="iso-8859-1"?>'."\n";
+        $out = '<?xml version="1.0" encoding="utf-8"?>'."\n";
         $out .= '<twfy>' . api_output_xml($arr) . '</twfy>';
     } elseif ($output == 'php') {
         $out = api_output_php($arr);

--- a/www/docs/api/api_functions.php
+++ b/www/docs/api/api_functions.php
@@ -213,7 +213,6 @@ function api_output($arr, $last_mod=null) {
     } elseif ($output == 'json') {
         $out = json_encode($arr, JSON_PRETTY_PRINT);
     } else { # JS
-        header('Access-Control-Allow-Origin: *');
         $out = api_output_js($arr);
         $callback = get_http_var('callback');
         if (preg_match('#^[A-Za-z0-9._[\]]+$#', $callback)) {

--- a/www/docs/api/api_getGeometry.php
+++ b/www/docs/api/api_getGeometry.php
@@ -47,13 +47,11 @@ function _api_getGeometry_name($name) {
         return null;
 
     $name = MySociety\TheyWorkForYou\Utility\Constituencies::normaliseConstituencyName($name);
-    # Names are currently in ISO-8859-1, but MapIt is in UTF-8
-    $name_utf8 = iconv('iso-8859-1', 'utf-8//TRANSLIT', $name);
 
     $areas_info = _api_cacheCheck('areas', 'WMC');
     $ni_geometry = _api_ni_centroids();
     foreach ($areas_info as $area_id => $area) {
-        if ($name_utf8 == $area['name']) {
+        if ($name == $area['name']) {
             if (isset($ni_geometry[$area_id])) {
                 $out = $ni_geometry[$area_id];
             } else {

--- a/www/docs/down.default.html
+++ b/www/docs/down.default.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
-	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<title>TheyWorkForYou.com: Are your MPs and Peers working for you in the UK's Parliament?</title>
 	<meta name="description" content="Making parliament easy.">
 	<meta name="keywords" content="Parliament, government, house of commons, house of lords, MP, Peer, Member of Parliament, MPs, Peers, Lords, Commons, UK, Britain, British, Welsh, Scottish, Wales, Scotland, ">

--- a/www/docs/news/rdf.php
+++ b/www/docs/news/rdf.php
@@ -2,7 +2,7 @@
 header('Content-type: application/rss+xml');
 include ($_SERVER['DOCUMENT_ROOT'] . '/../includes/easyparliament/init.php');
 require_once 'editme.php';
-print '<?xml version="1.0" encoding="iso-8859-1"?>' ?>
+print '<?xml version="1.0" encoding="utf-8"?>' ?>
 
 <rdf:RDF
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -1078,7 +1078,7 @@ Please read our <a href="<?php echo $RULESURL->generate(); ?>"><strong>House Rul
 Annotations should be information that adds value to the contribution, not opinion, rants, or messages to a politician.
 </small></p>
 
-                <form accept-charset="iso-8859-1" action="<?php echo $ADDURL->generate(); ?>" method="post">
+                <form accept-charset="utf-8" action="<?php echo $ADDURL->generate(); ?>" method="post">
                     <p><textarea name="body" rows="15" cols="55"><?php
         if (isset($commentdata['body'])) {
             echo _htmlentities($commentdata['body']);

--- a/www/includes/easyparliament/searchengine.php
+++ b/www/includes/easyparliament/searchengine.php
@@ -272,7 +272,7 @@ class SEARCHENGINE {
         preg_match_all('#S(\d+)#', $qd, $m);
         foreach ($m[1] as $mm) {
             $member = new MEMBER(array('person_id' => $mm));
-            $name = iconv('iso-8859-1', 'utf-8//TRANSLIT', $member->full_name()); # Names are currently in ISO-8859-1
+            $name = $member->full_name();
             $qd = str_replace("S$mm", "speaker:$name", $qd);
         }
 
@@ -296,7 +296,6 @@ class SEARCHENGINE {
             }
         }
 
-        $qd = iconv('utf-8', 'iso-8859-1//TRANSLIT', $qd); # Xapian is UTF-8, site is ISO8859-1
         $this->query_desc = trim($qd);
 
         #print 'DEBUG: ' . $query->get_description();
@@ -338,7 +337,6 @@ class SEARCHENGINE {
             return null;
 
         $qd = $this->queryparser->get_corrected_query_string();
-        $qd = iconv('utf-8', 'iso-8859-1//TRANSLIT', $qd); # Xapian is UTF-8, site is ISO8859-1
         return $qd;
     }
 

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -2,7 +2,7 @@
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en"><![endif]-->
 <!--[if gt IE 8]><!--><html class="no-js" lang="en"><!--<![endif]-->
 <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title><?= preg_replace('#<[^>]*>#', '', $page_title) ?></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <?php if (isset($meta_description)): ?>

--- a/www/includes/easyparliament/templates/rss/hansard_search.php
+++ b/www/includes/easyparliament/templates/rss/hansard_search.php
@@ -1,4 +1,4 @@
-<?php global $SEARCHENGINE; header("Content-Type: text/xml; charset=iso-8859-1"); print '<?xml version="1.0" encoding="iso-8859-1"?>'; ?>
+<?php global $SEARCHENGINE; header("Content-Type: text/xml; charset=utf-8"); print '<?xml version="1.0" encoding="utf-8"?>'; ?>
 
 <rss version="2.0" xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/">
 <channel>

--- a/www/includes/easyparliament/trackback.php
+++ b/www/includes/easyparliament/trackback.php
@@ -277,13 +277,13 @@ class TRACKBACK {
             // This page just does XML.
 
             if ($error) {
-                echo '<?xml version="1.0" encoding="iso-8859-1"?'.">\n";
+                echo '<?xml version="1.0" encoding="utf-8"?'.">\n";
                 echo "<response>\n";
                 echo "<error>1</error>\n";
                 echo "<message>$error_message</message>\n";
                 echo "</response>";
             } else {
-                echo '<?xml version="1.0" encoding="iso-8859-1"?'.">\n";
+                echo '<?xml version="1.0" encoding="utf-8"?'.">\n";
                 echo "<response>\n";
                 echo "<error>0</error>\n";
                 echo "</response>";

--- a/www/includes/mysql.php
+++ b/www/includes/mysql.php
@@ -262,7 +262,7 @@ Class MySQL {
         // These vars come from config.php.
 
         if (!$global_connection) {
-            $dsn = 'mysql:dbname=' . $db_name . ';host=' . $db_host;
+            $dsn = 'mysql:charset=utf8;dbname=' . $db_name . ';host=' . $db_host;
 
             try {
                 $conn = new PDO($dsn, $db_user, $db_pass);

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -557,17 +557,7 @@ function htmlentities_notags($text) {
     // If you want to do htmlentities() on some text that has HTML tags
     // in it, then you need this function.
 
-    $tbl = array();
-    if ( version_compare( phpversion(), '5.3.4', '<' ) ) {
-        // the third argument was only added in php 5.3.4 but our current production
-        // boxes run on 5.3.3
-        $tbl = get_html_translation_table(HTML_ENTITIES);
-    } else {
-    // we need to specify the encoding here because PHP 5.4 defaults to UTF-8
-    // Windows-1252 is uses because it contains the ISO-8859-1 table in PHP 5.4
-    // contains all of 4 characters, despite 5.3 containing 100 odd.
-        $tbl = get_html_translation_table(HTML_ENTITIES, ENT_QUOTES, 'Windows-1252');
-    }
+    $tbl = get_html_translation_table(HTML_ENTITIES, ENT_QUOTES, 'UTF-8');
 
     // You could encode extra stuff...
     //$tbl["“"] = "&quot;";
@@ -595,28 +585,19 @@ function htmlentities_notags($text) {
     # strtr "will *NOT* try to replace stuff that it has already worked on."
     $text = strtr($text, $tbl);
 
-    // This turns any out of bounds characters like fancy quotes
-    // into the ISO-8859-1 equivalent if possible.
-    $text = iconv('Windows-1252', 'ISO-8859-1//TRANSLIT', $text);
-
-    # Remove all illegal HTML characters (damn you, Windows-1252)
-    $text = preg_replace('/[\x80-\x9f]/', '', $text);
-
     return $text;
-
 }
 
 /*
  * PHP 5.4 changes the default encoding for htmlentities and htmlspecialchars
  * to be UTF-8, not using the php.ini character encoding until PHP 5.6. So
- * we have to wrap all uses of these two functions. Windows-1252 is used
- * because, as above, ISO-8859-1 is empty in PHP 5.4.
+ * we have to wrap all uses of these two functions.
  */
 function _htmlentities($s) {
-    return htmlentities($s, ENT_COMPAT, 'Windows-1252');
+    return htmlentities($s, ENT_COMPAT, 'UTF-8');
 }
 function _htmlspecialchars($s) {
-    return htmlspecialchars($s, ENT_COMPAT, 'Windows-1252');
+    return htmlspecialchars($s, ENT_COMPAT, 'UTF-8');
 }
 
 

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -880,9 +880,9 @@ function make_member_url($name, $const = '', $house = HOUSE_TYPE_COMMONS, $pid =
         return 'elizabeth_the_second';
     }
 
-    $s   = array(' ', '&amp;', '&ocirc;', '&Ouml;', '&ouml;', '&acirc;', '&iacute;', '&aacute;', '&uacute;', '&eacute;', '&oacute;', '&Oacute;');
-    $s2  = array(" ", "&",     "\xf4",    "\xd6",   "\xf6",   "\xe2",    "\xed",     "\xe1",     "\xfa",     "\xe9",     "\xf3",     "\xd3");
-    $r   = array('_', 'and',   'o',       'o',      'o',      'a',       'i',        'a',        'u',        'e',        'o',        'o');
+    $s   = array(' ', '&amp;', '&ocirc;',  '&Ouml;',  '&ouml;',   '&acirc;',  '&iacute;', '&aacute;', '&uacute;', '&eacute;', '&oacute;', '&Oacute;');
+    $s2  = array(" ", "&",     "\xc3\xb4", "\xc3\96", "\xc3\xb6", "\xc3\xa5", "\xc3\xad", "\xc3\xa1", "\xc3\xba", "\xc3\xa9", "\xc3\xb3", "\xc3\x93");
+    $r   = array('_', 'and',   'o',        'o',       'o',        'a',        'i',        'a',        'u',        'e',        'o',        'o');
     $name = preg_replace('#^the #', '', strtolower($name));
 
     $out = '';

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -769,7 +769,7 @@ function send_email($to, $subject, $message, $bulk = false, $from = '', $want_bo
 
     $headers =
      "From: TheyWorkForYou <$from>\r\n" .
-     "Content-Type: text/plain; charset=iso-8859-1\r\n" .
+     "Content-Type: text/plain; charset=utf-8\r\n" .
      "MIME-Version: 1.0\r\n" .
      "Content-Transfer-Encoding: 8bit\r\n" .
      ($bulk ? "Precedence: bulk\r\nAuto-Submitted: auto-generated\r\n" : "" ).


### PR DESCRIPTION
This updates the site to output and store UTF-8 everywhere rather than ISO-8859-1.

Along with this branch the following changes will need to be made to the database:

```sql
ALTER database twfy default character set utf8mb4;
ALTER database twfy default collate utf8mb4_general_ci;
```

and then something like this for all the tables:

```sql
ALTER table member convert to character set utf8mb4;
```

This latter command also updates the collation on columns for those where we have overridden it.

Generate this for all table with:

```bash
#!/bin/bash

QUERY="select table_name from information_schema.TABLES T, information_schema.         COLLATION_CHARACTER_SET_APPLICABILITY CCSA WHERE character_set_name =         'latin1' AND CCSA.collation_name = T.table_collation AND T.table_schema =       'twfy';"

TABLES=$(mysql twfy_struan --skip-column-names -e "$QUERY")

for t in $TABLES; do
    echo "alter table $t convert to charset utf8mb4;"
done;
```

The one exception to this is the `mentions` table which we need to convert to innoDB and only change to `utf8` before this in order to get round limitations with mysql index sizes. Or just leave as it is as I don't think it's used any more and it doesn't contain anything that should be matter.

NB: we use `utf8mb4` as `utf8` only supports up to 3 bytes.

Fixes #815