### PR TITLE
Specify default encoding for stylesheets.

### DIFF
--- a/www/docs/style/config.rb
+++ b/www/docs/style/config.rb
@@ -20,3 +20,5 @@ line_comments = false
 # preferred_syntax = :sass
 # and then run:
 # sass-convert -R --from scss --to sass sass scss && rm -rf sass && mv scss sass
+
+Encoding.default_external = "utf-8"


### PR DESCRIPTION
This specifies a default encoding for stylesheets as UTF-8, which makes Compass happier in Vagrant boxes.