### PR TITLE
Add party voting line to MP votes page.

### DIFF
--- a/classes/Member.php
+++ b/classes/Member.php
@@ -388,11 +388,18 @@ class Member extends \MEMBER {
                 if ( $only_diffs && $score_diff < 2 ) {
                     continue;
                 }
-                $policy_diffs[$policy_id] = $score_diff;
+                $policy_diffs[$policy_id] = [
+                    'policy_text' => $details['policy'],
+                    'score_difference' => $score_diff,
+                    'person_position' => $details['position'],
+                    'party_position' => $party_positions[$policy_id]['position'],
+                ];
             }
         }
 
-        arsort($policy_diffs);
+        uasort($policy_diffs, function($a, $b) {
+            return $b['score_difference'] - $a['score_difference'];
+        });
 
         return $policy_diffs;
     }

--- a/tests/VotesTest.php
+++ b/tests/VotesTest.php
@@ -22,7 +22,7 @@ class VotesTest extends FetchPageTestCase
 
     public function testVoteSummary() {
         $page = $this->fetch_votes_page();
-        $this->assertContains('policy=363">0 votes for, 4 votes against, 1 abstention, 1 absence, in 2013', $page);
+        $this->assertRegexp('#policy=363">\s*0 votes for, 4 votes against, 1 abstention, 1 absence, in 2013#', $page);
     }
 
     public function testLastUpdate() {

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -344,8 +344,8 @@ switch ($pagetype) {
         if ( $policy_set && array_key_exists($policy_set, $set_descriptions) ) {
             $sets = array($policy_set);
             $data['og_image'] = $MEMBER->url(true) . "/policy_set_png?policy_set=" . $policy_set;
-            $data['page_title'] = $policiesList->getSetDescriptions()[$policy_set] . ' ' . $title . ' - TheyWorkForYou';
-            $data['meta_description'] = 'See how ' . $data['full_name'] . ' voted on ' . $policiesList->getSetDescriptions()[$policy_set];
+            $data['page_title'] = $set_descriptions[$policy_set] . ' ' . $title . ' - TheyWorkForYou';
+            $data['meta_description'] = 'See how ' . $data['full_name'] . ' voted on ' . $set_descriptions[$policy_set];
             $data['single_policy_page'] = true;
         } else {
             $data['single_policy_page'] = false;

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -368,6 +368,8 @@ switch ($pagetype) {
             );
         }
 
+        person_party_policy_diffs($MEMBER, $policiesList, false);
+
         // Send the output for rendering
         MySociety\TheyWorkForYou\Renderer::output('mp/votes', $data);
 
@@ -421,19 +423,7 @@ switch ($pagetype) {
         // Generate limited voting record list
         $data['policyPositions'] = new MySociety\TheyWorkForYou\PolicyPositions($policies, $MEMBER, $policyOptions);
 
-        // generate party policy diffs
-        $party = new MySociety\TheyWorkForYou\Party($MEMBER->party());
-        $positions = new MySociety\TheyWorkForYou\PolicyPositions( $policiesList, $MEMBER );
-        $party_positions = $party->getAllPolicyPositions($policiesList);
-        $policy_diffs = $MEMBER->getPartyPolicyDiffs($party, $policiesList, $positions, true);
-
-        $data['sorted_diffs'] = $policy_diffs;
-        # house hard coded as this is only used for the party position
-        # comparison which is Commons only
-        $data['party_member_count'] = $party->getCurrentMemberCount(HOUSE_TYPE_COMMONS);
-        $data['party_positions'] = $party_positions;
-        $data['positions'] = $positions->positionsById;
-        $data['policies'] = $policiesList->getPolicies();
+        person_party_policy_diffs($MEMBER, $policiesList, true);
 
         // Send the output for rendering
         MySociety\TheyWorkForYou\Renderer::output('mp/profile', $data);
@@ -1042,4 +1032,19 @@ function policy_image($data, $MEMBER, $format) {
 
     $im->clear();
     $im->destroy();
+}
+
+// generate party policy diffs
+function person_party_policy_diffs($MEMBER, $policiesList, $only_diffs) {
+    global $data;
+
+    $party = new MySociety\TheyWorkForYou\Party($MEMBER->party());
+    $data['party_positions'] = $party->getAllPolicyPositions($policiesList);
+    # house hard coded as this is only used for the party position
+    # comparison which is Commons only
+    $data['party_member_count'] = $party->getCurrentMemberCount(HOUSE_TYPE_COMMONS);
+
+    $positions = new MySociety\TheyWorkForYou\PolicyPositions( $policiesList, $MEMBER );
+    $policy_diffs = $MEMBER->getPartyPolicyDiffs($party, $policiesList, $positions, $only_diffs);
+    $data['sorted_diffs'] = $policy_diffs;
 }

--- a/www/includes/easyparliament/templates/html/mp/_vote_description.php
+++ b/www/includes/easyparliament/templates/html/mp/_vote_description.php
@@ -2,8 +2,11 @@
     <?= $description ?>
     <?php if ( $show_link ) { ?>
         <a class="vote-description__source" href="<?= $link ?>">Show votes</a>
-        <?php if (isset($key_vote)) { ?>
-        <a class="vote-description__evidence" href="<?= $link ?>"><?= $key_vote['summary'] ?></a>
+        <?php if (isset($key_vote) || isset($party_voting_line)) { ?>
+        <a class="vote-description__evidence" href="<?= $link ?>">
+            <?= isset($key_vote) ? "$key_vote[summary]." : '' ?>
+            <?= isset($party_voting_line) ? $party_voting_line : '' ?>
+        </a>
         <?php } ?>
     <?php } ?>
 </li>

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -106,16 +106,16 @@ $display_wtt_stats_banner = '2015';
                         </p>
 
                         <ul class="vote-descriptions">
-                          <?php foreach ($sorted_diffs as $policy_id => $score) {
+                          <?php foreach ($sorted_diffs as $policy_id => $diff) {
 
                             $key_vote = NULL;
                             $description = sprintf(
-                                '%s <b>%s</b> %s; most %s MPs <b>%s</b>.',
+                                '%s <b>%s</b> %s; most current %s MPs <b>%s</b>.',
                                 $full_name,
-                                $positions[$policy_id]['position'],
-                                strip_tags($policies[$policy_id]),
+                                $diff['person_position'],
+                                strip_tags($diff['policy_text']),
                                 $party,
-                                $party_positions[$policy_id]['position']
+                                $diff['party_position']
                             );
                             $link = $member_url . '/divisions?policy=' . $policy_id;
                             $show_link = true;

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -65,9 +65,10 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
                             <ul class="vote-descriptions">
                               <?php foreach ($segment['votes']->positions as $key_vote) {
+                                $policy_id = $key_vote['policy_id'];
 
-                                if (isset($policy_last_update[$key_vote['policy_id']]) && $policy_last_update[$key_vote['policy_id']] > $most_recent) {
-                                  $most_recent = $policy_last_update[$key_vote['policy_id']];
+                                if (isset($policy_last_update[$policy_id]) && $policy_last_update[$policy_id] > $most_recent) {
+                                  $most_recent = $policy_last_update[$policy_id];
                                 }
 
                                 if ( $key_vote['has_strong'] || $key_vote['position'] == 'has never voted on' ) {
@@ -82,7 +83,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                                 $link = sprintf(
                                     '%s/divisions?policy=%s',
                                     $member_url,
-                                    $key_vote['policy_id']
+                                    $policy_id
                                 );
                                 $show_link = $key_vote['position'] != 'has never voted on';
 

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -87,6 +87,13 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                                 );
                                 $show_link = $key_vote['position'] != 'has never voted on';
 
+                                if (isset($sorted_diffs[$policy_id]) && $sorted_diffs[$policy_id]['score_difference'] > 1 && $party_member_count > 1) {
+                                    $diff = $sorted_diffs[$policy_id];
+                                    $party_voting_line = sprintf( 'Most current %s MPs %s.', $party, $diff['party_position']);
+                                } else {
+                                    $party_voting_line = null;
+                                }
+
                                 include '_vote_description.php';
 
                               } ?>


### PR DESCRIPTION
Fixes #1512.
![image](https://user-images.githubusercontent.com/154364/107384654-13ae1780-6aea-11eb-97b4-a3a167a1c008.png)
Includes the same information as is shown on the main MP page (where one score <0.4 and other is >0.6), but also includes differences where one score is between 0.4 and 0.6 and other score is outside that range (so one is 'mixed' and other is not mixed). Thoughts welcome.
Tried to tidy up a bit too, having the diffs include the information they need rather than setting the policies/party_positions globals.