### PR TITLE
Add support for Xapian Replication (resolves #1167)

### DIFF
--- a/conf/general-example
+++ b/conf/general-example
@@ -95,6 +95,9 @@ define ("METADATAPATH", BASEDIR . "/../includes/easyparliament/metadata.php");
 // To use the Xapian remote backend, specify server:port.
 // If non-empty will use XAPIAN search.
 define ("XAPIANDB", "");
+// To keep changesets when the indexer runs, set a value here.
+// See https://xapian.org/docs/replication.html
+define ("XAPIAN_MAX_CHANGESETS", "");
 // To allow back end to still index/send alerts, but turn off front end.
 define ('FRONT_END_SEARCH', 1);
 

--- a/conf/general-example
+++ b/conf/general-example
@@ -29,12 +29,12 @@ define ('OPTION_BBC_DB_PASS', '');
 
 // *******************************************************************************
 // Domains.
-// Set this to the domain you are hosting on. If you're running locally, this will be "localhost" 
+// Set this to the domain you are hosting on. If you're running locally, this will be "localhost"
 // You can include a port number by putting ":N" at the end of DOMAIN
 define ("DOMAIN", "www.example.org");
 define ("COOKIEDOMAIN", "www.example.org");
 
-// General 'Contact us' type email address. Point this at a real address if you 
+// General 'Contact us' type email address. Point this at a real address if you
 // want the site generated email to come to you. Can be overridden for other mails below.
 
 define ('EMAILDOMAIN', 'example.org');
@@ -46,12 +46,12 @@ if (!defined('BASEDIR')) {
 }
 
 // Webserver path to 'top' directory of the site (possibly just "/"). For example,
-// if the site is at 'http://www.yourdomain.com/public/theyworkforyou', 
+// if the site is at 'http://www.yourdomain.com/public/theyworkforyou',
 // this would be '/public/theyworkforyou'
 define ("WEBPATH", "/");
 
 // *******************************************************************************
-// Stop Here. In a basic developer configuration you shouldn't need to edit 
+// Stop Here. In a basic developer configuration you shouldn't need to edit
 // anything below this point.
 // Feel free to have an explore if you wish though.
 // *******************************************************************************
@@ -78,7 +78,7 @@ define('DISSOLUTION_DATE', '');
 define ("OPTION_MAIL_LOG_PREFIX", '/var/mail/twfy-');
 
 // *******************************************************************************
-// If you've unpacked the tar file normally, and set the paths correctly above, 
+// If you've unpacked the tar file normally, and set the paths correctly above,
 // you shouldn't change these.
 
 // File system path to where all the include files live.
@@ -91,6 +91,7 @@ define ("IMAGEPATH", WEBPATH . "images/");
 // This will be included in data.php. It's an array of page/section metadata.
 define ("METADATAPATH", BASEDIR . "/../includes/easyparliament/metadata.php");
 
+// Xapian Configuration.
 // Location of the directory that is the Xapian search database.
 // To use the Xapian remote backend, specify server:port.
 // If non-empty will use XAPIAN search.
@@ -98,10 +99,28 @@ define ("XAPIANDB", "");
 // To keep changesets when the indexer runs, set a value here.
 // See https://xapian.org/docs/replication.html
 define ("XAPIAN_MAX_CHANGESETS", "");
+// Set values here to activate one-shot replication. To disable, leave all undefined.
+// Location of the replication script (required):
+define ("XAPIAN_REPLICATION_SCRIPT", "");
+// Port to listen on (required):
+define ("XAPIAN_REPLICATION_PORT", "");
+// Backup hostname (required):
+define ("XAPIAN_REMOTE_HOST", "");
+// Username on backup host (required):
+define ("XAPIAN_REMOTE_USER", "");
+// Backup location on remote host (required):
+define ("XAPIAN_REMOTE_PATH", "");
+// SSH key file to use (required):
+define ("XAPIAN_SSH_IDENTITY_FILE", "");
+// Lockfile to use on remote host (optional):
+define ("XAPIAN_REMOTE_LOCKFILE", "");
+// Path to run-with-lockfile on remote host if not in PATH (optional):
+define ("XAPIAN_REMOTE_RUN_WITH_LOCKFILE_PATH, "");
+
 // To allow back end to still index/send alerts, but turn off front end.
 define ('FRONT_END_SEARCH', 1);
 
-// Location of the parliamentary recess data file. You can access this remotely 
+// Location of the parliamentary recess data file. You can access this remotely
 // from the main theyworkforyou site if you use
 define ("RECESSFILE","https://www.theyworkforyou.com/pwdata/parl-recesses.txt");
 // AND amend your global php.ini to 'allow_url_fopen = On'

--- a/conf/general-example
+++ b/conf/general-example
@@ -112,10 +112,8 @@ define ("XAPIAN_REMOTE_USER", "");
 define ("XAPIAN_REMOTE_PATH", "");
 // SSH key file to use (required):
 define ("XAPIAN_SSH_IDENTITY_FILE", "");
-// Lockfile to use on remote host (optional):
-define ("XAPIAN_REMOTE_LOCKFILE", "");
 // Path to run-with-lockfile on remote host if not in PATH (optional):
-define ("XAPIAN_REMOTE_RUN_WITH_LOCKFILE_PATH, "");
+define ("XAPIAN_REMOTE_RUN_WITH_LOCKFILE_PATH", "");
 
 // To allow back end to still index/send alerts, but turn off front end.
 define ('FRONT_END_SEARCH', 1);

--- a/scripts/morningupdate
+++ b/scripts/morningupdate
@@ -83,13 +83,6 @@ if ( $xapiandb !~ /:/ ) {
     if ( $missing_options ) {
         print "Skipping replication due to missing options: ${missing_options}\n" if $verbose;
     } else {
-        # Extract the script name.
-        my $replication_script = $xapian_options{'replication_script'};
-        delete $xapian_options{'replication_script'};
-        # Optional arguments:
-        $xapian_options{"remote_lockfile"} = mySociety::Config::get('XAPIAN_REMOTE_LOCKFILE');
-        $xapian_options{"remote_bin_path"} = mySociety::Config::get('XAPIAN_REMOTE_RUN_WITH_LOCKFILE_PATH');
-
         # Build a command line:
         my @replication_options = ( "$xapiandb",
                                   "$xapian_options{'replication_port'}",
@@ -97,14 +90,14 @@ if ( $xapiandb !~ /:/ ) {
                                   "$xapian_options{'remote_user'}",
                                   "$xapian_options{'remote_path'}",
                                   "$xapian_options{'ssh_identity_file'}" );
-        if ( $xapian_options{'remote_lockfile'} ) {
-            push @replication_options, "$xapian_options{'remote_lockfile'}";
-            push @replication_options, "$xapian_options{'remote_bin_path'}" if $xapian_options{'remote_bin_path'};
-        }
+
+        # Optional arguments:
+        $xapian_options{"remote_bin_path"} = mySociety::Config::get('XAPIAN_REMOTE_RUN_WITH_LOCKFILE_PATH');
+        push @replication_options, "$xapian_options{'remote_bin_path'}" if $xapian_options{'remote_bin_path'};
 
         # Attempt replication:
         print "Triggering Xapian Replication\n" if $verbose;
-        system $replication_script, @replication_options;
+        system $xapian_options{'replication_script'}, @replication_options;
     }
 }
 

--- a/scripts/morningupdate
+++ b/scripts/morningupdate
@@ -50,10 +50,63 @@ system "./xml2db.pl $cronquiet --recent --standing --quiet";
 system "python ./future-fetch.py";
 
 $cronquiet = substr($cronquiet, 2) if $cronquiet;
-# Update Xapan index
+
+## Xapian Stuff.
+# If there's a value for XAPIAN_MAX_CHANGESETS in the config file,
+# make sure it's in our environment.
+my $changesets = mySociety::Config::get('XAPIAN_MAX_CHANGESETS');
+$ENV{XAPIAN_MAX_CHANGESETS} = $changesets if $changesets;
+
+# Update xapian index
 print "Xapian indexing\n" if $verbose;
 chdir "$FindBin::Bin/../search";
 system "./index.pl sincefile $cronquiet";
+
+# Trigger Xapian Replication if the required settings are in place.
+my $xapiandb = mySociety::Config::get('XAPIANDB');
+# Only replicate if Xapian is local.
+if ( $xapiandb !~ /:/ ) {
+    my $missing_options = "";
+    my %xapian_options;
+    my @required_options = ( "replication_port",
+                            "remote_host",
+                            "remote_user",
+                            "remote_path",
+                            "ssh_identity_file",
+                            "replication_script" );
+    foreach my $option ( @required_options ) {
+        my $config =  "XAPIAN_" . uc $option;
+        $xapian_options{$option} = mySociety::Config::get("$config");
+        $missing_options += "$config " unless $xapian_options{$option};
+    }
+
+    if ( $missing_options ) {
+        print "Skipping replication due to missing options: ${missing_options}\n" if $verbose;
+    } else {
+        # Extract the script name.
+        my $replication_script = $xapian_options{'replication_script'};
+        delete $xapian_options{'replication_script'};
+        # Optional arguments:
+        $xapian_options{"remote_lockfile"} = mySociety::Config::get('XAPIAN_REMOTE_LOCKFILE');
+        $xapian_options{"remote_bin_path"} = mySociety::Config::get('XAPIAN_REMOTE_RUN_WITH_LOCKFILE_PATH');
+
+        # Build a command line:
+        my @replication_options = ( "$xapiandb",
+                                  "$xapian_options{'replication_port'}",
+                                  "$xapian_options{'remote_host'}",
+                                  "$xapian_options{'remote_user'}",
+                                  "$xapian_options{'remote_path'}",
+                                  "$xapian_options{'ssh_identity_file'}" );
+        if ( $xapian_options{'remote_lockfile'} ) {
+            push @replication_options, "$xapian_options{'remote_lockfile'}";
+            push @replication_options, "$xapian_options{'remote_bin_path'}" if $xapian_options{'remote_bin_path'};
+        }
+
+        # Attempt replication:
+        print "Triggering Xapian Replication\n" if $verbose;
+        system $replication_script, @replication_options;
+    }
+}
 
 # Video - updating GIDs that have video available according to parlvid database
 system "php5 $path/theyworkforyou/scripts/video-availability.php";
@@ -77,4 +130,3 @@ if ($verbose) {
 
 #print "Whole thing done time: ";
 #date +"%Y-%m-%d %H:%M:%S"
-

--- a/search/index.pl
+++ b/search/index.pl
@@ -31,6 +31,11 @@ die "As first parameter, specify:
     'checkfull' to check everything is indexed by fetching entire dbs and comparing
 " if !$action or ($action ne "all" and $action ne "lastweek" and $action ne "lastmonth" and $action ne "sincefile" and $action ne "check" and $action ne 'checkfull' and $action ne "daterange");
 
+# If there's a value for XAPIAN_MAX_CHANGESETS in the config file,
+# make sure it's in our environment.
+my $changesets = mySociety::Config::get('XAPIAN_MAX_CHANGESETS');
+$ENV{XAPIAN_MAX_CHANGESETS} = $changesets if $changesets;
+
 # Open MySQL
 my $dsn = 'DBI:mysql:database=' . mySociety::Config::get('TWFY_DB_NAME'). ':host=' . mySociety::Config::get('TWFY_DB_HOST');
 my $dbh = DBI->connect($dsn, mySociety::Config::get('TWFY_DB_USER'), mySociety::Config::get('TWFY_DB_PASS'), { RaiseError => 1, PrintError => 0 });


### PR DESCRIPTION
Provides required support for Xapian Replication.

- Provides for setting `XAPIAN_MAX_CHANGESETS` in `conf/general` and uses export this into the environment within `search/index.pl` if present. This ensures it is set wherever the index script is called from.
- Supplies necessary scripts to integrate trigger replication from the client-side based on those used with Alaveteli.

Once this is merged, we activate by setting a values for the various new configuration variables in the config file. See also https://github.com/mysociety/sysadmin/issues/654.
