### PR TITLE
Remove top margin on form controls

### DIFF
--- a/www/docs/style/sass/_twfy-mixins.scss
+++ b/www/docs/style/sass/_twfy-mixins.scss
@@ -307,6 +307,7 @@ input.form-control {
     font-size: inherit;
     line-height: inherit;
     padding: 0.35em 0.4em;
+    margin: 0 0 0 0;
     border: 1px solid $colour_mid_grey;
     @include border-radius(3px);
 }

--- a/www/docs/style/sass/_twfy-mixins.scss
+++ b/www/docs/style/sass/_twfy-mixins.scss
@@ -307,7 +307,6 @@ input.form-control {
     font-size: inherit;
     line-height: inherit;
     padding: 0.35em 0.4em;
-    margin: .2em 0 0 0;
     border: 1px solid $colour_mid_grey;
     @include border-radius(3px);
 }


### PR DESCRIPTION
There's a margin that offsets the text in text boxes, which does this to the search:

![image](https://user-images.githubusercontent.com/8157058/229765212-63337462-8af0-4202-a84c-8f52da1d9991.png)

Removing the line fixes it:

![image](https://user-images.githubusercontent.com/8157058/229765280-59397745-e124-4219-a5c6-26c6af963602.png)

Looks like it was added a few years ago to add spacing on user sign up page - but this seems a worse problem that that.