### PR TITLE
Change copy on front pages and about page

### DIFF
--- a/tests/AcceptBasicTest.php
+++ b/tests/AcceptBasicTest.php
@@ -25,7 +25,7 @@ class AcceptBasicTest extends FetchPageTestCase
     public function testHome()
     {
         $page = $this->fetch_page('');
-        $this->assertContains('your MP represent', $page);
+        $this->assertContains('Find out more', $page);
         $this->assertContains('Create an alert', $page);
         $this->assertContains('Upcoming', $page);
     }

--- a/www/docs/style/sass/pages/_home.scss
+++ b/www/docs/style/sass/pages/_home.scss
@@ -30,7 +30,7 @@
     h1 {
         line-height: 1.05em;
         color: #fff;
-        text-shadow: 0 2px 4px rgba(0,0,0,0.2);
+        text-shadow: 0px 0px 4px rgba(0,0,0,0.5);
         letter-spacing: -0.5px;
         @media (min-width: $medium-screen) {
             font-size: emCalc(68);

--- a/www/docs/style/sass/pages/_home.scss
+++ b/www/docs/style/sass/pages/_home.scss
@@ -1,6 +1,6 @@
 .hero {
     background-color: $primary-color;
-    color: #fff;
+    color: #000;
 }
 
 .hero__mp-search {
@@ -56,7 +56,7 @@
         @include grid-column(5);
     }
     h2 {
-        color: #fff;
+        color: #000;
         line-height: 1.05em;
         font-size: emCalc(32);
     }
@@ -64,7 +64,7 @@
         line-height: 1.4em;
     }
     a {
-        color: #fff;
+        color: #000;
     }
 }
 

--- a/www/includes/easyparliament/templates/html/footer.php
+++ b/www/includes/easyparliament/templates/html/footer.php
@@ -7,7 +7,7 @@
                 <p>Making it easy to keep an eye on the UK&rsquo;s parliaments. Discover who represents you, how they&rsquo;ve voted and what they&rsquo;ve said in debates &ndash; simply and clearly.</p>
             </div>
             <form method="post" class="footer__newsletter-form" action="//mysociety.us9.list-manage.com/subscribe/post?u=53d0d2026dea615ed488a8834&amp;id=287dc28511" onsubmit="trackFormSubmit(this, 'FooterNewsletterSignup', 'submit', null); return false;">
-                <p>Get insights on TheyWorkForYou and other mySociety sites, in our popular newsletter</p>
+                <p>Sign up to mySociety's newsletter</p>
                 <div class="row collapse">
                     <div class="small-8 columns">
                         <input type="email" placeholder="Your email address" name="EMAIL"/>

