### PR TITLE
Auto populate script

### DIFF
--- a/.devcontainer/auto-quick-setup/devcontainer.json
+++ b/.devcontainer/auto-quick-setup/devcontainer.json
@@ -1,0 +1,21 @@
+{
+	"name": "theyworkforyou",
+
+	"dockerComposeFile": "../../docker-compose.yml",
+	"service": "twfy",
+	"workspaceFolder": "/twfy",
+	"initializeCommand": [
+		".devcontainer/initializeCommand"
+	],
+	"onCreateCommand": "script/quick-populate",
+	"portsAttributes": {"8000": {"label": "TWFY"}}, 
+	"forwardPorts": [8000],
+
+	"extensions": [
+		"ms-vscode.test-adapter-converter",
+		"ms-azuretools.vscode-docker",
+		"bmewburn.vscode-intelephense-client",
+		"felixfbecker.php-debug",
+		"recca0120.vscode-phpunit"
+	]
+}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Push branch to git.mysociety.org
       id: push_to_mirror
-      uses: mysociety/action-git-pusher@v1.1.0
+      uses: mysociety/action-git-pusher@v1.1.1
       with:
         git_ssh_key: ${{ secrets.PUBLICCVS_GIT_KEY }}
         ssh_known_hosts: ${{ secrets.GIT_KNOWN_HOSTS }}

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Start a new codespace on Github by selecting the Code dropdown (top right), and 
 
 This will setup the Docker container and environment. Once finished, the link to the site should be avaliable in the ports tab of the terminal panel. 
 
+To populate with a minimal amount of data, run `scripts/quick-populate` (about 1 hour).
+
 ### DEPRECATED: Developing with Vagrant
 
 Please note that we are not currently supporting the Vagrant environment, and may remove it
@@ -65,6 +67,7 @@ You will need the latest versions of VirtualBox and Vagrant, then:
 * Point your web browser at `http://10.11.12.13` and marvel at modern technology.
 
 See INSTALL.md for instructions on downloading and importing Parlparse data (members, debates, votes, etc).
+
 
 #### Compiling Static Assets
 

