### PR TITLE
Add link to professional use survey to email alerts

### DIFF
--- a/www/includes/easyparliament/templates/emails/alert_mailout.html
+++ b/www/includes/easyparliament/templates/emails/alert_mailout.html
@@ -103,6 +103,12 @@
             <a href="https://www.theyworkforyou.com">
                 <img src="images/theyworkforyou-logo.png" alt="" width="170">
             </a>
+
+            <h1 style="color: #333333; font-size: 21px; font-weight: 400; line-height: 21px; font-family: 'Source Sans Pro'; margin-top: 30px;">Do you use TheyWorkForYou as part of your work?</h1>
+    
+            <p style="font-size: 16px; margin-top: 30px;">We're trying to understand more about how people use TheyWorkForYou to help make the case for funding.</p>
+            <p><a href="https://survey.alchemer.com/s3/5057795/twfy-professional-use-alerts">Can you take a quick five question survey to help us?</a> </p>
+
             <h1 style="color: #333333; font-size: 21px; font-weight: 400; line-height: 21px; font-family: 'Source Sans Pro'; margin-top: 30px;">Email alerts</h1>
         </header>
 

--- a/www/includes/easyparliament/templates/emails/alert_mailout.txt
+++ b/www/includes/easyparliament/templates/emails/alert_mailout.txt
@@ -1,4 +1,12 @@
 Subject: Your TheyWorkForYou email alert
+
+---
+Do you use TheyWorkForYou as part of your work?
+We're trying to understand more about how people use TheyWorkForYou to help make the case for funding. 
+Can you take a quick five question survey to help us?
+https://www.mysociety.org/surveys/twfy-professional-use/
+---
+
 {DATA}
 
 If clicking any of these links doesn't work, you may have


### PR DESCRIPTION
This adds a link to an alchemer survey to the text and html alerts template.