### PR TITLE
Fix A-Z links on MP list page for non last name sorting

### DIFF
--- a/www/includes/easyparliament/templates/html/people/index.php
+++ b/www/includes/easyparliament/templates/html/people/index.php
@@ -165,9 +165,14 @@ if (!count($data)) {
                 <?php } ?>
 
                 <div class="people-list">
-                <?php $current_initial = ''; ?>
-                <?php foreach ( $data as $person ) {
-                    $initial = substr( strtoupper($person['family_name']), 0, 1);
+                <?php
+                $current_initial = '';
+                $a_to_z_key = 'family_name';
+                if ($order == 'given_name') {
+                    $a_to_z_key = 'given_name';
+                }
+                foreach ( $data as $person ) {
+                    $initial = substr( strtoupper($person[$a_to_z_key]), 0, 1);
                     if ( $initial != $current_initial ) {
                         $current_initial = $initial;
                         $initial_link = "name=\"$initial\" ";

--- a/www/includes/easyparliament/templates/html/people/index.php
+++ b/www/includes/easyparliament/templates/html/people/index.php
@@ -165,19 +165,23 @@ if (!count($data)) {
                 <?php } ?>
 
                 <div class="people-list">
-                <?php
-                $current_initial = '';
-                $a_to_z_key = 'family_name';
-                if ($order == 'given_name') {
-                    $a_to_z_key = 'given_name';
+                <?php if ($order != 'party') {
+                    $current_initial = '';
+                    $a_to_z_key = 'family_name';
+                    if ($order == 'given_name') {
+                        $a_to_z_key = 'given_name';
+                    }
                 }
+                $initial_link = '';
                 foreach ( $data as $person ) {
-                    $initial = substr( strtoupper($person[$a_to_z_key]), 0, 1);
-                    if ( $initial != $current_initial ) {
-                        $current_initial = $initial;
-                        $initial_link = "name=\"$initial\" ";
-                    } else {
-                        $initial_link = "";
+                    if ($order != 'party') {
+                        $initial = substr( strtoupper($person[$a_to_z_key]), 0, 1);
+                        if ( $initial != $current_initial ) {
+                            $current_initial = $initial;
+                            $initial_link = "name=\"$initial\" ";
+                        } else {
+                            $initial_link = "";
+                        }
                     }
                 ?>
                 <a <?= $initial_link ?>href="/mp/<?= $person['url'] ?>" class="people-list__person">

--- a/www/includes/easyparliament/templates/html/people/index.php
+++ b/www/includes/easyparliament/templates/html/people/index.php
@@ -133,6 +133,7 @@ if (!count($data)) {
                 </ul>
                 <?php } ?>
 
+                <?php if ($order != 'party') { ?>
                 <div class="people-list-alphabet">
                     <a href="#A">A</a>
                     <a href="#B">B</a>
@@ -161,6 +162,7 @@ if (!count($data)) {
                     <a href="#Y">Y</a>
                     <a href="#Z">Z</a>
                 </div>
+                <?php } ?>
 
                 <div class="people-list">
                 <?php $current_initial = ''; ?>


### PR DESCRIPTION
This fixes the A-Z links so they refer to first names when sorting by first name.
It hides the A-Z links when sorting by party as they aren't actually useful in that case.

Fixes #1060