### PR TITLE
Add social media details from EP

### DIFF
--- a/scripts/mpinfoin.pl
+++ b/scripts/mpinfoin.pl
@@ -117,8 +117,11 @@ if ($action{'links'}) {
     $twig->parsefile($pwmembers . 'websites.xml', ErrorContext => 2);
     print "  MSP websites\n" if $verbose;
     $twig->parsefile($pwmembers . 'websites-sp.xml', ErrorContext => 2);
-    print "  MSP Twitter username\n" if $verbose;
+    print "  Twitter usernames and facebook pages\n" if $verbose;
     $twig->parsefile($pwmembers . 'twitter.xml', ErrorContext => 2);
+    $twig->parsefile($pwmembers . 'social-media-commons.xml', ErrorContext => 2);
+    $twig->parsefile($pwmembers . 'social-media-sp.xml', ErrorContext => 2);
+    $twig->parsefile($pwmembers . 'social-media-ni.xml', ErrorContext => 2);
     chdir $FindBin::Bin;
     print "  Lords biographies\n" if $verbose;
     $twig->parsefile($pwmembers . 'lordbiogs.xml', ErrorContext => 2);

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -324,6 +324,7 @@ $data['other_constituencies'] = $MEMBER->getOtherConstituenciesString();
 $data['rebellion_rate'] = person_rebellion_rate($MEMBER);
 $data['recent_appearances'] = person_recent_appearances($MEMBER);
 $data['useful_links'] = person_useful_links($MEMBER);
+$data['social_links'] = person_social_links($MEMBER);
 $data['topics_of_interest'] = person_topics($MEMBER);
 $data['current_offices'] = $MEMBER->offices('current');
 $data['previous_offices'] = $MEMBER->offices('previous');
@@ -938,13 +939,6 @@ function person_useful_links($member) {
         );
     }
 
-    if (isset($links['twitter_username'])) {
-        $out[] = array(
-                'href' => 'https://twitter.com/' . $links['twitter_username'],
-                'text' => 'Twitter feed'
-        );
-    }
-
     if (isset($links['sp_url'])) {
         $out[] = array(
                 'href' => $links['sp_url'],
@@ -984,6 +978,31 @@ function person_useful_links($member) {
         $out[] = array(
                 'href' => $links['journa_list_link'],
                 'text' => 'Newspaper articles written by this MP'
+        );
+    }
+
+    return $out;
+}
+
+function person_social_links($member) {
+
+    $links = $member->extra_info();
+
+    $out = array();
+
+    if (isset($links['twitter_username'])) {
+        $out[] = array(
+                'href' => 'https://twitter.com/' . _htmlentities($links['twitter_username']),
+                'text' => '@' . _htmlentities($links['twitter_username']),
+                'type' => 'twitter'
+        );
+    }
+
+    if (isset($links['facebook_page'])) {
+        $out[] = array(
+                'href' => _htmlentities($links['facebook_page']),
+                'text' => _htmlentities($links['facebook_page']),
+                'type' => 'facebook'
         );
     }
 

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -261,6 +261,16 @@ $display_wtt_stats_banner = '2015';
 
                     <?php endif; ?>
 
+                    <?php if (count($social_links) > 0): ?>
+                    <h3>Social Media</h3>
+                    <ul>
+                        <?php foreach ($social_links as $link): ?>
+                        <li><a class="fi-social-<?= $link['type'] ?>" href="<?= $link['href'] ?>"><?= $link['text'] ?></a></li>
+                        <?php endforeach; ?>
+                    </ul>
+                    <?php endif; ?>
+
+
                     <?php if ($has_expenses): ?>
                     <h3>Expenses</h3>
 


### PR DESCRIPTION
This uses the XML generated by parlparse from EveryPolitician to update the twitter and facebook links in `person_info`. It also splits these out to a Social Media sub-heading in the profile to make them a bit more obvious.

Part of #1133