### PR TITLE
Restart Apache when booting Vagrant VM

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,4 +57,11 @@ Vagrant.configure(2) do |config|
     echo "Your site should now be visible at http://10.11.12.13/"
   SHELL
 
+  # It's likely the shared folder wasn't available when Apache started.
+  # So restart Apache again once the machine has started up.
+  config.vm.provision "shell", run: "always", inline: <<-SHELL
+    sudo apachectl restart
+    echo "Your site should now be visible at http://10.11.12.13/"
+  SHELL
+
 end


### PR DESCRIPTION
No idea why this is needed, but without it, whenever I start the VM and SSH in, Apache isn’t running, so I have to run it manually.

I’ve had this fix hanging around, unstaged, in my git directory for months. Figured I should finally see whether we want to merge it into `master` 😉 