### PR TITLE
Add hint about where to manage your API account

### DIFF
--- a/www/docs/api/api_functions.php
+++ b/www/docs/api/api_functions.php
@@ -184,9 +184,15 @@ function api_check_key($key) {
 
 # Front-end sidebar of all methods
 
-function api_sidebar() {
+function api_sidebar($subscription) {
     global $methods;
-    $sidebar = '<div class="block"><h4>API Functions</h4> <div class="blockbody"><ul>';
+    $sidebar = '';
+    if ($subscription && $subscription->stripe) {
+        $sidebar .= '<div class="block"><h4>Your account</h4><div class="blockbody"><ul>';
+        $sidebar .= '<li><a href="/api/key">Plan and keys</a></li>';
+        $sidebar .= '</ul></div></div>';
+    }
+    $sidebar .= '<div class="block"><h4>API Functions</h4> <div class="blockbody"><ul>';
     foreach ($methods as $method => $data) {
         if (isset($data['superuser']) && $data['superuser']) {
             continue;

--- a/www/docs/api/cancel-plan.php
+++ b/www/docs/api/cancel-plan.php
@@ -29,6 +29,6 @@ $PAGE->stripe_start();
 
 include_once INCLUDESPATH . 'easyparliament/templates/html/api/cancel.php';
 
-$sidebar = api_sidebar();
+$sidebar = api_sidebar($subscription);
 $PAGE->stripe_end(array($sidebar));
 $PAGE->page_end();

--- a/www/docs/api/index.php
+++ b/www/docs/api/index.php
@@ -88,7 +88,7 @@ if ($q_method = get_http_var('method')) {
 }
 
 function api_documentation_front($method, $explorer) {
-    global $PAGE, $this_page, $DATA;
+    global $PAGE, $this_page, $DATA, $THEUSER;
     $this_page = 'api_doc_front';
     $DATA->set_page_metadata($this_page, 'title', "$method function");
     $PAGE->page_start();
@@ -99,7 +99,9 @@ function api_documentation_front($method, $explorer) {
     if ($method != 'getQuota') {
         api_documentation_explorer($method, $explorer);
     }
-    $sidebar = api_sidebar();
+
+    $subscription = new MySociety\TheyWorkForYou\Subscription($THEUSER);
+    $sidebar = api_sidebar($subscription);
     $PAGE->stripe_end(array($sidebar));
     $PAGE->page_end();
 }
@@ -154,15 +156,25 @@ function api_front_page($error = '') {
         print "<p style='color: #cc0000'>$error</p>";
     }
 
+    $subscription = new MySociety\TheyWorkForYou\Subscription($THEUSER);
+
 ?>
 
 <p>
     Welcome to TheyWorkForYou’s API section. The API (Application Programming
     Interface) is a way of querying our database for information.
 </p>
+
+<?php if ($subscription->stripe) { ?>
+<p align="center"><big>
+    <a href="key">Manage your keys and payments</a>
+</big></p>
+<?php } else { ?>
 <p align="center"><big>
     To use the API you need to <a href="key">get an API key</a>.
 </big></p>
+<?php } ?>
+
 <p>
     The documentation for each individual API function is linked from this
     page: you can read what each function does, and test it out, without
@@ -193,9 +205,16 @@ non-profit project on an unpaid basis.</p>
 <p>Please read our full <a href="/api/terms">terms of usage</a>, including
 licence and attribution requirements.</p>
 
+<?php if ($subscription->stripe) { ?>
+<p align="center"><big>
+    <a href="key">Manage your keys and payments</a>
+</big></p>
+<?php } else { ?>
 <p align="center"><big>
     To use the API you need to <a href="key">get an API key</a>.
 </big></p>
+<?php } ?>
+
 
 <hr>
 
@@ -270,7 +289,7 @@ to discuss things.</p>
 </ul>
 
 <?php
-    $sidebar = api_sidebar();
+    $sidebar = api_sidebar($subscription);
     $PAGE->stripe_end(array($sidebar));
     $PAGE->page_end();
 }

--- a/www/docs/api/key.php
+++ b/www/docs/api/key.php
@@ -10,6 +10,7 @@ $this_page = 'api_key';
 $PAGE->page_start();
 $PAGE->stripe_start();
 
+$subscription = null;
 if ($THEUSER->loggedin()) {
     if (get_http_var('create_key')) {
         if (!Volnix\CSRF\CSRF::validate($_POST)) {
@@ -90,7 +91,7 @@ if ($THEUSER->loggedin()) {
     logged_out();
 }
 
-$sidebar = api_sidebar();
+$sidebar = api_sidebar($subscription);
 $PAGE->stripe_end(array($sidebar));
 $PAGE->page_end();
 

--- a/www/docs/api/update-plan.php
+++ b/www/docs/api/update-plan.php
@@ -30,6 +30,6 @@ $PAGE->stripe_start();
 
 include_once INCLUDESPATH . 'easyparliament/templates/html/api/update.php';
 
-$sidebar = api_sidebar();
+$sidebar = api_sidebar($subscription);
 $PAGE->stripe_end(array($sidebar));
 $PAGE->page_end();


### PR DESCRIPTION
We get more email than I'd like from people who can't figure out how to manage, change, cancel their subscription. This might help them find the page?