### PR TITLE
Update Vagrant box to use Xapian 1.4.9

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,6 +28,7 @@ Vagrant.configure(2) do |config|
   # Provision the vagrant box
   config.vm.provision "shell", inline: <<-SHELL
     export DEBIAN_FRONTEND=noninteractive
+    echo 'deb http://mirror.bytemark.co.uk/debian stretch-backports main' > /etc/apt/sources.list.d/backports.list
     apt-get update
 
     chown vagrant:vagrant /vagrant

--- a/bin/install-php7-xapian.sh
+++ b/bin/install-php7-xapian.sh
@@ -1,36 +1,54 @@
 #!/bin/sh
+#
+# Install php7-xapian from source
+#
+# Based on http://trac.xapian.org/wiki/FAQ/PHP%20Bindings%20Package, but
+# as we're using Xapian from stretch-backports and there's no corresponding
+# source package in the repos we manage that and its dependencies directly.
+#
+
+# Root URL for the xapian-bindings source for version 1.4.9 
+# matching the binaries in stretch-backports
+SOURCE_URL=https://snapshot.debian.org/archive/debian/20181104T030400Z/pool/main/x/xapian-bindings
+
+# version of PHP we're building for
+v=7.0
 
 echo "Checking for php7-xapian package... "
 if ! dpkg -l php7-xapian 2>/dev/null | grep -q '^.i'; then
-    # Install php5-xapian from source
-    # From http://trac.xapian.org/wiki/FAQ/PHP%20Bindings%20Package
     echo "Installing php7-xapian from source..."
     cd /tmp
-    echo "  Build dependencies for xapian-bindings... "
-    apt-get -qq build-dep xapian-bindings >/dev/null
 
-    v=7.0
-    echo "  PHP dev headers and devscripts... "
-    apt-get -qq install devscripts php$v-dev php$v-cli >/dev/null
-    echo "  xapian-bindings source... "
-    apt-get -qq source xapian-bindings=1.4.3-1 >/dev/null
-    cd xapian-bindings-1.4.3
+    echo "  Xapian dev headers from backports..."
+    apt-get -qq -t stretch-backports install libxapian-dev >/dev/null
 
-    echo "Get 1.4.5-1 debian bindings"
-    rm -fr debian
-    git clone --quiet https://salsa.debian.org/olly/xapian-bindings.git debian
-    cd debian
-    git checkout --quiet debian/1.4.5-1
-    git checkout --quiet debian/1.4.3-1 changelog
-    cd ..
+    echo "  build-essential and devscripts... "
+    apt-get -qq install build-essential devscripts >/dev/null
 
+    echo "  PHP dev headers... "
+    apt-get -qq install php$v-dev php$v-cli >/dev/null
+
+    echo "  Getting xapian-bindings source from snapshot.debian.org... "
+    wget ${SOURCE_URL}/xapian-bindings_1.4.9.orig.tar.xz
+    wget ${SOURCE_URL}/xapian-bindings_1.4.9-1.debian.tar.xz
+    wget ${SOURCE_URL}/xapian-bindings_1.4.9-1.dsc
+    tar xJf xapian-bindings_1.4.9.orig.tar.xz
+    tar xJf xapian-bindings_1.4.9-1.debian.tar.xz -C xapian-bindings-1.4.9
+    cd xapian-bindings-1.4.9
     echo php7 > debian/bindings-to-package
+
     echo "  debian/rules maint with PHP7_VERSIONS set... "
     debian/rules maint PHP7_VERSIONS=$v >/dev/null
+
     echo "  debuild... "
     env DEB_BUILD_OPTIONS=nocheck debuild -e PHP7_VERSIONS=$v -us -uc >/dev/null
     cd ..
+
     echo "  installing package... "
     dpkg -i php7-xapian_*.deb >/dev/null
+
+    echo "  enabling xapian extension for cgi and cli..."
+    /usr/sbin/phpenmod xapian
+
     rm -rf *xapian*
 fi


### PR DESCRIPTION
This adds backports to the apt sources in the Vagrant box and builds the PHP Xapian bindings for the corresponding Xapian version.