### PR TITLE
Remove reference to a non-existent button

### DIFF
--- a/www/includes/easyparliament/templates/html/search/by-person.php
+++ b/www/includes/easyparliament/templates/html/search/by-person.php
@@ -34,7 +34,7 @@
               <?php if ( $wtt ) { ?>
                 <p><strong>Now, try reading what a couple of these Lords are saying,
                 to help you find someone appropriate. When you've found someone,
-                hit the "I want to write to this Lord" button on their results page
+                follow the "I want to write to (name of lord)" link on their results page
                 to go back to WriteToThem.
                 </strong></p>
               <?php } ?>


### PR DESCRIPTION
A user wrote in to say "I have followed the instructions however there is not a button named “I want to write to this Lord” as described." and was right, there isn't. This commit changes the instructions to refer to what's actually on the page (which changed, I presume, in a long-ago redesign).