--- a/www/includes/easyparliament/templates/html/index.php
+++ b/www/includes/easyparliament/templates/html/index.php
@@ -8,7 +8,7 @@
     <div class="hero__mp-search">
         <div class="hero__mp-search__wrap">
             <?php if (count($mp_data)) { ?>
-            <h1>Does <?= $mp_data['former'] ? 'your former MP ' : '' ?><?= $mp_data['name'] ?> represent you?</h1>
+            <h1>Find out more about <?= $mp_data['former'] ? 'your former MP ' : 'your MP' ?><?= $mp_data['name'] ?></h1>
             <div class="row collapse">
                 <div class="medium-4 columns">
                     <a href="<?= $mp_data['mp_url']?>" class="button homepage-search__button" />Find out &rarr;</a>
@@ -20,7 +20,7 @@
                 </div>
             </div>
             <?php } else { ?>
-            <h1>Does your MP represent you?</h1>
+            <h1>Find out more about your MP</h1>
             <div class="row collapse">
                 <form action="/postcode/" class="mp-search__form"  onsubmit="trackFormSubmit(this, 'PostcodeSearch', 'Submit', 'Home'); return false;">
                     <label for="postcode">Your postcode</label>
@@ -38,9 +38,9 @@
     <div class="hero__site-intro">
         <div class="hero__site-intro__wrap">
             <h2>Democracy: it&rsquo;s for everyone</h2>
-            <p>You shouldn&rsquo;t have to be an expert to understand what goes on in Parliament. Your politicians represent you&hellip; but what exactly do they do in your name?</p>
-            <p>TheyWorkForYou takes open data from the UK Parliament, and presents it in a way that&rsquo;s easy to follow &ndash; for everyone. So now you can check, with just a few clicks: are They Working For You?</p>
-            <a href="/about/" class="site-intro__more-link">Find out more about TheyWorkForYou <i>&rarr;</i></a>
+            <p>You shouldn&rsquo;t have to be an expert to understand what goes on in Parliament.</p>
+            <p>TheyWorkForYou takes open data from the UK's Parliaments, and presents it in a way that&rsquo;s easy to follow &ndash; for everyone.</p>
+            <a href="/about/" class="site-intro__more-link">About TheyWorkForYou <i>&rarr;</i></a>
         </div>
     </div>
     </div>

--- a/www/includes/easyparliament/templates/html/london/index.php
+++ b/www/includes/easyparliament/templates/html/london/index.php
@@ -2,7 +2,7 @@
         <div class="row">
         <div class="hero__mp-search">
             <div class="hero__mp-search__wrap">
-                <h1>Do your Assembly Members represent you?</h1>
+                <h1>Find out more about your AMs</h1>
                 <div class="row collapse">
                     <?php if ( count($data['regional']) > 0 ) { ?>
                         <ul class="homepage-rep-list">
@@ -28,8 +28,8 @@
         <div class="hero__site-intro">
             <div class="hero__site-intro__wrap">
                 <h2>Democracy: it&rsquo;s for everyone</h2>
-                <p>You shouldn&rsquo;t have to be an expert to understand what goes on in the London Assembly. Your politicians represent you&hellip; but what exactly do they do in your name?</p>
-                <p>TheyWorkForYou takes open data from the London Assembly, and presents it in a way that&rsquo;s easy to follow &ndash; for everyone. So now you can check, with just a few clicks: are They Working For You?</p>
+                <p>You shouldn&rsquo;t have to be an expert to understand what goes on in the London Assembly. </p>
+                <p>TheyWorkForYou takes open data from the London Assembly, and presents it in a way that&rsquo;s easy to follow &ndash; for everyone.</p>
                 <a href="/about/" class="site-intro__more-link">Find out more about TheyWorkForYou <i>&rarr;</i></a>
             </div>
         </div>

--- a/www/includes/easyparliament/templates/html/ni/index.php
+++ b/www/includes/easyparliament/templates/html/ni/index.php
@@ -2,7 +2,7 @@
         <div class="row">
         <div class="hero__mp-search">
             <div class="hero__mp-search__wrap">
-                <h1>Do your MLAs represent you?</h1>
+                <h1>Find out more about your MLAs</h1>
                 <div class="row collapse">
                     <?php if ( count($data['regional']) > 0 ) { ?>
                         <ul class="homepage-rep-list">
@@ -28,8 +28,8 @@
         <div class="hero__site-intro">
             <div class="hero__site-intro__wrap">
                 <h2>Democracy: it&rsquo;s for everyone</h2>
-                <p>You shouldn&rsquo;t have to be an expert to understand what goes on in the Northern Ireland Assembly. Your politicians represent you&hellip; but what exactly do they do in your name?</p>
-                <p>TheyWorkForYou takes open data from the Northern Ireland Assembly, and presents it in a way that&rsquo;s easy to follow &ndash; for everyone. So now you can check, with just a few clicks: are They Working For You?</p>
+                <p>You shouldn&rsquo;t have to be an expert to understand what goes on in the Northern Ireland Assembly.</p>
+                <p>TheyWorkForYou takes open data from the Northern Ireland Assembly, and presents it in a way that&rsquo;s easy to follow &ndash; for everyone.</p>
                 <a href="/about/" class="site-intro__more-link">Find out more about TheyWorkForYou <i>&rarr;</i></a>
             </div>
         </div>

--- a/www/includes/easyparliament/templates/html/scotland/index.php
+++ b/www/includes/easyparliament/templates/html/scotland/index.php
@@ -27,7 +27,7 @@
                     </div>
                 </div>
                 <?php } else { ?>
-                <h1>Do your MSPs represent you?</h1>
+                <h1>Find out more about your MSPs</h1>
                 <div class="row collapse">
                     <form action="/postcode/" class="mp-search__form"  onsubmit="trackFormSubmit(this, 'PostcodeSearch', 'Submit', 'ScotlandHome'); return false;">
                         <label for="postcode">Your Scottish postcode</label>
@@ -45,8 +45,8 @@
         <div class="hero__site-intro">
             <div class="hero__site-intro__wrap">
                 <h2>Democracy: it&rsquo;s for everyone</h2>
-                <p>You shouldn&rsquo;t have to be an expert to understand what goes on in the Scottish Parliament. Your politicians represent you&hellip; but what exactly do they do in your name?</p>
-                <p>TheyWorkForYou takes open data from the Scottish Parliament, and presents it in a way that&rsquo;s easy to follow &ndash; for everyone. So now you can check, with just a few clicks: are They Working For You?</p>
+                <p>You shouldn&rsquo;t have to be an expert to understand what goes on in the Scottish Parliament.</p>
+                <p>TheyWorkForYou takes open data from the Scottish Parliament, and presents it in a way that&rsquo;s easy to follow &ndash; for everyone.</p>
                 <a href="/about/" class="site-intro__more-link">Find out more about TheyWorkForYou <i>&rarr;</i></a>
             </div>
         </div>

--- a/www/includes/easyparliament/templates/html/static/about.php
+++ b/www/includes/easyparliament/templates/html/static/about.php
@@ -1,55 +1,60 @@
 <div class="full-page static-page about-page">
     <div class="full-page__row">
-        <div class="panel">
-            <h1>TheyWorkForYou makes Parliament easier to understand</h1>
+        <div class="panel about-page__mysociety">
 
-            <p>Most people don&rsquo;t know the name of their MP, let alone
-            what they&rsquo;ve been saying in Parliament, or how they&rsquo;ve
-            voted.</p>
+            <h1>About TheyWorkForYou</h1>
 
-            <p>TheyWorkForYou aims to get that changed.</p>
+            <p>TheyWorkForYou was founded <a href="https://www.mysociety.org/anniversary/">twenty years ago</a> to make Parliament more accessible.</p>
 
-            <hr>
+            <p>We believe that information about our elected representatives should be easily understandable and accessible to everyone, and not just insiders or those who can pay.</p>
 
-            <h2>Why bother? It&rsquo;s just a load of boring old politicians</h2>
+            <p>We now work across the UK's Parliaments to bring information together in one place, and make it accessible to both citizens and to civil society.</p>
 
-            <p>We know that Parliament can be dry, fusty, and even
-            intimidating. And there&rsquo;s the problem: keeping up just
-            involves too much effort.</p>
+            <p>Through <a href="https://www.theyworkforyou.com/">TheyWorkForYou</a> and <a href="https://writetothem.com">WriteToThem</a>, we want to make it easy to understand what the UK's
+              different layers of representation do, and make the actions of our
+            representatives and governments more transparent.</p>
 
-            <p>Once you get past those barriers, though, you&rsquo;ll find
-            information that can entertain you, educate you and&mdash;no
-            exaggeration&mdash;give you the power to get things changed.
-            We think that should be available to everyone.</p>
+            <p>We do this by:</p>
 
-            <h2>That&rsquo;s where TheyWorkForYou comes in</h2>
-
-            <p>TheyWorkForYou launched in 2004, taking data and information
-            from official parliamentary sources and adding features that make
-            them easier to understand, like:</p>
-
-            <ul class="about-page__features">
-                <li>A search box, so you can find mentions of any topic, in debates as recent as yesterday or as far back as the 1930s.</li>
-                <li>Not just the name, but the party, photo and position of each person who speaks, right next to their contribution to any debate.</li>
-                <li>A unique link for every statement, so you can share precisely what someone said, by email, Twitter or Facebook.</li>
-                <li>An alert sign-up, so you don&rsquo;t have to come to the site to see what your MP is saying: it&rsquo;ll drop straight into your email inbox instead.</li>
+            <ul>
+              <li>Making parliamentary debates searchable for all Parliaments.</li>
+              <li>Making it easy for people to write to their representatives at any layer of government.</li>
+              <li>Powering <a href="https://www.theyworkforyou.com/alert/">email alerts</a> that let <a href="https://www.mysociety.org/2022/07/28/theyworkforyou-quietly-provides-essential-services-for-civil-society-and-beyond/">citizens and civil society</a> stay informed about their representatives or areas of interest.</li>
+              <li>Adding new information and summaries that build on the information that Parliament releases (such as voting record summaries and more accessible registers of members interests).</li>
             </ul>
 
-            <p>And that&rsquo;s, basically, what we&rsquo;re all about: making it so easy to follow Parliament, that you, and everyone else, will know exactly what&rsquo;s going on.</p>
+            <p>If you support TheyWorkForYou's goals, you can help us do more by making a <a href="https://www.mysociety.org/donate/?utm_source=theyworkforyou&utm_medium=website&utm_campaign=theyworkforyou-about-page">donation</a>.</p>
+
+            <p>For more information about how we run the site, please read <a href="/help">our FAQs.</a></p>
+
+
+        </div>
+        <div class="panel about-page__mysociety">
+            <h1>About mySociety</h1>
+            <p>TheyWorkForYou is run by <a href="https://www.mysociety.org/">mySociety</a>, a UK charity that puts <a href="https://www.mysociety.org/2021/11/24/the-need-to-repower-democracy/">power in more people's hands</a> through the use of digital tools and data.</p>
+            <p>Through <strong>TheyWorkForYou</strong> and <strong>WriteToThem</strong> we have made elected representatives more transparent and contactable. Every year, hundreds of thousands of reports are made through <strong>FixMyStreet</strong>, and over a million Freedom of Information requests have been made through <strong>WhatDoTheyKnow</strong>.</p>
+
+            <p><a href="https://www.mysociety.org/about/funding/">Find out more about how mySociety is funded.</a></p>
+
+            <h3>Sign up for updates from mySociety</h3>
+            <form method="post" class="footer__newsletter-form" action="//mysociety.us9.list-manage.com/subscribe/post?u=53d0d2026dea615ed488a8834&amp;id=287dc28511" onsubmit="trackFormSubmit(this, 'FooterNewsletterSignup', 'submit', null); return false;">
+                <div class="row collapse">
+                    <div class="small-8 columns">
+                        <input type="email" placeholder="Your email address" name="EMAIL"/>
+                    </div>
+                    <div class="small-4 columns">
+                        <label style="position: absolute; left: -5000px;">
+                          Leave this box empty: <input type="text" name="b_53d0d2026dea615ed488a8834_287dc28511" tabindex="-1" value="" />
+                        </label>
+                        <input type="hidden" name="group[11745][32]" value="1">
+                        <input type="submit" value="Subscribe" name="subscribe" class="button prefix">
+                    </div>
+                </div>
+            </form>
+          <hr>
 
           </div>
 
-          <div class="panel about-page__mysociety">
-
-            <h2>Who runs this site?</h2>
-
-            <p>TheyWorkForYou is run by <a href="https://www.mysociety.org/">mySociety</a>, a UK charity. We build web tools that make democracy a little more accessible. mySociety is not politically-aligned, and its projects are for everyone to use.</p>
-
-            <p class="about-page__donate">We are funded, in part, by donations from people like you. <a href="https://www.mysociety.org/donate/">Here&rsquo;s how to help support our projects.</a></p>
-
-            <p>Still got questions? <a href="/help">Check our FAQs.</a></p>
-
-          </div>
 
           <div class="panel">
 

--- a/www/includes/easyparliament/templates/html/wales/index.php
+++ b/www/includes/easyparliament/templates/html/wales/index.php
@@ -5,29 +5,14 @@
         </div>
 
         <div class="business-section__primary">
-            <h1>We need you!</h1>
+            <h1>Coming soon!</h1>
 
-            <p>It&rsquo;d be fantastic if TheyWorkForYou also covered the
-            Senedd, as we do with the
-            <a href="/ni/">Northern Ireland Assembly</a> and the
-            <a href="/scotland/">Scottish Parliament</a>.
+            <p>The Welsh Government is funding mySociety to add the proceedings and Members of the Welsh Parliament to TheyWorkForYou, and to provide a Welsh language version of the site.</p>
+            
+            <p>The Record can be accessed through the <a href="https://senedd.wales/">Senedd Cymru website</a>, and intergrating this data into TheyWorkForYou will allow citizens in Wales to access information about their representatives in the same way that Scottish and NI citizens can, with the same search and email alerts.</p>
+            
+            <p>This is part of the Welsh Government's efforts to promote democratic engagement, by enabling Welsh citizens to access information about the Senedd alongside the UK Parliament.</p>
 
-            <p>But we don&rsquo;t currently have the time or resources
-            to add the Senedd ourselves. In fact, because the
-            code that runs TheyWorkForYou is
-            <a href="https://github.com/mysociety/theyworkforyou">open
-            source</a>, both Scotland and Northern Ireland were mainly
-            added by volunteers.</p>
-        </div>
-
-        <div class="business-section__secondary">
-            <h2>Next steps</h2>
-
-            <p>If you can help us add the Senedd to TheyWorkForYou,
-            <a href="https://groups.google.com/a/mysociety.org/forum/#!forum/theyworkforyou">join
-            our discussion list</a> and say hello.</p>
-
-            <p>If not, maybe you can get the information you need on <a href="https://senedd.wales/">the official Senedd website</a>.</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This PR does the following quick changes:

- A quick change to simplify the home page copy
- A quick fix for colour contrast on homepage
- Placeholder text for Welsh Parliament (given about page talks about "across all parliaments" and this will be true soon).
- A new version of the about page.

My general approach here is to make an improvement we can come back to later rather than trying to get it perfect now.

Questions:
- @MyfanwyNixon : This copy look ok enough? (with a view we'll want to come back and change later in the year as we get the repowering democracy work up).
- @zarino: Can you live with this as a temporary approach to the contrast issue (a lighter green background). Would still love a proper pass (https://github.com/mysociety/Design-Internal-tasks/issues/7) at some point given there are common problems across services, but also would prefer an imperfect solution sooner. (A full pass also raises questions about buttons, the link blue, etc).
- @dracos : Tagging if you have any comments/objections. 

![image](https://user-images.githubusercontent.com/8157058/229820368-887a78d6-1d85-4fcb-ae92-9880aededa9b.png)

![image](https://user-images.githubusercontent.com/8157058/229826651-bfc35693-617b-4cdf-bf40-d1548bc6ca77.png)

![image](https://user-images.githubusercontent.com/8157058/229826706-02dddda1-5bc1-4e71-b255-73b013f9ceaa.png)


![image](https://user-images.githubusercontent.com/8157058/229827909-7c9ca07a-a260-4aa4-b5f6-488d9997193e.png)
