### PR TITLE
custom Facebook share button for tracking MP voting record shares

### DIFF
--- a/www/docs/js/main.js
+++ b/www/docs/js/main.js
@@ -170,6 +170,34 @@ $(function(){
       function() { $(this).children('.moreinfo-text').show(); },
       function() { $(this).children('.moreinfo-text').hide(); }
   );
+
+  $('.fb-share-button-tracked').on('click', function(e) {
+    $a = $(e.target);
+    name = $a.data('title');
+    link = $a.data('href');
+    picture = $a.data('picture');
+    caption = $a.data('caption');
+    desc = $a.data('desc');
+    console.log(link);
+    FB.ui(
+      {
+        method: 'feed',
+        name: name,
+        link: link,
+        picture: picture,
+        caption: caption,
+        description: desc
+      },
+      function(response) {
+        // only try this if GA is actually loaded and they shared
+        // the post.
+        if (response && window._gat && window._gat._getTracker) {
+          ga('send', 'social', 'facebook', 'share', link);
+        }
+      }
+    );
+    return false;
+  });
   if( $('.about-this-page__one-of-two').length ) {
     // these are usually .panel--secondary elements
     var $elements = $('.about-this-page__one-of-two').children();

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -370,7 +370,9 @@ switch ($pagetype) {
           $data['og_image'] = $MEMBER->url(true) . "/policy_set_png?policy_set=" . $policy_set;
           $data['page_title'] = $policiesList->getSetDescriptions()[$policy_set] . ' ' . $title . ' - TheyWorkForYou';
           $data['meta_description'] = 'See how ' . $data['full_name'] . ' voted on ' . $policiesList->getSetDescriptions()[$policy_set];
+          $data['single_policy_page'] = true;
         } else {
+            $data['single_policy_page'] = false;
             $set_descriptions = $policiesList->getSetDescriptions();
             $data['key_votes_segments'] = array(
                 array(

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -722,6 +722,44 @@
     }
 }
 
+// style for our custom FB share button that uses FB.ui
+// so we can track shares
+.fb-share-button-tracked {
+    display: inline-block;
+    position: relative;
+    height: 20px;
+    padding: 0px 4px;
+    vertical-align: middle;
+
+    background: #4c69ba;
+    border: none;
+    border-radius: 2px;
+    cursor: pointer;
+
+    color: #fff;
+    font-weight: 500;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+    font-size: 11px;
+    line-height: 20px;
+    text-decoration: none !important;
+
+    &:hover, &:focus {
+        background-color: darken(#4c69ba, 15%);
+        color: #fff;
+    }
+
+    &:before {
+        content: "";
+        display: inline-block;
+        background: transparent url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 216 216'%3E%3Cpath fill='%23fff' d='M204.1 0H11.9C5.3 0 0 5.3 0 11.9v192.2c0 6.6 5.3 11.9 11.9 11.9h103.5v-83.6H87.2V99.8h28.1v-24c0-27.9 17-43.1 41.9-43.1 11.9 0 22.2.9 25.2 1.3v29.2h-17.3c-13.5 0-16.2 6.4-16.2 15.9v20.8h32.3l-4.2 32.6h-28V216h55c6.6 0 11.9-5.3 11.9-11.9V11.9C216 5.3 210.7 0 204.1 0z'/%3E%3C/svg%3E") 0 0 no-repeat;
+        background-size: 14px 14px;
+        width: 14px;
+        height: 14px;
+        vertical-align: -3px;
+        margin-right: 0.5em;
+    }
+}
+
 .about-this-page {
     .about-this-page__one-of-two {
         @include grid-column(12);

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -87,7 +87,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                             <div class="share-vote-descriptions">
                                 <p>Share a screenshot of these votes:</p>
 
-                                <div class="fb-share-button" data-href="<?= $abs_member_url ?>/votes?policy=<?= $segment['key'] ?>" data-layout="button" data-size="small" data-mobile-iframe="true"><a class="fb-xfbml-parse-ignore" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=<?= urlencode( $abs_member_url . "/votes?policy=" . $segment['key'] ) ?>&amp;src=sdkpreparse">Share</a></div>
+                                <a href="#" class="fb-share-button-tracked" data-title="<?= $single_policy_page ? '' : $segment['title'] . ' ' ?><?= $page_title ?>" data-href="<?= $abs_member_url ?>/votes?policy=<?= $segment['key'] ?>" data-image="<?= $abs_member_url ?>/policy_set_png?policy_set=<?= $segment['key'] ?>" "See how <?= $full_name ?> voted on <?= $segment["title"] ?>">Share</a>
 
                                 <a class="twitter-share-button" href="https://twitter.com/share" data-size="small" data-url="<?= $abs_member_url ?>/votes?policy=<?= $segment['key'] ?>">Tweet</a>
                                 </div>


### PR DESCRIPTION
It's not possible to subscribe to share events using FB.Event so roll
our own code to launch the share dialog using FB.ui. This means we can
hook in Google Analytics to the response handler.

![screen shot 2017-04-12 at 15 02 16](https://cloud.githubusercontent.com/assets/5310/24961555/12e433e6-1f91-11e7-830d-5a8d505d0875.png)

Fixes #1238