### PR TITLE
allow redirect to policy page from postcode page

### DIFF
--- a/classes/Member.php
+++ b/classes/Member.php
@@ -236,6 +236,20 @@ class Member extends \MEMBER {
 
     }
 
+
+    public function getPolicyURL($args = array()) {
+        $base_url = $this->url();
+        if (isset($args['policy_number'])) {
+            $url = $base_url . '/divisions?policy=' . $args['policy_number'];
+        } else if (isset($args['policy_set'])) {
+            $url = $base_url . '/votes?policy=' . $args['policy_set'];
+        } else {
+            $url = $base_url . '/votes';
+        }
+
+        return $url;
+    }
+
     private function getOfficeObject($include_only, $ignore_committees, $row) {
         if (!$this->includeOffice($include_only, $row['to_date'])) {
             return null;

--- a/tests/PostcodePageTest.php
+++ b/tests/PostcodePageTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Testing for postcode Utility functions
+ */
+
+class PostcodePageTest extends FetchPageTestCase
+{
+
+    /**
+     * Loads the member testing fixture.
+     */
+    public function getDataSet()
+    {
+        return $this->createMySQLXMLDataSet(dirname(__FILE__).'/_fixtures/postcodepage.xml');
+    }
+
+    private function fetch_postcode_page($postcode, $options = array()) {
+      $args = array('pc' => $postcode);
+      $args = array_merge($args, $options);
+
+      return $this->base_fetch_page(
+          $args,
+          'postcode',
+          'index.php',
+          '/postcode/'
+      );
+    }
+
+    public function testNoPostcodeGivesError()
+    {
+        $page = $this->fetch_postcode_page('');
+        $this->assertContains('Please supply a postcode!', $page);
+    }
+
+    public function testRedirectsForWestminsterOnly()
+    {
+        $page = $this->fetch_postcode_page('SW1A 1AA');
+        $this->assertContains('Location: /mp/2/test_current-mp/test_westminster_constituency', $page);
+    }
+
+    public function testShowsOptionsForScottishPostcode()
+    {
+        $page = $this->fetch_postcode_page('PH6 2DB');
+        $this->assertContains('That postcode has multiple results', $page);
+        $this->assertContains('Test2 Current-MP', $page);
+        $this->assertContains('Test Current-MSP', $page);
+        $this->assertContains('Test Current-Regional-MSP', $page);
+    }
+
+    public function testShowsOptionsForNIPostcode()
+    {
+        $page = $this->fetch_postcode_page('BT1 1AA');
+        $this->assertContains('That postcode has multiple results', $page);
+        $this->assertContains('Test3 Current-MP', $page);
+        $this->assertContains('Test Current-MLA', $page);
+    }
+
+    public function testRedirectsWithPolicySet()
+    {
+        $page = $this->fetch_postcode_page('SW1A 1AA', array('policy_set' => 'social'));
+        $this->assertContains('Location: /mp/2/test_current-mp/test_westminster_constituency/votes?policy=social', $page);
+    }
+
+    public function testRedirectsWithPolicySetForScottishPostcode()
+    {
+        $page = $this->fetch_postcode_page('PH6 2DB', array('policy_set' => 'social'));
+        $this->assertContains('Location: /mp/3/test2_current-mp/test_scottish_westminster_constituency/votes?policy=social', $page);
+    }
+
+    public function testRedirectsWithPolicySetForNIPostcode()
+    {
+        $page = $this->fetch_postcode_page('BT1 1AA', array('policy_set' => 'social'));
+        $this->assertContains('Location: /mp/6/test3_current-mp/test_ni_westminster_constituency/votes?policy=social', $page);
+    }
+}

--- a/tests/_fixtures/api.xml
+++ b/tests/_fixtures/api.xml
@@ -182,6 +182,14 @@
 	<table_data name="personinfo">
 	</table_data>
 	<table_data name="postcode_lookup">
+      <row>
+          <field name="postcode">SW1A 1AA</field>
+          <field name="name">Cities of London and Westminster</field>
+      </row>
+      <row>
+          <field name="postcode">BT17 0XD</field>
+          <field name="name">Belfast West|Belfast West</field>
+      </row>
 	</table_data>
 	<table_data name="search_query_log">
 	</table_data>

--- a/tests/_fixtures/postcode.xml
+++ b/tests/_fixtures/postcode.xml
@@ -59,6 +59,10 @@
 	<table_data name="personinfo">
 	</table_data>
 	<table_data name="postcode_lookup">
+      <row>
+          <field name="postcode">SW1A 1AA</field>
+          <field name="name">Cities of London and Westminster</field>
+      </row>
 	</table_data>
 	<table_data name="search_query_log">
 	</table_data>

--- a/tests/_fixtures/postcodepage.xml
+++ b/tests/_fixtures/postcodepage.xml
@@ -1,0 +1,241 @@
+<?xml version="1.0"?>
+<mysqldump xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<database name="twfy_testing">
+	<table_data name="alerts">
+	</table_data>
+	<table_data name="anonvotes">
+	</table_data>
+	<table_data name="api_key">
+	</table_data>
+	<table_data name="api_stats">
+	</table_data>
+	<table_data name="bills">
+		<row>
+			<field name="id">1</field>
+			<field name="title">Test Bill</field>
+			<field name="url">http://example.com</field>
+			<field name="type">unknown</field>
+			<field name="lords">0</field>
+			<field name="session">2013-14</field>
+			<field name="standingprefix">test_</field>
+		</row>
+	</table_data>
+	<table_data name="campaigners">
+	</table_data>
+	<table_data name="campaigners_sent_email">
+	</table_data>
+	<table_data name="commentreports">
+	</table_data>
+	<table_data name="comments">
+	</table_data>
+	<table_data name="consinfo">
+		<row>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="data_key">test_constituency_key</field>
+			<field name="data_value">Test Constituency Value</field>
+		</row>
+	</table_data>
+	<table_data name="constituency">
+        <row>
+            <field name="name">Test Scottish Westminster Constituency</field>
+            <field name="main_name">1</field>
+            <field name="from_date">1983-00-00</field>
+            <field name="to_date">9999-12-31</field>
+            <field name="cons_id">11</field>
+        </row>
+        <row>
+            <field name="name">Test NI Westminster Constituency</field>
+            <field name="main_name">1</field>
+            <field name="from_date">1983-00-00</field>
+            <field name="to_date">9999-12-31</field>
+            <field name="cons_id">12</field>
+        </row>
+	</table_data>
+	<table_data name="editqueue">
+	</table_data>
+	<table_data name="epobject">
+	</table_data>
+	<table_data name="future">
+	</table_data>
+	<table_data name="future_people">
+	</table_data>
+	<table_data name="gidredirect">
+	</table_data>
+	<table_data name="glossary">
+	</table_data>
+	<table_data name="hansard">
+	</table_data>
+	<table_data name="indexbatch">
+	</table_data>
+	<table_data name="member">
+		<row>
+			<field name="member_id">1</field>
+			<field name="house">1</field>
+			<field name="constituency">Test Westminster Constituency</field>
+			<field name="party"></field>
+			<field name="entered_house">2007-05-06</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">2</field>
+			<field name="lastupdate">2013-08-07 11:02:49</field>
+		</row>
+		<row>
+			<field name="member_id">2</field>
+			<field name="house">1</field>
+			<field name="constituency">Test Scottish Westminster Constituency</field>
+			<field name="party"></field>
+			<field name="entered_house">2007-05-06</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">3</field>
+			<field name="lastupdate">2013-08-07 11:02:49</field>
+		</row>
+		<row>
+			<field name="member_id">3</field>
+			<field name="house">4</field>
+			<field name="constituency">Test Holyrood Constituency</field>
+			<field name="party"></field>
+			<field name="entered_house">2007-05-06</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">4</field>
+			<field name="lastupdate">2013-08-07 11:02:49</field>
+		</row>
+		<row>
+			<field name="member_id">4</field>
+			<field name="house">4</field>
+			<field name="constituency">Test Scottish Region</field>
+			<field name="party"></field>
+			<field name="entered_house">2007-05-06</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">5</field>
+			<field name="lastupdate">2013-08-07 11:02:49</field>
+		</row>
+		<row>
+			<field name="house">1</field>
+			<field name="member_id">5</field>
+			<field name="constituency">Test NI Westminster Constituency</field>
+			<field name="party"></field>
+			<field name="entered_house">2007-05-06</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">6</field>
+			<field name="lastupdate">2013-08-07 11:02:49</field>
+		</row>
+		<row>
+			<field name="member_id">6</field>
+			<field name="house">3</field>
+			<field name="constituency">Test Stormont Constituency</field>
+			<field name="party"></field>
+			<field name="entered_house">2007-05-06</field>
+			<field name="left_house">9999-12-31</field>
+			<field name="entered_reason">general_election</field>
+			<field name="left_reason">still_in_office</field>
+			<field name="person_id">7</field>
+			<field name="lastupdate">2013-08-07 11:02:49</field>
+		</row>
+	</table_data>
+	<table_data name="person_names">
+		<row>
+			<field name="given_name">Test</field>
+			<field name="family_name">Current-MP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">2</field>
+			<field name="title">Mrs</field>
+		</row>
+		<row>
+			<field name="given_name">Test2</field>
+			<field name="family_name">Current-MP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">3</field>
+			<field name="title">Mr</field>
+		</row>
+		<row>
+			<field name="given_name">Test</field>
+			<field name="family_name">Current-MSP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">4</field>
+			<field name="title">Mrs</field>
+		</row>
+		<row>
+			<field name="given_name">Test</field>
+			<field name="family_name">Current-Regional-MSP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">5</field>
+			<field name="title">Dr</field>
+		</row>
+		<row>
+			<field name="given_name">Test3</field>
+			<field name="family_name">Current-MP</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">6</field>
+			<field name="title">Miss</field>
+		</row>
+		<row>
+			<field name="given_name">Test</field>
+			<field name="family_name">Current-MLA</field>
+			<field name="start_date">2000-01-01</field>
+			<field name="end_date">9999-12-31</field>
+			<field name="person_id">7</field>
+			<field name="title">Mr</field>
+		</row>
+	</table_data>
+	<table_data name="memberinfo">
+	</table_data>
+	<table_data name="mentions">
+	</table_data>
+	<table_data name="moffice">
+	</table_data>
+	<table_data name="pbc_members">
+	</table_data>
+	<table_data name="personinfo">
+	</table_data>
+	<table_data name="postcode_lookup">
+      <row>
+          <field name="postcode">PH6 2DB</field>
+          <field name="name">Test Scottish Westminster Constituency|Test Holyrood Constituency|Test Scottish Region</field>
+      </row>
+      <row>
+          <field name="postcode">BT1 1AA</field>
+          <field name="name">Test NI Westminster Constituency|Test Stormont Constituency</field>
+      </row>
+      <row>
+          <field name="postcode">SW1A 1AA</field>
+          <field name="name">Test Westminster Constituency</field>
+      </row>
+      <row>
+          <field name="postcode">OX1 4LF</field>
+          <field name="name">Another Westminster Constituency</field>
+      </row>
+	</table_data>
+	<table_data name="search_query_log">
+	</table_data>
+	<table_data name="survey">
+	</table_data>
+	<table_data name="titles">
+	</table_data>
+	<table_data name="titles_ignored">
+	</table_data>
+	<table_data name="trackbacks">
+	</table_data>
+	<table_data name="users">
+	</table_data>
+	<table_data name="uservotes">
+	</table_data>
+	<table_data name="video_timestamps">
+	</table_data>
+	<table_data name="editorial">
+	</table_data>
+</database>
+</mysqldump>

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -494,6 +494,7 @@ switch ($pagetype) {
         $divisions = new MySociety\TheyWorkForYou\Divisions($MEMBER, $positions, $policiesList);
 
         if ( $policyID ) {
+            $data['policy'] = $policiesList->getPolicyDetails($policyID);
             $data['policydivisions'] = $divisions->getMemberDivisionsForPolicy($policyID);
         } else {
             $data['policydivisions'] = $divisions->getAllMemberDivisionsByPolicy();

--- a/www/docs/postcode/index.php
+++ b/www/docs/postcode/index.php
@@ -52,10 +52,26 @@ $PAGE->page_end();
 function postcode_error($error) {
     global $PAGE;
     $hidden = get_policy_array();
+    $title = '';
+    if (count($hidden) > 0 ) {
+        $policies = new \MySociety\TheyWorkForYou\Policies();
+
+        if (isset($hidden['policy_number'])) {
+            $policies = $policies->getPolicies();
+            if (isset($policies[$hidden['policy_number']])) {
+                $title = "Find out how your MP voted on " . $policies[$hidden['policy_number']] . ".";
+            }
+        } else if (isset($hidden['policy_set'])) {
+            $sets = $policies->getSetDescriptions();
+            if (isset($sets[$hidden['policy_set']])) {
+                $title = "Find out how your MP voted on " . $sets[$hidden['policy_set']] . ".";
+            }
+        }
+    }
     $PAGE->page_start();
     $PAGE->stripe_start();
     $PAGE->error_message($error);
-    $PAGE->postcode_form($hidden);
+    $PAGE->postcode_form($hidden, $title);
     $PAGE->stripe_end();
     $PAGE->page_end();
     exit;

--- a/www/docs/postcode/index.php
+++ b/www/docs/postcode/index.php
@@ -187,7 +187,14 @@ function member_redirect(&$MEMBER, $options = array()) {
         } else {
             $url = $MEMBER->url();
         }
-        header("Location: $url");
+        // awfulness so we can test this works becuase we use the CLI
+        // in our test framework for page requests and the CLI doesn't
+        // print out headers
+        if (php_sapi_name() === 'cli') {
+            print("Location: $url");
+        } else {
+            header("Location: $url");
+        }
         exit;
     }
 }

--- a/www/docs/postcode/index.php
+++ b/www/docs/postcode/index.php
@@ -26,16 +26,19 @@ if ($constituencies == 'CONNECTION_TIMED_OUT') {
 }
 
 $out = ''; $sidebars = array();
-if (isset($constituencies['SPE']) || isset($constituencies['SPC'])) {
+$options = get_policy_array();
+// if there is a policy set or a policy number then assume we want the MP
+// as those arguments only make sense for MPs
+if (count($options) == 0 && (isset($constituencies['SPE']) || isset($constituencies['SPC']))) {
     $MEMBER = fetch_mp($pc, $constituencies);
     list($out, $sidebars) = pick_multiple($pc, $constituencies, 'SPE', 'MSP');
-} elseif (isset($constituencies['NIE'])) {
+} elseif (count($options) == 0 && isset($constituencies['NIE'])) {
     $MEMBER = fetch_mp($pc, $constituencies);
     list($out, $sidebars) = pick_multiple($pc, $constituencies, 'NIE', 'MLA');
 } else {
     # Just have an MP, redirect instantly to the canonical page
     $MEMBER = fetch_mp($pc, $constituencies, 1);
-    member_redirect($MEMBER);
+    member_redirect($MEMBER, $options);
 }
 
 $PAGE->page_start();
@@ -48,10 +51,11 @@ $PAGE->page_end();
 
 function postcode_error($error) {
     global $PAGE;
+    $hidden = get_policy_array();
     $PAGE->page_start();
     $PAGE->stripe_start();
     $PAGE->error_message($error);
-    $PAGE->postcode_form();
+    $PAGE->postcode_form($hidden);
     $PAGE->stripe_end();
     $PAGE->page_end();
     exit;
@@ -64,7 +68,7 @@ function fetch_mp($pc, $constituencies, $house=null) {
         $args['house'] = $house;
     }
     try {
-        $MEMBER = new MEMBER($args);
+        $MEMBER = new \MySociety\TheyWorkForYou\Member($args);
     } catch (MySociety\TheyWorkForYou\MemberException $e){
         postcode_error($e->getMessage());
     }
@@ -160,10 +164,25 @@ function pick_multiple($pc, $areas, $area_type, $rep_type) {
     return array($out, $sidebar);
 }
 
-function member_redirect(&$MEMBER) {
+function member_redirect(&$MEMBER, $options = array()) {
     if ($MEMBER->valid) {
-        $url = $MEMBER->url();
+        if (count($options) > 0 ) {
+            $url = $MEMBER->getPolicyURL($options);
+        } else {
+            $url = $MEMBER->url();
+        }
         header("Location: $url");
         exit;
     }
+}
+
+function get_policy_array() {
+    $policy_options = array();
+    if ($policy_set = get_http_var('policy_set')) {
+        $policy_options['policy_set'] = $policy_set;
+    } else if ($policy_number = get_http_var('policy_number')) {
+        $policy_options['policy_number'] = $policy_number;
+    }
+
+    return $policy_options;
 }

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -349,7 +349,7 @@ class PAGE {
         $this->heading_displayed = true;
     }
 
-    public function postcode_form() {
+    public function postcode_form($hidden = array()) {
         // Used on the mp (and yourmp) pages.
         // And the userchangepc page.
         global $THEUSER;

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -349,13 +349,17 @@ class PAGE {
         $this->heading_displayed = true;
     }
 
-    public function postcode_form($hidden = array()) {
+    public function postcode_form($hidden = array(), $title = '') {
         // Used on the mp (and yourmp) pages.
         // And the userchangepc page.
         global $THEUSER;
 
+        if ($title == '') {
+            $title = 'Find out about your MP/MSPs/MLAs';
+        }
+
         echo '<br>';
-        $this->block_start(array('id'=>'mp', 'title'=>'Find out about your MP/MSPs/MLAs'));
+        $this->block_start(array('id'=>'mp', 'title'=>$title));
         echo '<form action="/postcode/" method="get">';
         if (count($hidden) > 0) {
             foreach ($hidden as $field => $value) {

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -357,6 +357,11 @@ class PAGE {
         echo '<br>';
         $this->block_start(array('id'=>'mp', 'title'=>'Find out about your MP/MSPs/MLAs'));
         echo '<form action="/postcode/" method="get">';
+        if (count($hidden) > 0) {
+            foreach ($hidden as $field => $value) {
+                echo('<input type="hidden" name="' . $field . '" value="' . _htmlentities($value) . '">');
+            }
+        }
         if ($THEUSER->postcode_is_set()) {
             $FORGETURL = new URL('userchangepc');
             $FORGETURL->insert(array('forget'=>'t'));

--- a/www/includes/easyparliament/templates/html/mp/divisions.php
+++ b/www/includes/easyparliament/templates/html/mp/divisions.php
@@ -126,8 +126,26 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
                 <?php if (!$displayed_votes) { ?>
 
+                    <?php if ( isset($policy['image']) ) { ?>
+                        <div class="panel policy-votes-hero" style="background-image: url('<?php echo $policy['image']; ?>');">
+                            <h2><?php echo $policy['title']; ?></h2>
+                            <p><?php echo $policy['description']; ?>.</p>
+                            <?php if ( $policy['image_source'] ) { ?>
+                            <span class="policy-votes-hero__image-attribution">
+                                Photo:
+                                <a href="<?php echo $policy['image_source']; ?>">
+                                    <?php echo $policy['image_attribution']; ?>
+                                </a>
+                                <a href="<?php echo $policy['image_license_url']; ?>">
+                                    <?php echo $policy['image_license']; ?>
+                                </a>
+                            </span>
+                            <?php } ?>
+                        </div>
+                    <?php } ?>
+
                     <div class="panel">
-                        <p>This person has not voted on this policy.</p>
+                        <p><?= $full_name ?> has not voted on this policy.</p>
                     </div>
 
                 <?php }


### PR DESCRIPTION
Add the ability to specify a policy set or policy to visit after the user has set their postcode at `/postcode` so that we can link to a policy from e.g. social media.

By adding either `?policy_set=social` or `?policy_number=6710` the postcode page will redirect to the relevant policy set or policy page for the MP.

If the user is in Scotland or Northern Ireland the choose representative page isn't shown as we only have policies for MPs so offering them a choice to see an MSP or MLA isn't going to be useful.

There's also a change to the postcode form title to indicate that putting in a postcode is part of the process of getting the information.

![screen shot 2017-04-13 at 16 45 29](https://cloud.githubusercontent.com/assets/5310/25012515/a3974ff4-2068-11e7-9ea1-292ffe30e330.png)


Fixes #1248