### PR TITLE
escape utf8 fancy quotes from js api output

### DIFF
--- a/tests/AcceptApiTest.php
+++ b/tests/AcceptApiTest.php
@@ -54,6 +54,7 @@ class AcceptApiTest extends FetchPageTestCase
             {"name":"Amber Valley"},
             {"name":"Belfast West"},
             {"name":"Cities of London and Westminster"}
+            {"name":"Cities of \"London\" and Westminster"}
             ]');
     }
 

--- a/tests/_fixtures/api.xml
+++ b/tests/_fixtures/api.xml
@@ -63,6 +63,13 @@
 		<field name="to_date">9999-12-31</field>
 		<field name="cons_id">11</field>
 	</row>
+	<row>
+		<field name="name">Cities of ‶London″ and Westminster</field>
+		<field name="main_name">1</field>
+		<field name="from_date">1983-00-00</field>
+		<field name="to_date">9999-12-31</field>
+		<field name="cons_id">13</field>
+	</row>
 	</table_data>
 	<table_data name="editqueue">
 	</table_data>

--- a/www/docs/api/api_functions.php
+++ b/www/docs/api/api_functions.php
@@ -324,8 +324,8 @@ function api_output_js($v, $level=0) {
         $out = "null";
     } elseif (is_string($v)) {
         $out = '"' . str_replace(
-            array("\\",'"',"\n","\t","\r"),
-            array("\\\\",'\"','\n','\t','\r'), $v) . '"';
+            array("\\",'"',"\n","\t","\r", "‶", "″", "“", "”"),
+            array("\\\\",'\"','\n','\t','\r', '\"', '\"', '\"', '\"'), $v) . '"';
     } elseif (is_bool($v)) {
         $out = $v ? 'true' : 'false';
     } elseif (is_int($v) || is_float($v)) {


### PR DESCRIPTION
otherwise iconv will convert them into plain quotes and hence break the
JS output.

Fixes #1218