### PR TITLE
Speeding up populate scripts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+	"name": "theyworkforyou",
+
+	"dockerComposeFile": "../docker-compose.yml",
+	"service": "twfy",
+	"workspaceFolder": "/workspaces/theyworkforyou",
+	"initializeCommand":"git submodule update --init",
+	"portsAttributes": {"8000": {"label": "TWFY"}}, 
+	"forwardPorts": [8000],
+
+	"extensions": [
+		"ms-vscode.test-adapter-converter",
+		"ms-azuretools.vscode-docker",
+		"bmewburn.vscode-intelephense-client",
+		"felixfbecker.php-debug",
+		"recca0120.vscode-phpunit"
+	],
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,5 +14,5 @@
 		"bmewburn.vscode-intelephense-client",
 		"felixfbecker.php-debug",
 		"recca0120.vscode-phpunit"
-	],
+	]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ www/docs/rss/mp/*.rdf
 /www/docs/people-images
 
 data/
+searchdb/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,69 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run script (WSL)",
+            "type": "php",
+            "request": "launch",
+            "program": "${file}",
+            "cwd": "${fileDirname}",
+            "port": 9000,
+            "hostname": "0.0.0.0",
+            "runtimeArgs": [
+                "-dxdebug.start_with_request=yes"
+            ],
+            "env": {
+                "XDEBUG_SESSION":"1",
+                "XDEBUG_MODE": "debug,develop",
+                "XDEBUG_CONFIG": "client_port=${port} client_host=${WSL_IP} remote_enable=1"
+            }
+        },
+        {
+            "name": "Run script (Linux docker)",
+            "type": "php",
+            "request": "launch",
+            "program": "${file}",
+            "cwd": "${fileDirname}",
+            "port": 9000,
+            "hostname": "0.0.0.0",
+            "runtimeArgs": [
+                "-dxdebug.start_with_request=yes"
+            ],
+            "env": {
+                "XDEBUG_SESSION":"1",
+                "XDEBUG_MODE": "debug,develop",
+                "XDEBUG_CONFIG": "client_port=${port} client_host=$docker.host.internal remote_enable=1"
+            }
+        },
+        {
+            "name": "Listen for Xdebug",
+            "type": "php",
+            "request": "launch",
+            "hostname": "0.0.0.0",
+            "port": 9000,
+            "pathMappings": {
+                "/var/www/html": "${workspaceRoot}"
+            }
+        },
+        {
+            "name": "Launch Built-in web server",
+            "type": "php",
+            "request": "launch",
+            "hostname": "0.0.0.0",
+            "runtimeArgs": [
+                "-dxdebug.mode=debug",
+                "-dxdebug.start_with_request=yes",
+                "-S",
+                "localhost:0"
+            ],
+            "program": "",
+            "cwd": "${workspaceRoot}",
+            "port": 9003,
+            "serverReadyAction": {
+                "pattern": "Development Server \\(http://localhost:([0-9]+)\\) started",
+                "uriFormat": "http://localhost:%s",
+                "action": "openExternally"
+            }
+        }
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get -qq update && apt-get -qq install \
       ruby-dev \
       unzip \
       php-xdebug \
+      rsync \
     --no-install-recommends && \
     rm -r /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,3 +39,5 @@ WORKDIR /twfy
 
 # Apache will run on port 80, so expose it
 EXPOSE 80
+
+ENV DEV_MODE=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get -qq update && apt-get -qq install \
       php-zip \
       ruby-dev \
       unzip \
+      php-xdebug \
     --no-install-recommends && \
     rm -r /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,10 @@ RUN /usr/sbin/a2enmod expires rewrite && \
       ln -sfT /proc/self/fd/1 /var/log/apache2/access.log && \
       ln -sfT /proc/self/fd/1 /var/log/apache2/other_vhosts_access.log
 
-# Bind mount your working copy here
-WORKDIR /twfy
+# Codespaces needs the working directory to be /workspaces/theyworkforyou
+# Some scripts want it in twfy, minimise changes needed for codespaces
+WORKDIR /workspaces/theyworkforyou
+RUN ln -s /workspaces/theyworkforyou /twfy
 
 # Apache will run on port 80, so expose it
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Start a new codespace on Github by selecting the Code dropdown (top right), and 
 
 This will setup the Docker container and environment. Once finished, the link to the site should be avaliable in the ports tab of the terminal panel. 
 
+To populate with a minimal amount of data, run `scripts\quick-populate` (about 30-40 minutes).
+
+
 ### DEPRECATED: Developing with Vagrant
 
 Please note that we are not currently supporting the Vagrant environment, and may remove it
@@ -66,6 +69,7 @@ You will need the latest versions of VirtualBox and Vagrant, then:
 * Point your web browser at `http://10.11.12.13` and marvel at modern technology.
 
 See INSTALL.md for instructions on downloading and importing Parlparse data (members, debates, votes, etc).
+
 
 #### Compiling Static Assets
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ with some useful commands and more detailed Docker-specific setup notes.
 
 To use xdebug in VS Code while using WSL, you'll need to set an environmental variable of the WSL_IP within the subsystem of the IP address of the subsystem.
  
+# Developing with codespaces
+
+Start a new codespace on Github by selecting the Code dropdown (top right), and starting a new codespace (or use the [GitHub CLI](https://github.com/cli/cli)).
+
+This will setup the Docker container and environment. Once finished, the link to the site should be avaliable in the ports tab of the terminal panel. 
+
 ### DEPRECATED: Developing with Vagrant
 
 Please note that we are not currently supporting the Vagrant environment, and may remove it

--- a/README.md
+++ b/README.md
@@ -42,8 +42,12 @@ about downloading and importing Parlparse data (members, debates, votes, etc).
 You can stop the environment by running `docker compose down`. Adding a `-v` will remove any
 Docker volumes that may be in use, including all their data.
 
+
 [DOCKER.md](DOCKER.md) has some more detailed notes on the development environment, together
 with some useful commands and more detailed Docker-specific setup notes.
+
+To use xdebug in VS Code while using WSL, you'll need to set an environmental variable of the WSL_IP within the subsystem of the IP address of the subsystem.
+ 
 ### DEPRECATED: Developing with Vagrant
 
 Please note that we are not currently supporting the Vagrant environment, and may remove it

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -23,5 +23,6 @@ sed -r \
   conf/general-example > conf/general
 
 bin/deploy.bash
+php composer.phar install
 
 /usr/sbin/apache2ctl -DFOREGROUND

--- a/classes/PartyCohort.php
+++ b/classes/PartyCohort.php
@@ -435,6 +435,7 @@ class PartyCohort
     public static function calculatePositions($quiet=true){
         // get current hashes available
         $cohorts = PartyCohort::getCohorts();
+        $db = new \ParlDB;
         $policies = new Policies;
         $n_cohorts = count($cohorts);
 
@@ -448,9 +449,12 @@ class PartyCohort
 
             $cohort_count++;
 
+            $db->query("START TRANSACTION");
             foreach ( $positions as $position ) {
                 $cohort->cache_position( $position );
             }
+            $db->query("COMMIT");
+
             if (!$quiet) {
                 print("$cohort_count/$n_cohorts\n");
             }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     depends_on:
       - mariadb
       - memcache
-    entrypoint: /twfy/bin/docker-entrypoint.sh
+    entrypoint: /workspaces/theyworkforyou/bin/docker-entrypoint.sh
     ports:
       - "8000:80"
       - TWFY_TEST_DB_HOST=mariatestdb
@@ -19,8 +19,9 @@ services:
       - TWFY_TEST_DB_PASS=password
       - DEV_MODE=true
     volumes:
-      - ./:/twfy
-      - xapian:/twfy/searchdb
+      - ./:/workspaces/theyworkforyou/
+      - xapian:/workspaces/theyworkforyou/searchdb
+      - ./xdebug-local.ini:/etc/php/7.3/cli/conf.d/xdebug-local.ini
 
   mariadb:
     image: mariadb:10.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     entrypoint: /workspaces/theyworkforyou/bin/docker-entrypoint.sh
     ports:
       - "8000:80"
+    environment:
+      - WSL_IP
       - TWFY_TEST_DB_HOST=mariatestdb
       - TWFY_TEST_DB_NAME=twfytest
       - TWFY_TEST_DB_USER=twfytest
@@ -22,6 +24,8 @@ services:
       - ./:/workspaces/theyworkforyou/
       - xapian:/workspaces/theyworkforyou/searchdb
       - ./xdebug-local.ini:/etc/php/7.3/cli/conf.d/xdebug-local.ini
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   mariadb:
     image: mariadb:10.3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
     entrypoint: /twfy/bin/docker-entrypoint.sh
     ports:
       - "8000:80"
+      - TWFY_TEST_DB_HOST=mariatestdb
+      - TWFY_TEST_DB_NAME=twfytest
+      - TWFY_TEST_DB_USER=twfytest
+      - TWFY_TEST_DB_PASS=password
+      - DEV_MODE=true
     volumes:
       - ./:/twfy
       - xapian:/twfy/searchdb
@@ -29,11 +34,24 @@ services:
       - ./db/schema.sql:/docker-entrypoint-initdb.d/schema.sql
       - db:/var/lib/mysql
 
+  mariatestdb:
+    image: mariadb:10.3
+    command: '--sql_mode="ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"'
+    environment:
+      MARIADB_RANDOM_ROOT_PASSWORD: '1'
+      MARIADB_USER: twfytest
+      MARIADB_PASSWORD: password
+      MARIADB_DATABASE: twfytest
+    volumes:
+      - ./db/schema.sql:/docker-entrypoint-initdb.d/schema.sql
+      - testdb:/var/lib/mysql
+
   memcache:
     image: memcached:1.6-alpine
 
 volumes:
   db:
+  testdb:
   xapian:
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
 
   twfy:
     image: theyworkforyou
+    platform: linux/amd64
     build:
       context: .
     depends_on:

--- a/scripts/json2db.pl
+++ b/scripts/json2db.pl
@@ -13,6 +13,14 @@ mySociety::Config::set_file("$FindBin::Bin/../conf/general");
 
 my $parldata = mySociety::Config::get('RAWDATA');
 
+my $verbose = 0;
+for( @ARGV ){
+  if( $_ eq "--verbose" ){
+    $verbose = 1;
+    last;
+  }
+}
+
 use DBI;
 use File::Slurp::Unicode;
 use JSON::XS;
@@ -45,6 +53,9 @@ my $strong_for_policy_check = $dbh->prepare("SELECT count(*) as strong_votes FRO
 my $strong_vote_add = $dbh->prepare("INSERT into personinfo ( data_key, data_value, person_id ) VALUES ( ?, ?, ? )");
 my $strong_vote_update = $dbh->prepare("UPDATE personinfo SET data_value = ? WHERE data_key = ? AND person_id = ?");
 
+my $start_transaction = $dbh->prepare("START TRANSACTION");
+my $query_commit = $dbh->prepare("COMMIT");
+
 my $motionsdir = $parldata . "scrapedjson/policy-motions/";
 
 $motion_count = $policy_count = $vote_count = 0;
@@ -67,12 +78,16 @@ foreach my $dreamid ( @policyids ) {
 
     $policy_count++;
 
+    if ($verbose){
+        print("processing motions for $dreamid\n");
+    }  
     process_motions($policy, $dreamid);
 }
 
 # And recently changed ones
 my $policy_file = $motionsdir . "recently-changed-divisions.json";
 if (-f $policy_file) {
+    print("processing recently changed divisions\n");
     my $policy_json = read_file($policy_file);
     my $policy = $json->decode($policy_json);
     process_motions($policy);
@@ -82,9 +97,13 @@ print "parsed $policy_count policies, $motion_count divisions and $vote_count vo
 
 sub process_motions {
     my ($policy, $dreamid) = @_;
+    $start_transaction->execute();
 
     for my $motion ( @{ $policy->{aspects} } ) {
         $motion_count++;
+        if ($verbose && $motion_count % 10 == 0){
+            print("$motion_count\n");
+        };
         my ($motion_num, $house);
         ($motion_num = $motion->{motion}->{id}) =~ s/pw-\d+-\d+-\d+-(\d+)/$1/;
         ($house = $motion->{motion}->{organization_id}) =~ s/uk.parliament.(\w+)/$1/;
@@ -250,4 +269,5 @@ sub process_motions {
         }
 
     }
+     $query_commit->execute();
 }

--- a/scripts/load-people
+++ b/scripts/load-people
@@ -53,7 +53,7 @@ verbose("End");
 
 # ---
 
-my ($dbh, $memberadd, $memberexist, $membercheck, $nameadd, $nameupdate, $namefetch, $namedelete, $gradd, $grdelete);
+my ($dbh, $memberadd, $memberexist, $membercheck, $nameadd, $nameupdate, $namefetch, $namedelete, $gradd, $grdelete, $start_transaction, $query_commit, );
 
 sub db_connect {
     #DBI->trace(1);
@@ -78,6 +78,10 @@ sub db_connect {
 
     $gradd = $dbh->prepare("replace into gidredirect (gid_from, gid_to) values (?,?)");
     $grdelete = $dbh->prepare("delete from gidredirect where gid_from = ?");
+
+    $start_transaction = $dbh->prepare("START TRANSACTION");
+    $query_commit = $dbh->prepare("COMMIT");
+
 }
 
 my %organizations;
@@ -146,6 +150,7 @@ sub load_people {
     foreach (@{$j->{posts}}) {
         $posts{$_->{id}} = $_;
     }
+    $start_transaction->execute();
     foreach (@{$j->{memberships}}) {
         if ($_->{redirect}) {
             $gradd->execute($_->{id}, $_->{redirect});
@@ -153,6 +158,9 @@ sub load_people {
             load_member($_);
         }
     }
+    $query_commit->execute();
+
+    $start_transaction->execute();
     foreach (@{$j->{persons}}) {
         if ($_->{redirect}) {
             $gradd->execute($_->{id}, $_->{redirect});
@@ -160,6 +168,7 @@ sub load_people {
             load_names($_);
         }
     }
+    $query_commit->execute();
 }
 
 my %member_ids = ();

--- a/scripts/mpinfoin.pl
+++ b/scripts/mpinfoin.pl
@@ -158,7 +158,11 @@ my $personinfoadd    = $dbh->prepare("insert into personinfo (person_id, data_ke
 my $personinfoupdate = $dbh->prepare('update personinfo set data_value=? where person_id=? and data_key=?');
 my $consinfoadd      = $dbh->prepare("insert into consinfo (constituency, data_key, data_value) values (?, ?, ?) on duplicate key update data_value=?");
 
+my $start_transaction = $dbh->prepare("START TRANSACTION");
+my $query_commit = $dbh->prepare("COMMIT");
+
 # Write to database - members
+$start_transaction->execute();
 foreach my $mp_id (keys %$memberinfohash) {
     (my $mp_id_num = $mp_id) =~ s#uk.org.publicwhip/(member|lord)/##;
     my $data = $memberinfohash->{$mp_id};
@@ -172,8 +176,10 @@ foreach my $mp_id (keys %$memberinfohash) {
         }
     }
 }
+$query_commit->execute();
 
 # Write to database - people
+$start_transaction->execute();
 foreach my $person_id (keys %$personinfohash) {
     (my $person_id_num = $person_id) =~ s#uk.org.publicwhip/person/##;
     my $data = $personinfohash->{$person_id};
@@ -187,8 +193,10 @@ foreach my $person_id (keys %$personinfohash) {
         }
     }
 }
+$query_commit->execute();
 
 # Write to database - cons
+$start_transaction->execute();
 foreach my $constituency (keys %$consinfohash) {
     my $data = $consinfohash->{$constituency};
     foreach my $key (keys %$data) {
@@ -196,6 +204,7 @@ foreach my $constituency (keys %$consinfohash) {
         $consinfoadd->execute($constituency, $key, $value, $value);
     }
 }
+$query_commit->execute();
 
 # just temporary to check cron working
 # print "mpinfoin done\n";

--- a/scripts/quick-populate
+++ b/scripts/quick-populate
@@ -1,0 +1,32 @@
+#!/bin/bash
+# For a fresh install get a basic set of data in
+
+echo 'Cloning parlparse'
+git clone https://github.com/mysociety/parlparse data/parlparse
+
+# See http://parser.theyworkforyou.com/hansard.html for details on download specific ranges
+echo 'Downloading minimal data'
+rsync -az --progress --exclude '.svn' --exclude 'tmp/' --relative data.theyworkforyou.com::parldata/scrapedxml/debates/debates2022-01* data/pwdata
+rsync -az --progress --exclude '.svn' --exclude 'tmp/' --relative data.theyworkforyou.com::parldata/scrapedjson data/pwdata
+rsync -az --progress --exclude '.svn' --exclude 'tmp/' --relative data.theyworkforyou.com::parldata/people.json data/pwdata
+rsync -az --progress --exclude '.svn' --exclude 'tmp/' --relative data.theyworkforyou.com::parldata/scrapedxml/divisionsonly/divisions2022-01* data/pwdata
+rsync -az --progress --exclude '.svn' --exclude 'tmp/' --relative data.theyworkforyou.com::parldata/scrapedxml/regmem data/pwdata
+
+echo 'Load people into database'
+scripts/load-people
+
+echo 'Load divisions/policies from json'
+scripts/json2db.pl --verbose
+
+echo 'Load Jan 2022 debates and divisions'
+scripts/xml2db.pl --debates --all
+
+# this only imports public whip, run with different arguments to pull in members expenses
+echo 'Importing MP extra info for voting comparison'
+scripts/mpinfoin.pl publicwhip
+
+echo 'Generate party positions on issues'
+php scripts/generate_party_positions.php
+
+echo 'Generate search index'
+search/index.pl all


### PR DESCRIPTION
Building on https://github.com/mysociety/theyworkforyou/pull/1590 (which you might also have opinions on), because codespaces starts from scratch (and was getting an idle timeout on a script that didn't report back for a while), I wanted to improve the speed of the initial import of data.

I've done this by wrapping some of the INSERT statements in various scripts looks in START TRANSACTION and COMMIT. This seems to work ok for my testing, but might have other implications. 

There is also a `scripts/quick-populate` that handles pulling in a small set of data and running the correct scripts to process it. I think all the steps currently there are required, but anything extra or missing?

