### PR TITLE
Replaced email alert donate link

### DIFF
--- a/www/includes/easyparliament/templates/emails/alert_gone.txt
+++ b/www/includes/easyparliament/templates/emails/alert_gone.txt
@@ -29,6 +29,6 @@ United Kingdom
 TheyWorkForYou email alerts need love and support to look
 after. Please consider donating to mySociety to help us
 continue and expand:
-        http://www.mysociety.org/donate/
+        https://www.mysociety.org/twfy-donate/
 -------------------------------------------------------------------
 

--- a/www/includes/easyparliament/templates/emails/alert_mailout.txt
+++ b/www/includes/easyparliament/templates/emails/alert_mailout.txt
@@ -19,7 +19,7 @@ United Kingdom
 TheyWorkForYou email alerts need love and support to look
 after. Please consider donating to mySociety to help us
 continue and expand:
-        http://www.mysociety.org/donate/
+        https://www.mysociety.org/twfy-donate/
 -------------------------------------------------------------------
 
 To manage, unsubscribe or add to your alerts, please visit the following link:

--- a/www/includes/easyparliament/templates/emails/alert_new_mp.txt
+++ b/www/includes/easyparliament/templates/emails/alert_new_mp.txt
@@ -27,6 +27,6 @@ United Kingdom
 TheyWorkForYou email alerts need love and support to look
 after. Please consider donating to mySociety to help us
 continue and expand:
-        http://www.mysociety.org/donate/
+        https://www.mysociety.org/twfy-donate/
 -------------------------------------------------------------------
 


### PR DESCRIPTION
TWFY alert donate link doesn't current include campaign tracking information. 

This replaces the link with a redirect that introduces tracking information.

Addresses https://github.com/mysociety/theyworkforyou/issues/1388.