### PR TITLE
Add instruction to mention TWFY when emailing

### DIFF
--- a/www/docs/api/index.php
+++ b/www/docs/api/index.php
@@ -183,9 +183,9 @@ $em = join('&#64;', array('enquiries', 'mysociety.org'));
     registered charities, or individuals pursuing a non-profit project on an
     unpaid basis, with a volume of up to 50,000 calls per year. All other use
     requires a licence, as a contribution towards the costs of providing this
-    service. Please email us at <a href="mailto:<?=$em?>"><?=$em?></a> if your
-    usage is likely to fall into the non-free bracket: <strong>unlicensed users
-    may be blocked without warning</strong>.
+    service. Please email us at <a href="mailto:<?=$em?>"><?=$em?></a>
+    (mentioning TheyWorkForYou) if your usage is likely to fall into the
+    non-free bracket: <strong>unlicensed users may be blocked without warning</strong>.
 </p>
 
 <h3>Pricing</h3>


### PR DESCRIPTION
The email address quoted on this page gets email from a number of different sources, but people who find it via this page don't know that, so they quite often don't say what they're emailing about (assuming we'll know). Hopefully if we add a request to mention TWFY it'll reduce the headscratching and need for detective work when emails come in...