### PR TITLE
WIP: Get tests passing on PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,11 @@ php:
   - "5.5"
   - "5.6"
   - "7.0"
+  - "7.1"
 
 matrix:
   allow_failures:
-    - php: "7.0"
+    - php: "7.1"
 
 services:
   - memcached
@@ -32,7 +33,7 @@ before_script:
  - mysql -e "create database IF NOT EXISTS twfy_test;" -uroot
  - mysql -u root twfy_test < db/schema.sql
  - php composer.phar install --no-interaction --prefer-source
- - echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+ - bash -c 'if [ $(echo "$TRAVIS_PHP_VERSION>=7.0" | bc -l) == 1 ]; then echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; else echo "extension = memcache.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
 
 script:
  - mkdir -p build/logs

--- a/classes/Memcache.php
+++ b/classes/Memcache.php
@@ -14,20 +14,33 @@ class Memcache {
 
     public function __construct() {
         if (!self::$memcache) {
-            self::$memcache = new \Memcache;
-            self::$memcache->connect('localhost', 11211);
+            if (class_exists('\Memcached')) {
+                self::$memcache = new \Memcached;
+                self::$memcache->addServer('localhost', 11211);
+            } else {
+                self::$memcache = new \Memcache;
+                self::$memcache->connect('localhost', 11211);
+            }
         }
     }
 
     public function set($key, $value, $timeout = 3600) {
-        self::$memcache->set(OPTION_TWFY_DB_NAME . ':' . $key, $value, MEMCACHE_COMPRESSED, $timeout);
+        if (class_exists('\Memcached')) {
+            self::$memcache->set(OPTION_TWFY_DB_NAME.':'.$key, $value, $timeout);
+        } else {
+            self::$memcache->set(OPTION_TWFY_DB_NAME.':'.$key, $value, MEMCACHE_COMPRESSED, $timeout);
+        }
     }
 
     public function get($key) {
         // see http://php.net/manual/en/memcache.get.php#112056 for explanation of this
         $was_found = false;
-        $value = self::$memcache->get(OPTION_TWFY_DB_NAME . ':' . $key, $was_found);
-        if ( $was_found === false ) {
+        if (class_exists('\Memcached')) {
+            $value = self::$memcache->get(OPTION_TWFY_DB_NAME.':'.$key, null, $was_found);
+        } else {
+            $value = self::$memcache->get(OPTION_TWFY_DB_NAME.':'.$key, $was_found);
+        }
+        if ($was_found === false) {
             return false; // mmmmm
         } else {
             return $value;


### PR DESCRIPTION
Makes the necessary changes to get tests passing on PHP 7 on Travis, more specifically:

* Do not attempt to overload `random_bytes()` if the function already exists.
* Conditionally use `memcached.so` instead of `memcache.so` on PHP 7 in Travis configuration.
* The `TWFY\Memcache` class now detects the presence of `\Memcached` and uses that (with appropriate syntax changes) where necessary.