### PR TITLE
Update mirror action

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -17,7 +17,7 @@ jobs:
 
     - name: Push branch to git.mysociety.org
       id: push_to_mirror
-      uses: mysociety/action-git-pusher@v1.1.0
+      uses: mysociety/action-git-pusher@v1.1.1
       with:
         git_ssh_key: ${{ secrets.PUBLICCVS_GIT_KEY }}
         ssh_known_hosts: ${{ secrets.GIT_KNOWN_HOSTS }}


### PR DESCRIPTION
Buster update required update to action-git-pusher (https://github.com/mysociety/action-git-pusher/pull/2)

Increment version to new v1.1.1 tag.