### PR TITLE
Move Facebook SDK to use Packagist/Composer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "foundation"]
 	path = foundation
 	url = https://github.com/zurb/foundation.git
-[submodule "php-graph-sdk"]
-	path = php-graph-sdk
-	url = https://github.com/facebook/php-graph-sdk

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,14 @@
 {
     "autoload": {
         "psr-4": {
-            "MySociety\\TheyWorkForYou\\": "classes/",
-            "Facebook\\": "php-graph-sdk/src/Facebook/"
-        },
-        "files": ["php-graph-sdk/src/Facebook/polyfills.php"]
+            "MySociety\\TheyWorkForYou\\": "classes/"
+        }
     },
     "require": {
         "php": ">=5.4",
         "filp/whoops": "1.*",
-        "ircmaxell/password-compat": "1.0.4"
+        "ircmaxell/password-compat": "1.0.4",
+        "facebook/graph-sdk": "^5.6"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,66 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "26fc22fef873e697b0a53f68d4ee01ec",
+    "content-hash": "7b50a3b9797a7057b4fbcf6789da790f",
     "packages": [
+        {
+            "name": "facebook/graph-sdk",
+            "version": "5.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/facebook/php-graph-sdk.git",
+                "reference": "2f9639c15ae043911f40ffe44080b32bac2c5280"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/facebook/php-graph-sdk/zipball/2f9639c15ae043911f40ffe44080b32bac2c5280",
+                "reference": "2f9639c15ae043911f40ffe44080b32bac2c5280",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.4|^7.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "~5.0",
+                "mockery/mockery": "~0.8",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "guzzlehttp/guzzle": "Allows for implementation of the Guzzle HTTP client",
+                "paragonie/random_compat": "Provides a better CSPRNG option in PHP 5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Facebook\\": "src/Facebook/"
+                },
+                "files": [
+                    "src/Facebook/polyfills.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Facebook Platform"
+            ],
+            "authors": [
+                {
+                    "name": "Facebook",
+                    "homepage": "https://github.com/facebook/php-graph-sdk/contributors"
+                }
+            ],
+            "description": "Facebook SDK for PHP",
+            "homepage": "https://github.com/facebook/php-graph-sdk",
+            "keywords": [
+                "facebook",
+                "sdk"
+            ],
+            "time": "2017-08-16T17:28:07+00:00"
+        },
         {
             "name": "filp/whoops",
             "version": "1.1.10",


### PR DESCRIPTION
Swaps out loading the Facebook SDK via git submodule to using Composer and Packagist instead.