### PR TITLE
Remove New Zealand website links

### DIFF
--- a/classes/Renderer/Footer.php
+++ b/classes/Renderer/Footer.php
@@ -16,7 +16,7 @@ class Footer
 
     private $about_links = array ('help', 'about', 'linktous', 'houserules', 'blog', 'news', 'contact', 'privacy');
     private $assemblies_links = array('hansard', 'sp_home', 'ni_home', 'wales_home', 'london_home');
-    private $international_links = array('newzealand', 'australia', 'ireland', 'mzalendo');
+    private $international_links = array('australia', 'ireland', 'mzalendo');
     private $tech_links = array('code', 'api', 'data', 'pombola', 'devmailinglist', 'irc');
 
 

--- a/www/includes/easyparliament/metadata.php
+++ b/www/includes/easyparliament/metadata.php
@@ -474,11 +474,6 @@ $this->page = array (
         'heading'		=> 'IRC chat channel',
         'url'			=> 'http://www.irc.mysociety.org/'
     ),
-    'newzealand' => array (
-        'title'			=> 'New Zealand',
-        'heading'		=> 'They Work For You - New Zealand',
-        'url'			=> 'http://www.theyworkforyou.co.nz/'
-    ),
     'australia' => array (
         'title'			=> 'Australia',
         'heading'		=> 'Open Australia',

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -177,13 +177,11 @@
     </div>
   </div>
 
-  <?php if (isset($country) && in_array($country, array('NZ', 'AU', 'IE', 'CA'))) { ?>
+  <?php if (isset($country) && in_array($country, array('AU', 'IE', 'CA'))) { ?>
     <div class="banner">
         <div class="full-page__row">
             <div class="banner__content">
-              <?php if ($country == 'NZ') { ?>
-                You&rsquo;re in New Zealand, so check out <a href="http://www.theyworkforyou.co.nz">TheyWorkForYou.co.nz</a>
-              <?php } elseif ($country == 'AU') { ?>
+              <?php if ($country == 'AU') { ?>
                 You&rsquo;re in Australia, so check out <a href="http://www.openaustralia.org">OpenAustralia</a>, a TheyWorkForYou for down under
               <?php } elseif ($country == 'IE') { ?>
                 Check out <a href="https://www.kildarestreet.com/">KildareStreet</a>, a TheyWorkForYou for the Houses of the Oireachtas


### PR DESCRIPTION
Resolves #1465 

Removal of defunct theyworkforyou.co.nz site