### PR TITLE
Update crowfunder banners during and after crowdfunder

### DIFF
--- a/www/docs/js/main.js
+++ b/www/docs/js/main.js
@@ -349,4 +349,44 @@ $(function(){
     }
   });
 
+  function crowdfunder(now) {
+      var now_utc = (typeof now === 'undefined') ? new Date() : new Date(now);
+      var crowdfunder_end_utc = new Date(Date.UTC(2019, 11, 20, 12, 0, 0));
+      var hours_until_crowdfunder_end = (crowdfunder_end_utc - now_utc) / 3600000;
+      var crowdfunder_has_ended = 0;
+      var time_left_string = '' + Math.ceil(hours_until_crowdfunder_end / 24) + ' days';
+
+      if (hours_until_crowdfunder_end < 0) {
+          crowdfunder_has_ended = 1;
+      } else if (hours_until_crowdfunder_end < 2) {
+          time_left_string = 'an hour';
+      } else if (hours_until_crowdfunder_end < 12) {
+          time_left_string = 'a few hours';
+      } else if (hours_until_crowdfunder_end < 36) {
+          time_left_string = '1 day';
+      }
+
+      $('.js-crowdfunder-time-left').each(function(){
+          $(this).html(time_left_string);
+      });
+
+      $('.js-show-during-crowdfunder').each(function(){
+          if (crowdfunder_has_ended) {
+              $(this).hide();
+          } else {
+              $(this).show();
+          }
+      });
+
+      $('.js-show-after-crowdfunder').each(function(){
+          if (crowdfunder_has_ended) {
+              $(this).show();
+          } else {
+              $(this).hide();
+          }
+      });
+  }
+
+  crowdfunder();
+
 });

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -168,10 +168,10 @@
     </div>
   <?php } ?>
 
-  <div class="crowdfunding-topper">
+  <div class="crowdfunding-topper js-show-during-crowdfunder">
     <div class="full-page__row">
       <div class="full-page__unit">
-        <p>We need your support to keep TheyWorkForYou running and make sure people across the UK can continue to hold their elected representatives to account.</p>
+        <p><strong>Only <span class="js-crowdfunder-time-left">a few days</span> to go:</strong> We’re raising £25,000 to keep TheyWorkForYou running and make sure people across the UK can hold their elected representatives to account.</p>
         <a class="button button--negative" href="https://www.crowdfunder.co.uk/theyworkforyou" data-track-click="crowdfunder-header">Donate to our crowdfunder</a>
       </div>
     </div>

--- a/www/includes/easyparliament/templates/html/index.php
+++ b/www/includes/easyparliament/templates/html/index.php
@@ -68,15 +68,15 @@
                     </div>
                 </div>
             </div>
-            <!-- <div class="panel panel--video">
+            <div class="panel panel--video js-show-after-crowdfunder" style="display: none">
                 <h2>Inform yourself, get yourself heard</h2>
                 <div>
                     <div class="flex-video">
                         <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/L_19GumEQCM?rel=0&amp;showinfo=0" frameborder="0" allowfullscreen></iframe>
                     </div>
                 </div>
-            </div> -->
-            <div class="panel panel--primary panel--crowdfunding">
+            </div>
+            <div class="panel panel--primary panel--crowdfunding js-show-during-crowdfunder">
                 <h2>Can you help keep TheyWorkForYou running?</h2>
                 <p>Now more than ever, the UK needs TheyWorkForYou to provide clarity on what happens in Parliament. But we rely on public donations from users like you to keep the site running.</p>
                 <p>That’s why we’ve set up <a href="https://www.crowdfunder.co.uk/theyworkforyou">mySociety’s first ever crowdfunder</a>. If you enjoy — or perhaps even rely on — TheyWorkForYou’s services, then be a hero and pledge to help keep the site alive.</p>

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -42,10 +42,10 @@ $display_wtt_stats_banner = '2015';
             </div>
             <div class="primary-content__unit">
 
-                <div class="panel panel--primary panel--crowdfunding">
-                    <h2>We need your help</h2>
+                <div class="panel panel--primary panel--crowdfunding js-show-during-crowdfunder">
+                <h2>Crowdfunder – only <span class="js-crowdfunder-time-left">a few days</span> to go</h2>
+                    <p>We’re trying to raise £25,000 to support TheyWorkForYou into the future.</p>
                     <p>Please take a minute to <a href="https://www.crowdfunder.co.uk/theyworkforyou">donate to TheyWorkForYou</a> so we can bring you voting summaries like this for years to come.</p>
-                    <p>If everyone who visited TheyWorkForYou donated just £1, we’d reach our crowdfunding target in less than 3 days.</p>
                     <a href="https://www.crowdfunder.co.uk/theyworkforyou" class="button" data-track-click="crowdfunder-mp-profile">Donate now</a>
                 </div>
 

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -28,10 +28,10 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
             </div>
             <div class="primary-content__unit">
 
-                <div class="panel panel--primary panel--crowdfunding">
-                    <h2>We need your help</h2>
+                <div class="panel panel--primary panel--crowdfunding js-show-during-crowdfunder">
+                    <h2>Crowdfunder – only <span class="js-crowdfunder-time-left">a few days</span> to go</h2>
+                    <p>We’re trying to raise £25,000 to support TheyWorkForYou into the future.</p>
                     <p>Please take a minute to <a href="https://www.crowdfunder.co.uk/theyworkforyou">donate to TheyWorkForYou</a> so we can bring you voting summaries like this for years to come.</p>
-                    <p>If everyone who visited TheyWorkForYou donated just £1, we’d reach our crowdfunding target in less than 3 days.</p>
                     <a href="https://www.crowdfunder.co.uk/theyworkforyou" class="button" data-track-click="crowdfunder-mp-votes">Donate now</a>
                 </div>
 


### PR DESCRIPTION
Up until Thursday, the banners will say "only X days to go" (see screenshots below). On Thursday, they’ll say "only 1 day to go". On Friday, they’ll say "only a few hours to go", until 10:00, when they’ll say "only an hour to go".

After 12:00, all the banners will be hidden.

# Page topper

<img width="1193" alt="Screen Shot 2019-12-16 at 16 05 50" src="https://user-images.githubusercontent.com/739624/70922568-3778e900-201e-11ea-9153-3b07531b2eab.png">

# MP profile page

<img width="973" alt="Screen Shot 2019-12-16 at 16 06 11" src="https://user-images.githubusercontent.com/739624/70922573-3942ac80-201e-11ea-985e-d0e89ab9ec6d.png">

Fixes https://github.com/mysociety/theyworkforyou/issues/1493.