### PR TITLE
Improve party-switch description

### DIFF
--- a/classes/Member.php
+++ b/classes/Member.php
@@ -105,6 +105,16 @@ class Member extends \MEMBER {
         return $direction;
     }
 
+    public function currentPartyComparison(){
+        # Simplify the current party when being compared to the original
+        # Stops co-op and labour being seen as different
+        $party = $this->party;
+        if ( $party == 'Labour/Co-operative' ) {
+            $party = 'Labour';
+        }
+        return $party;
+    }
+
     public function cohortParty($house = HOUSE_TYPE_COMMONS){
         // The party being compared against for party comparison purposes
         // Unless specified by the condition in cohortPartyComparisonDirection
@@ -129,7 +139,11 @@ class Member extends \MEMBER {
         " . $direction, array(":house" => $house,
                  ":person_id" => $person_id))->first();
         if ($row) {
-            return $row["party"];
+            $party = $row["party"];
+            if ( $party == 'Labour/Co-operative' ) {
+                $party = 'Labour';
+            }
+            return $party;
         } else {
             return null;
         }

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -294,6 +294,7 @@ $data['latest_membership'] = $MEMBER->getMostRecentMembership();
 
 $data['constituency'] = $MEMBER->constituency();
 $data['party'] = $MEMBER->party_text();
+$data['current_party_comparison'] = $MEMBER->currentPartyComparison();
 $data['current_member_anywhere'] = $MEMBER->current_member_anywhere();
 $data['current_member'] = $MEMBER->current_member();
 $data['the_users_mp'] = $MEMBER->the_users_mp();

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -116,6 +116,7 @@ $display_wtt_stats_banner = '2015';
                             $party_score_difference = $key_vote["score_difference"];
                             $party_position = $key_vote['party_position'] ;
                             $comparison_party = $data["comparison_party"];
+                            $current_party_comparison = $data["current_party_comparison"];
                             $party_voting_line = sprintf("%s, %s", $party, $diff['party_voting_summary']);
                             $description = sprintf(
                                 '%s <b>%s</b> %s; comparable %s MPs <b>%s</b>.',
@@ -137,13 +138,24 @@ $display_wtt_stats_banner = '2015';
 
                     <?php elseif (count($policyPositions->positions) > 0 ): ?>
                         <?php if (count($party_positions) && $party_member_count > 1) { ?>
-                        <p>
-                        <?= $full_name ?> is a <?= $party ?> MP, and on the <b>vast majority</b> of issues votes the <b>same way</b> as other <?= $party ?> MPs.
-                        </p>
+                            <?php if ($current_party_comparison <> $comparison_party){ ?> 
+                                <p>
+                                    <?= $full_name ?> is a <?= $party ?> MP, but has changed parties or become independent.
+                                </p>
+                                <p>
+                                    Compared to their original party (<?= $comparison_party ?>), for the <b>vast majority</b> of issues they have voted in the <b>same way</b> as other <?= $comparison_party ?> MPs.
+                                </p>
+
+                                <?php } else { ?>
+                                <p>
+                                    <?= $full_name ?> is a <?= $party ?> MP, and on the <b>vast majority</b> of issues votes the <b>same way</b> as other <?= $party ?> MPs.
+                                </p>
+
+                            <?php } ?>
                         <?php } ?>
 
                         <p>
-                        This is a random selection of <?= $full_name ?>&rsquo;s votes, where they voted similarly to their party.
+                            This is a random selection of <?= $full_name ?>&rsquo;s votes.
                         </p>
 
                         <ul class="vote-descriptions">

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -35,7 +35,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
                 <?php include('_covid19_panel.php'); ?>
 
-                <?php if ($party <> $data["comparison_party"]): ?>
+                <?php if ($current_party_comparison <> $data["comparison_party"]): ?>
                 <?php include('_cross_party_mp_panel.php'); ?>
                 <?php endif; ?>
 


### PR DESCRIPTION
## Overview page will highlight party change in summary

The overview page for a live party-switcher now contains language talking about their current and comparison party. 

![image](https://user-images.githubusercontent.com/8157058/150191276-cfa36b16-cbe7-4405-a7ca-de3db5314771.png)

## Voting record page will not see coop/labour as party change

The voting record page when comparing the current party to the comparison party puts the current party now compared to a version of the current party that merges labour/coop and labour. 

![image](https://user-images.githubusercontent.com/8157058/150191345-54492434-8e01-4c17-9dd8-9fae69630f92.png)
