### PR TITLE
do not merge paragraphs after a quote from official record

### DIFF
--- a/www/includes/easyparliament/templates/html/people/index.php
+++ b/www/includes/easyparliament/templates/html/people/index.php
@@ -165,9 +165,14 @@ if (!count($data)) {
                 <?php } ?>
 
                 <div class="people-list">
-                <?php $current_initial = ''; ?>
-                <?php foreach ( $data as $person ) {
-                    $initial = substr( strtoupper($person['family_name']), 0, 1);
+                <?php
+                $current_initial = '';
+                $a_to_z_key = 'family_name';
+                if ($order == 'given_name') {
+                    $a_to_z_key = 'given_name';
+                }
+                foreach ( $data as $person ) {
+                    $initial = substr( strtoupper($person[$a_to_z_key]), 0, 1);
                     if ( $initial != $current_initial ) {
                         $current_initial = $initial;
                         $initial_link = "name=\"$initial\" ";

--- a/www/includes/easyparliament/templates/html/people/index.php
+++ b/www/includes/easyparliament/templates/html/people/index.php
@@ -165,19 +165,23 @@ if (!count($data)) {
                 <?php } ?>
 
                 <div class="people-list">
-                <?php
-                $current_initial = '';
-                $a_to_z_key = 'family_name';
-                if ($order == 'given_name') {
-                    $a_to_z_key = 'given_name';
+                <?php if ($order != 'party') {
+                    $current_initial = '';
+                    $a_to_z_key = 'family_name';
+                    if ($order == 'given_name') {
+                        $a_to_z_key = 'given_name';
+                    }
                 }
+                $initial_link = '';
                 foreach ( $data as $person ) {
-                    $initial = substr( strtoupper($person[$a_to_z_key]), 0, 1);
-                    if ( $initial != $current_initial ) {
-                        $current_initial = $initial;
-                        $initial_link = "name=\"$initial\" ";
-                    } else {
-                        $initial_link = "";
+                    if ($order != 'party') {
+                        $initial = substr( strtoupper($person[$a_to_z_key]), 0, 1);
+                        if ( $initial != $current_initial ) {
+                            $current_initial = $initial;
+                            $initial_link = "name=\"$initial\" ";
+                        } else {
+                            $initial_link = "";
+                        }
                     }
                 ?>
                 <a <?= $initial_link ?>href="/mp/<?= $person['url'] ?>" class="people-list__person">

--- a/www/includes/easyparliament/templates/html/people/index.php
+++ b/www/includes/easyparliament/templates/html/people/index.php
@@ -133,6 +133,7 @@ if (!count($data)) {
                 </ul>
                 <?php } ?>
 
+                <?php if ($order != 'party') { ?>
                 <div class="people-list-alphabet">
                     <a href="#A">A</a>
                     <a href="#B">B</a>
@@ -161,6 +162,7 @@ if (!count($data)) {
                     <a href="#Y">Y</a>
                     <a href="#Z">Z</a>
                 </div>
+                <?php } ?>
 
                 <div class="people-list">
                 <?php $current_initial = ''; ?>

--- a/www/includes/easyparliament/templates/html/section/_section_content.php
+++ b/www/includes/easyparliament/templates/html/section/_section_content.php
@@ -51,7 +51,7 @@
         $body = preg_replace('#<p>\s*</p>#', '', $body);
 
         # Assume a paragraph starting with a lowercase character should be run on
-        $body = preg_replace('#(?<!:)</p>\s*<p[^>]*>(?=[a-z])(?![ivx]+\.)#', ' ', $body);
+        $body = preg_replace('#(?<!:|\])</p>\s*<p[^>]*>(?=[a-z])(?![ivx]+\.)#', ' ', $body);
 
         $body = str_replace(array('<br/>', '</p><p'), array('</p> <p>', '</p> <p'), $body); # NN4 font size bug
     }

--- a/www/includes/easyparliament/templates/html/section/_section_content.php
+++ b/www/includes/easyparliament/templates/html/section/_section_content.php
@@ -51,7 +51,7 @@
         $body = preg_replace('#<p>\s*</p>#', '', $body);
 
         # Assume a paragraph starting with a lowercase character should be run on
-        $body = preg_replace('#(?<!:|\])</p>\s*<p[^>]*>(?=[a-z])(?![ivx]+\.)#', ' ', $body);
+        $body = preg_replace('#(?<!:|\]|&\#8221;,)</p>\s*<p[^>]*>(?=[a-z])(?![ivx]+\.)#', ' ', $body);
 
         $body = str_replace(array('<br/>', '</p><p'), array('</p> <p>', '</p> <p'), $body); # NN4 font size bug
     }


### PR DESCRIPTION
Improve the merging of run-on paragraphs to detect when something looks
like the end of a quote from the official record by checking for a
paragraph ending with ]. This avoids formatting a follow on sentence
into the indent for the quote.

Fixes #1195