### PR TITLE
Plain-English versions of left_reason don't include entry for new value "recall_petition"

### DIFF
--- a/www/includes/easyparliament/member.php
+++ b/www/includes/easyparliament/member.php
@@ -46,6 +46,7 @@ class MEMBER {
         'general_election_not_standing' 	=> 'did not stand for re-election',
         'reinstated'		=> 'Reinstated',
         'resigned'		=> 'Resigned',
+        'recall_petition'   => 'Removed from office by a recall petition',
         'still_in_office'	=> 'Still in office',
         'dissolution'		=> 'Dissolved for election',
         'regional_election'	=> 'Election', # Scottish Parliament


### PR DESCRIPTION
Adding missing string for new ENUM value of "recall_petition"