### PR TITLE
Link directly to screenshot of votes

### DIFF
--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -91,7 +91,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                             </ul>
 
                             <div class="share-vote-descriptions">
-                                <p>Share a screenshot of these votes:</p>
+                                <p>Share a <a href="<?= $abs_member_url ?>/policy_set_png?policy_set=<?= $segment['key'] ?>">screenshot</a> of these votes:</p>
 
                                 <a href="#" class="facebook-share-button js-facebook-share" data-text="<?= $single_policy_page ? '' : $segment['title'] . ' ' ?><?= $page_title ?>" data-url="<?= $abs_member_url ?>/votes?policy=<?= $segment['key'] ?>">Share</a>
 


### PR DESCRIPTION
It is nice that easily-shareable screenshots of an MP's voting record are available, but at the moment they're hard to get at; they're set up to be automatically used when shared on social media (through the `og:image` meta element) but it may be useful to allow people to get at those images directly so they can copy them to share in other places (for example, pasting them into chat apps, or sharing on social media without having to use the provided "share" buttons). So, make the word "screenshot" a link to that screenshot explicitly so it can be got at.