--- a/classes/PartyCohort.php
+++ b/classes/PartyCohort.php
@@ -435,6 +435,7 @@ class PartyCohort
     public static function calculatePositions($quiet=true){
         // get current hashes available
         $cohorts = PartyCohort::getCohorts();
+        $db = new \ParlDB;
         $policies = new Policies;
         $n_cohorts = count($cohorts);
 
@@ -448,9 +449,11 @@ class PartyCohort
 
             $cohort_count++;
 
+            $db->conn->beginTransaction();
             foreach ( $positions as $position ) {
                 $cohort->cache_position( $position );
             }
+            $db->conn->commit();
             if (!$quiet) {
                 print("$cohort_count/$n_cohorts\n");
             }

--- a/scripts/json2db.pl
+++ b/scripts/json2db.pl
@@ -53,9 +53,6 @@ my $strong_for_policy_check = $dbh->prepare("SELECT count(*) as strong_votes FRO
 my $strong_vote_add = $dbh->prepare("INSERT into personinfo ( data_key, data_value, person_id ) VALUES ( ?, ?, ? )");
 my $strong_vote_update = $dbh->prepare("UPDATE personinfo SET data_value = ? WHERE data_key = ? AND person_id = ?");
 
-my $start_transaction = $dbh->prepare("START TRANSACTION");
-my $query_commit = $dbh->prepare("COMMIT");
-
 my $motionsdir = $parldata . "scrapedjson/policy-motions/";
 
 $motion_count = $policy_count = $vote_count = 0;
@@ -99,8 +96,8 @@ print "parsed $policy_count policies, $motion_count divisions and $vote_count vo
 
 sub process_motions {
     my ($policy, $dreamid) = @_;
-    $start_transaction->execute();
-
+    # Set AutoCommit off
+    $dbh->{AutoCommit} = 0;
     for my $motion ( @{ $policy->{aspects} } ) {
         $motion_count++;
         if ($verbose && $motion_count % 10 == 0){
@@ -270,5 +267,7 @@ sub process_motions {
         }
 
     }
-     $query_commit->execute();
+    $dbh->commit();
+    # Set AutoCommit on
+    $dbh->{AutoCommit} = 1;
 }

--- a/scripts/json2db.pl
+++ b/scripts/json2db.pl
@@ -15,9 +15,9 @@ my $parldata = mySociety::Config::get('RAWDATA');
 
 my $verbose = 0;
 for( @ARGV ){
-  if( $_ eq "--verbose" ){
-    $verbose = 1;
-    last;
+    if( $_ eq "--verbose" ){
+        $verbose = 1;
+        last;
   }
 }
 
@@ -85,7 +85,7 @@ foreach my $dreamid ( @policyids ) {
 my $policy_file = $motionsdir . "recently-changed-divisions.json";
 if (-f $policy_file) {
     if ($verbose){
-    print("processing recently changed divisions\n");
+        print("processing recently changed divisions\n");
     }
     my $policy_json = read_file($policy_file);
     my $policy = $json->decode($policy_json);

--- a/scripts/load-people
+++ b/scripts/load-people
@@ -53,7 +53,7 @@ verbose("End");
 
 # ---
 
-my ($dbh, $memberadd, $memberexist, $membercheck, $nameadd, $nameupdate, $namefetch, $namedelete, $gradd, $grdelete);
+my ($dbh, $memberadd, $memberexist, $membercheck, $nameadd, $nameupdate, $namefetch, $namedelete, $gradd, $grdelete, $start_transaction, $query_commit, );
 
 sub db_connect {
     #DBI->trace(1);
@@ -139,6 +139,10 @@ sub load_constituencies {
 }
 
 sub load_people {
+
+    # disable autocommit to load multiple people and memberships at once
+    $dbh->{AutoCommit} = 0;
+
     my $j = decode_json(read_file($pwmembers . 'people.json'));
     foreach (@{$j->{organizations}}) {
         $organizations{$_->{id}} = $_;
@@ -146,6 +150,7 @@ sub load_people {
     foreach (@{$j->{posts}}) {
         $posts{$_->{id}} = $_;
     }
+    $dbh->commit();
     foreach (@{$j->{memberships}}) {
         if ($_->{redirect}) {
             $gradd->execute($_->{id}, $_->{redirect});
@@ -160,6 +165,10 @@ sub load_people {
             load_names($_);
         }
     }
+    $dbh->commit();
+
+    $dbh->{AutoCommit} = 1;
+
 }
 
 my %member_ids = ();

--- a/scripts/mpinfoin.pl
+++ b/scripts/mpinfoin.pl
@@ -158,6 +158,10 @@ my $personinfoadd    = $dbh->prepare("insert into personinfo (person_id, data_ke
 my $personinfoupdate = $dbh->prepare('update personinfo set data_value=? where person_id=? and data_key=?');
 my $consinfoadd      = $dbh->prepare("insert into consinfo (constituency, data_key, data_value) values (?, ?, ?) on duplicate key update data_value=?");
 
+
+# Set AutoCommit off
+$dbh->{AutoCommit} = 0;
+
 # Write to database - members
 foreach my $mp_id (keys %$memberinfohash) {
     (my $mp_id_num = $mp_id) =~ s#uk.org.publicwhip/(member|lord)/##;
@@ -172,6 +176,7 @@ foreach my $mp_id (keys %$memberinfohash) {
         }
     }
 }
+$dbh->commit();
 
 # Write to database - people
 foreach my $person_id (keys %$personinfohash) {
@@ -187,6 +192,7 @@ foreach my $person_id (keys %$personinfohash) {
         }
     }
 }
+$dbh->commit();
 
 # Write to database - cons
 foreach my $constituency (keys %$consinfohash) {
@@ -196,6 +202,11 @@ foreach my $constituency (keys %$consinfohash) {
         $consinfoadd->execute($constituency, $key, $value, $value);
     }
 }
+$dbh->commit();
+
+
+# Set AutoCommit on
+$dbh->{AutoCommit} = 1;
 
 # just temporary to check cron working
 # print "mpinfoin done\n";

--- a/scripts/quick-populate
+++ b/scripts/quick-populate
@@ -1,0 +1,32 @@
+#!/bin/bash
+# For a fresh install get a basic set of data in
+
+echo 'Cloning parlparse'
+git clone https://github.com/mysociety/parlparse data/parlparse --depth 1
+
+# See http://parser.theyworkforyou.com/hansard.html for details on download specific ranges
+echo 'Downloading minimal data'
+rsync -az --progress --exclude '.svn' --exclude 'tmp/' --relative data.theyworkforyou.com::parldata/scrapedxml/debates/debates2022-01* data/pwdata
+rsync -az --progress --exclude '.svn' --exclude 'tmp/' --relative data.theyworkforyou.com::parldata/scrapedjson data/pwdata
+rsync -az --progress --exclude '.svn' --exclude 'tmp/' --relative data.theyworkforyou.com::parldata/people.json data/pwdata
+rsync -az --progress --exclude '.svn' --exclude 'tmp/' --relative data.theyworkforyou.com::parldata/scrapedxml/divisionsonly/divisions2022-01* data/pwdata
+rsync -az --progress --exclude '.svn' --exclude 'tmp/' --relative data.theyworkforyou.com::parldata/scrapedxml/regmem data/pwdata
+
+echo 'Load people into database'
+scripts/load-people
+
+echo 'Load divisions/policies from json'
+scripts/json2db.pl --verbose
+
+echo 'Load Jan 2022 debates and divisions'
+scripts/xml2db.pl --debates --all
+
+# this only imports public whip, run with different arguments to pull in members expenses
+echo 'Importing MP extra info for voting comparison'
+scripts/mpinfoin.pl publicwhip
+
+echo 'Generate party positions on issues'
+php scripts/generate_party_positions.php
+
+echo 'Generate search index'
+search/index.pl all


### PR DESCRIPTION
This PR adjusts data loading scripts to be quicker for loading initial sets of data, and creates a new `script/quick-populate` to make loading a minimal set of data consisutent.

This replaces https://github.com/mysociety/theyworkforyou/pull/1591 because that was merging into an outdated version of a branch that has now been merged into master.

I have adjusted the populate scripts based on the feedback in that PR request. 