### PR TITLE
Vagrant adjustments

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,11 +8,11 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
-  config.vm.box = "debian/stretch64"
+  config.vm.box = "sagepe/stretch"
 
   # Enable NFS access to the disk
   config.vm.synced_folder ".", "/vagrant", disabled: true
-  config.vm.synced_folder ".", "/vagrant/theyworkforyou", :nfs => true
+  config.vm.synced_folder ".", "/vagrant/theyworkforyou"
 
   # NFS requires a host-only network
   # This also allows you to test via other devices (e.g. mobiles) on the same
@@ -35,7 +35,7 @@ Vagrant.configure(2) do |config|
     cd /vagrant/theyworkforyou
 
     # Install needed things
-    apt-get -qq -y install unzip fakeroot git >/dev/null
+    apt-get -qq -y install unzip fakeroot git libffi-dev >/dev/null
 
     # mysql and xapian
     bin/install-php7-xapian.sh
@@ -51,11 +51,6 @@ Vagrant.configure(2) do |config|
     cp conf/httpd.vagrant /etc/apache2/sites-enabled/twfy.conf
     a2enmod expires rewrite
     /etc/init.d/apache2 reload
-
-    # NFS woes mean you have to do this - it can't compile FFI inside
-    mkdir /home/vagrant/bundle
-    chown vagrant:vagrant /home/vagrant/bundle
-    ln -sn /home/vagrant/bundle vendor/bundle
 
     su vagrant -c 'bin/install-as-user vagrant 10.11.12.13 /vagrant yes'
     su vagrant -c 'bin/deploy.bash'

--- a/bin/install-php7-xapian.sh
+++ b/bin/install-php7-xapian.sh
@@ -9,7 +9,7 @@
 
 # Root URL for the xapian-bindings source for version 1.4.9 
 # matching the binaries in stretch-backports
-SOURCE_URL=https://snapshot.debian.org/archive/debian/20181104T030400Z/pool/main/x/xapian-bindings
+SOURCE_URL=https://snapshot.debian.org/archive/debian/20190625T042133Z/pool/main/x/xapian-bindings/
 
 # version of PHP we're building for
 v=7.0
@@ -29,12 +29,12 @@ if ! dpkg -l php7-xapian 2>/dev/null | grep -q '^.i'; then
     apt-get -qq install php$v-dev php$v-cli >/dev/null
 
     echo "  Getting xapian-bindings source from snapshot.debian.org... "
-    wget ${SOURCE_URL}/xapian-bindings_1.4.9.orig.tar.xz
-    wget ${SOURCE_URL}/xapian-bindings_1.4.9-1.debian.tar.xz
-    wget ${SOURCE_URL}/xapian-bindings_1.4.9-1.dsc
-    tar xJf xapian-bindings_1.4.9.orig.tar.xz
-    tar xJf xapian-bindings_1.4.9-1.debian.tar.xz -C xapian-bindings-1.4.9
-    cd xapian-bindings-1.4.9
+    wget ${SOURCE_URL}/xapian-bindings_1.4.11.orig.tar.xz
+    wget ${SOURCE_URL}/xapian-bindings_1.4.11-2.debian.tar.xz
+    wget ${SOURCE_URL}/xapian-bindings_1.4.11-2.dsc
+    tar xJf xapian-bindings_1.4.11.orig.tar.xz
+    tar xJf xapian-bindings_1.4.11-2.debian.tar.xz -C xapian-bindings-1.4.11
+    cd xapian-bindings-1.4.11
     echo php7 > debian/bindings-to-package
 
     echo "  debian/rules maint with PHP7_VERSIONS set... "


### PR DESCRIPTION
This updates the php7-xapian build script and uses a Vagrant box with Guest Additions installed rather than NFS.

Tested on a fresh clone (with submodules) - the box built successfully.
