### PR TITLE
setup tweaks

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -137,7 +137,7 @@ MPs. This will be based on XML format data published by theyworkforyou.com.
 
     We recommend either using rsync or downloading the
     zip files containing all the data if you want it - for more information,
-    see http://parser.theyworkforyou.com/ under "Getting the Data".
+    see https://parser.theyworkforyou.com/hansard.html under "Getting the Data".
 
     At a minimum, we'd recommend getting some recent debates; for example you
     could get everything in 2021 by grabbing `scrapedxml/debates/debates2021*`.

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -19,6 +19,7 @@ sed -r \
     -e 's!^(.*"COOKIEDOMAIN", *)"[^"]*"!'"\\1'localhost'!" \
     -e 's!^(.*"RAWDATA", *)"[^"]*"!'"\\1'/twfy/data/pwdata/'!" \
     -e 's!^(.*"PWMEMBERS", *)"[^"]*"!'"\\1'/twfy/data/parlparse/members/'!" \
+    -e 's!^(.*"XAPIANDB", *)"[^"]*"!'"\\1'/twfy/data/xapiandb'!" \
     -e "s/array\('127.0.0.1'\)/array\('sentinel'\)/" \
   conf/general-example > conf/general
 


### PR DESCRIPTION
- Set the XAPIANDB config value in docker-entrypoint.sh. Previously, XAPIANDB would have been configured to an empty string inside the docker container. This would cause the `index.pl` script to fail, because it would attempt to create a new Xapian DB at an empty path (and fail with an error about "mkdir").

- Update URL for more info about getting data. I guess this page moved, so it took me a while to realize the "Getting the Data" section was on the "hansard.html" page.
