### PR TITLE
Put links to any divisions at top of debate page.

### DIFF
--- a/www/docs/style/sass/pages/_divisions.scss
+++ b/www/docs/style/sass/pages/_divisions.scss
@@ -181,6 +181,14 @@
   }
 }
 
+// The "Votes in this debate" list, at the top of debate pages.
+ul.debate-speech__division__details {
+  clear: none;
+  margin-bottom: 0;
+  margin-top: -0.5em;
+  padding-left: 70px;
+}
+
 .division-section__vote {
   @media (min-width: 32em) {
     @include box-sizing(content-box);

--- a/www/includes/easyparliament/templates/html/section/_section_content.php
+++ b/www/includes/easyparliament/templates/html/section/_section_content.php
@@ -1,4 +1,6 @@
-  <?php foreach($data['rows'] as $speech) { ?>
+<?php
+
+foreach($data['rows'] as $speech) { ?>
 
     <?php
 
@@ -327,8 +329,11 @@
 
     <?php $previous_speech_time = $speech['htime']; ?>
 
-  <?php } // end foreach
-        if (isset($data['subrows'])) {
+<?php
+
+} // end foreach
+
+    if (isset($data['subrows'])) {
         print '<div class="subrows"><div class="full-page__row"><div class="full-page__unit"><ul>';
         foreach ($data['subrows'] as $row) {
             print '<li class="subrows__list-item">';
@@ -366,6 +371,7 @@
         }
         print '</ul></div></div></div>';
     }
+
     if ($section && $individual_item) { ?>
         <div class="debate-comments">
             <div class="full-page__row">
@@ -379,7 +385,5 @@
                 </div>
             </div>
         </div>
-        <?php
+<?php
     }
-
-?>

--- a/www/includes/easyparliament/templates/html/section/_section_toc.php
+++ b/www/includes/easyparliament/templates/html/section/_section_toc.php
@@ -1,0 +1,50 @@
+<?php
+
+$divisions_to_link = array();
+foreach($data['rows'] as $speech) {
+
+    # Only care about divisions...
+    if ($speech['htype'] != 14) {
+        continue;
+    }
+    # ...in Commons/Lords
+    if ($data['info']['major'] != 1 && $data['info']['major'] != 101) {
+        continue;
+    }
+
+    $divisions_to_link[] = $speech;
+}
+
+if (count($divisions_to_link)) {
+?>
+
+<div class="debate-speech">
+    <div class="full-page__row">
+        <div class="full-page__unit">
+            <div class="debate-speech__division">
+                <h2 class="debate-speech__division__header">
+                    <img src="/images/bell.png" alt="">
+                    <strong class="debate-speech__division__title">Votes in this debate</strong>
+                </h2>
+
+                <ul class="debate-speech__division__details">
+                    <?php foreach ($divisions_to_link as $speech) {
+                        $division = $speech['division'];
+                    ?>
+                    <li><a href="#g<?= gid_to_anchor($speech['gid']) ?>">Division number <?= $division['number'] ?></a>
+                        <?php if ($division['has_description']) { ?>
+                            <br><span class="policy-vote__text">
+                                <?php include( dirname(__FILE__) . '/../divisions/_vote_description.php'); ?>
+                            </span>
+                        <?php } ?>
+
+                    <?php } ?>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php
+
+}

--- a/www/includes/easyparliament/templates/html/section/section.php
+++ b/www/includes/easyparliament/templates/html/section/section.php
@@ -25,7 +25,11 @@
 
 <div class="full-page">
 
-<?php $section = true; include '_section_content.php'; ?>
+<?php
+    include '_section_toc.php';
+    $section = true;
+    include '_section_content.php';
+?>
 
 </div>
 


### PR DESCRIPTION
This adds a vote-contents list to the top of a debate page. If the vote has manual yes/no descriptions, they are also included, otherwise it will only be a list of division numbers.

<img width="1302" alt="screen shot 2018-12-17 at 16 43 42" src="https://user-images.githubusercontent.com/739624/50101611-f8e9fc00-021a-11e9-908d-e33fdd4055ab.png">

Fixes #1201.