### PR TITLE
Remove blanket covid text in favour of highlighting specific votes.

### DIFF
--- a/classes/Policies.php
+++ b/classes/Policies.php
@@ -279,6 +279,9 @@ class Policies {
         )
     );
 
+    # policies where votes affected by covid voting restrictions
+    protected $covid_affected = [1136, 6860];
+
     protected $set_descs = array(
         'social' => 'Social Issues',
         'foreignpolicy' => 'Foreign Policy and Defence',
@@ -308,6 +311,10 @@ class Policies {
                 $policy_id => $this->policies[$policy_id]
             );
         }
+    }
+
+    public function getCovidAffected() {
+        return $this->covid_affected;
     }
 
     public function getPolicies() {

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -641,7 +641,6 @@ html.js {
 .vote-description__covid {
     display: block;
     color: #757470;
-    text-decoration: none !important; // override .person-panels .panel a
     font-size: 0.7em;
     line-height: 1.5em;
     margin-top: 0.2em;

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -638,6 +638,16 @@ html.js {
   }
 }
 
+.vote-description__covid {
+    display: block;
+    color: #757470;
+    text-decoration: none !important; // override .person-panels .panel a
+    font-size: 0.7em;
+    line-height: 1.5em;
+    margin-top: 0.2em;
+
+  }
+
 .vote-description__evidence {
   display: block;
   color: #757470;

--- a/www/includes/easyparliament/templates/html/mp/_covid19_panel.php
+++ b/www/includes/easyparliament/templates/html/mp/_covid19_panel.php
@@ -1,26 +1,24 @@
 <?php if (in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+<a name="covid-19"></a>
 <div class="panel panel--highlight panel--covid19">
     <h2>As a result of COVID-19, some MPs were less able to vote in Parliament in certain periods, and this will be reflected by absences in their voting record.</h2>
 
-    <details>
-        <summary>Show more detail</summary>
-        <dl>
-            <dt>11th May to 2nd June 2020</dt>
-            <dd>
-                <p>All MPs could vote remotely through an online voting tool. Votes cast remotely are shown as normal on the TheyWorkForYou voting record.</p>
-            </dd>
-            <dt>2nd to 9th June 2020</dt>
-            <dd>
-                <p>The option of online voting was removed, and a number of MPs may have been unable to vote because they were not physically able to attend.</p>
-            </dd>
-            <dt>10th June 2020 onwards</dt>
-            <dd>
-                <p>The requirements on proxy voting were relaxed, allowing MPs to designate another MP to cast a vote on their behalf.</p>
-                <p>If an MP votes by proxy, it is effectively exactly the same as if they cast the vote in person and it shows up on their TheyWorkForYou voting record.</p>
-                <p>MPs are not required to designate a proxy, and may instead <a href="https://en.wikipedia.org/wiki/Pair_(parliamentary_convention)">pair with an opposing MP</a> to miss a vote. Parliament does not record when two MPs have come to a pairing arrangement, so on TheyWorkForYou, they will both appear to have been absent for the vote.</p>
-            </dd>
-        </dl>
-        <p>We will update this information if the situation changes. <a href="https://www.mysociety.org/2020/07/06/parliamentary-votes-during-covid-19/">See more detail on votes during the COVID-19 period here.</a></p>
-    </details>
+    <dl>
+        <dt>11th May to 2nd June 2020</dt>
+        <dd>
+            <p>All MPs could vote remotely through an online voting tool. Votes cast remotely are shown as normal on the TheyWorkForYou voting record.</p>
+        </dd>
+        <dt>2nd to 9th June 2020</dt>
+        <dd>
+            <p>The option of online voting was removed, and a number of MPs may have been unable to vote because they were not physically able to attend.</p>
+        </dd>
+        <dt>10th June 2020 onwards</dt>
+        <dd>
+            <p>The requirements on proxy voting were relaxed, allowing MPs to designate another MP to cast a vote on their behalf.</p>
+            <p>If an MP votes by proxy, it is effectively exactly the same as if they cast the vote in person and it shows up on their TheyWorkForYou voting record.</p>
+            <p>MPs are not required to designate a proxy, and may instead <a href="https://en.wikipedia.org/wiki/Pair_(parliamentary_convention)">pair with an opposing MP</a> to miss a vote. Parliament does not record when two MPs have come to a pairing arrangement, so on TheyWorkForYou, they will both appear to have been absent for the vote.</p>
+        </dd>
+    </dl>
+    <p> <a href="https://www.mysociety.org/2020/07/06/parliamentary-votes-during-covid-19/">See more detail on votes during the COVID-19 period here.</a></p>
 </div>
 <?php endif; ?>

--- a/www/includes/easyparliament/templates/html/mp/_division_description.php
+++ b/www/includes/easyparliament/templates/html/mp/_division_description.php
@@ -2,7 +2,7 @@
     <span class="policy-vote__date">On <?= strftime('%e %b %Y', strtotime($division['date'])) ?>:</span>
     <span class="policy-vote__text"><?= $full_name ?><?= $division['text'] ?></span>
     <?php if ($division['date'] > '2020-06-01' && $division['date'] < '2020-06-10' && $division['vote'] == 'absent') { ?>
-        <p class="vote-description__covid">This absence may have been affected by <a href="#covid-19">COVID-19 restrictions</a>.</p> 
+        <p class="vote-description__covid">This absence may have been affected by <a href="<?= $member_url ?>/votes#covid-19">COVID-19 restrictions</a>.</p> 
     <?php } ?>
     <a class="vote-description__source" href="/divisions/<?= $division['division_id'] ?>/mp/<?= $person_id ?>">Show vote</a>
 </li>

--- a/www/includes/easyparliament/templates/html/mp/_division_description.php
+++ b/www/includes/easyparliament/templates/html/mp/_division_description.php
@@ -1,6 +1,9 @@
 <li id="<?= $division['division_id'] ?>" class="<?= $show_all || $division['strong'] ? 'policy-vote--major' : 'policy-vote--minor' ?>">
     <span class="policy-vote__date">On <?= strftime('%e %b %Y', strtotime($division['date'])) ?>:</span>
     <span class="policy-vote__text"><?= $full_name ?><?= $division['text'] ?></span>
+    <?php if ($division['date'] > '2020-06-01' && $division['date'] < '2020-06-10' && $division['vote'] == 'absent') { ?>
+        <p class="vote-description__covid">This absence may have been affected by <a href="#covid-19">COVID-19 restrictions</a>.</p> 
+    <?php } ?>
     <a class="vote-description__source" href="/divisions/<?= $division['division_id'] ?>/mp/<?= $person_id ?>">Show vote</a>
 </li>
 

--- a/www/includes/easyparliament/templates/html/mp/_vote_description.php
+++ b/www/includes/easyparliament/templates/html/mp/_vote_description.php
@@ -8,7 +8,7 @@
         <?= isset($party_voting_line) ? $party_voting_line : '' ?>
     </a>
     <?php if (isset($covid_affected) && $covid_affected) { ?>
-    <span style="font-size:60%">Absences for this policy may be affected <a href="votes#covid-19">COVID-19 restrictions</a>.</span>
+    <span style="font-size:60%">Absences for this policy may be affected <a href="<?= $member_url ?>/votes#covid-19">COVID-19 restrictions</a>.</span>
     <?php } ?>
     <?php } ?>
 </li>

--- a/www/includes/easyparliament/templates/html/mp/_vote_description.php
+++ b/www/includes/easyparliament/templates/html/mp/_vote_description.php
@@ -8,7 +8,7 @@
         <?= isset($party_voting_line) ? $party_voting_line : '' ?>
     </a>
     <?php if (isset($covid_affected) && $covid_affected) { ?>
-    <span style="font-size:60%">Absences for this policy may be affected <a href="#covid-19">COVID-19 restrictions</a>.</span>
+    <span style="font-size:60%">Absences for this policy may be affected <a href="votes#covid-19">COVID-19 restrictions</a>.</span>
     <?php } ?>
     <?php } ?>
 </li>

--- a/www/includes/easyparliament/templates/html/mp/_vote_description.php
+++ b/www/includes/easyparliament/templates/html/mp/_vote_description.php
@@ -7,5 +7,8 @@
         <?= isset($key_vote) ? "$key_vote[summary]." : '' ?>
         <?= isset($party_voting_line) ? $party_voting_line : '' ?>
     </a>
+    <?php if ($covid_affected) { ?>
+    <span style="font-size:60%">Absences for this policy may be affected <a href="#covid-19">COVID-19 restrictions</a>.</span>
+    <?php } ?>
     <?php } ?>
 </li>

--- a/www/includes/easyparliament/templates/html/mp/_vote_description.php
+++ b/www/includes/easyparliament/templates/html/mp/_vote_description.php
@@ -7,7 +7,7 @@
         <?= isset($key_vote) ? "$key_vote[summary]." : '' ?>
         <?= isset($party_voting_line) ? $party_voting_line : '' ?>
     </a>
-    <?php if ($covid_affected) { ?>
+    <?php if (isset($covid_affected) && $covid_affected) { ?>
     <span style="font-size:60%">Absences for this policy may be affected <a href="#covid-19">COVID-19 restrictions</a>.</span>
     <?php } ?>
     <?php } ?>

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -44,8 +44,6 @@ $display_wtt_stats_banner = '2015';
                 </div>
               <?php endif; ?>
 
-              <?php include('_covid19_panel.php'); ?>
-
               <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
                 <div class="panel">
                     <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -71,7 +71,8 @@ $display_wtt_stats_banner = '2015';
                         <ul class="vote-descriptions">
                           <?php foreach ($policyPositions->positions as $key_vote) {
                             $policy_id = $key_vote['policy_id'];
-                            $covid_affected = in_array($policy_id, [1136, 6860]);
+                            $policies_obj = new MySociety\TheyWorkForYou\Policies();
+                            $covid_affected = in_array($policy_id, $policies_obj->getCovidAffected());
                             $description = ucfirst($key_vote['desc']);
                             $link = sprintf(
                                 '%s/divisions?policy=%s',
@@ -108,7 +109,8 @@ $display_wtt_stats_banner = '2015';
                           <?php foreach ($sorted_diffs as $policy_id => $diff) {
 
                             $key_vote = $diff;
-                            $covid_affected = in_array($policy_id, [1136, 6860]);
+                            $policies_obj = new MySociety\TheyWorkForYou\Policies();
+                            $covid_affected = in_array($policy_id, $policies_obj->getCovidAffected());
                             $policy_desc = strip_tags($key_vote['policy_text']);
                             $policy_direction = $key_vote["person_position"];
                             $policy_group = "highlighted";
@@ -161,7 +163,8 @@ $display_wtt_stats_banner = '2015';
                           <?php foreach ($policyPositions->positions as $key_vote) {
                             
                             $policy_id = $key_vote['policy_id'];
-                            $covid_affected = in_array($policy_id, [1136, 6860]);
+                            $policies_obj = new MySociety\TheyWorkForYou\Policies();
+                            $covid_affected = in_array($policy_id, $policies_obj->getCovidAffected());
                             $description = ucfirst($key_vote['desc']);
                             $link = sprintf(
                                 '%s/divisions?policy=%s',

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -6,6 +6,9 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 // year
 $display_wtt_stats_banner = '2015';
 
+# fetch covid_policy_list
+$policies_obj = new MySociety\TheyWorkForYou\Policies();
+$covid_policy_list = $policies_obj->getCovidAffected();
 ?>
 
 <div class="full-page">
@@ -71,8 +74,7 @@ $display_wtt_stats_banner = '2015';
                         <ul class="vote-descriptions">
                           <?php foreach ($policyPositions->positions as $key_vote) {
                             $policy_id = $key_vote['policy_id'];
-                            $policies_obj = new MySociety\TheyWorkForYou\Policies();
-                            $covid_affected = in_array($policy_id, $policies_obj->getCovidAffected());
+                            $covid_affected = in_array($policy_id, $covid_policy_list);
                             $description = ucfirst($key_vote['desc']);
                             $link = sprintf(
                                 '%s/divisions?policy=%s',
@@ -109,8 +111,7 @@ $display_wtt_stats_banner = '2015';
                           <?php foreach ($sorted_diffs as $policy_id => $diff) {
 
                             $key_vote = $diff;
-                            $policies_obj = new MySociety\TheyWorkForYou\Policies();
-                            $covid_affected = in_array($policy_id, $policies_obj->getCovidAffected());
+                            $covid_affected = in_array($policy_id, $covid_policy_list);
                             $policy_desc = strip_tags($key_vote['policy_text']);
                             $policy_direction = $key_vote["person_position"];
                             $policy_group = "highlighted";
@@ -163,9 +164,7 @@ $display_wtt_stats_banner = '2015';
                           <?php foreach ($policyPositions->positions as $key_vote) {
                             
                             $policy_id = $key_vote['policy_id'];
-                            $policies_obj = new MySociety\TheyWorkForYou\Policies();
-                            $covid_affected = in_array($policy_id, $policies_obj->getCovidAffected());
-                            $description = ucfirst($key_vote['desc']);
+                            $covid_affected = in_array($policy_id, $covid_policy_list);                            $description = ucfirst($key_vote['desc']);
                             $link = sprintf(
                                 '%s/divisions?policy=%s',
                                 $member_url,

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -70,7 +70,8 @@ $display_wtt_stats_banner = '2015';
 
                         <ul class="vote-descriptions">
                           <?php foreach ($policyPositions->positions as $key_vote) {
-
+                            $policy_id = $key_vote['policy_id'];
+                            $covid_affected = in_array($policy_id, [1136, 6860]);
                             $description = ucfirst($key_vote['desc']);
                             $link = sprintf(
                                 '%s/divisions?policy=%s',
@@ -107,7 +108,7 @@ $display_wtt_stats_banner = '2015';
                           <?php foreach ($sorted_diffs as $policy_id => $diff) {
 
                             $key_vote = $diff;
-
+                            $covid_affected = in_array($policy_id, [1136, 6860]);
                             $policy_desc = strip_tags($key_vote['policy_text']);
                             $policy_direction = $key_vote["person_position"];
                             $policy_group = "highlighted";
@@ -158,7 +159,9 @@ $display_wtt_stats_banner = '2015';
 
                         <ul class="vote-descriptions">
                           <?php foreach ($policyPositions->positions as $key_vote) {
-
+                            
+                            $policy_id = $key_vote['policy_id'];
+                            $covid_affected = in_array($policy_id, [1136, 6860]);
                             $description = ucfirst($key_vote['desc']);
                             $link = sprintf(
                                 '%s/divisions?policy=%s',

--- a/www/includes/easyparliament/templates/html/mp/recent.php
+++ b/www/includes/easyparliament/templates/html/mp/recent.php
@@ -15,7 +15,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
         </div>
         <div class="person-panels">
             <div class="primary-content__unit">
-                <?php include('_covid19_panel.php'); ?>
+
 
                 <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
                 <div class="panel">
@@ -57,6 +57,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                         <p>This person has not voted recently.</p>
                     </div>
                 <?php }
+                include('_covid19_panel.php');
                 include('_vote_footer.php'); ?>
             </div>
 

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -69,9 +69,8 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                             <ul class="vote-descriptions">
                               <?php foreach ($segment['votes']->positions as $key_vote) {
                                 $policy_id = $key_vote['policy_id'];
-
-                                # policies where a vote is in our affected early june 2020 windows
-                                $covid_affected = in_array($policy_id, [1136, 6860]);
+                                $policies_obj = new MySociety\TheyWorkForYou\Policies();
+                                $covid_affected = in_array($policy_id, $policies_obj->getCovidAffected());
                                 $policy_desc = strip_tags($key_vote['policy']);
                                 $policy_direction = $key_vote["position"];
                                 $policy_group = $segment['key'];

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -33,8 +33,6 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                 </div>
                 <?php endif; ?>
 
-                <?php include('_covid19_panel.php'); ?>
-
                 <?php if ($current_party_comparison <> $data["comparison_party"]): ?>
                 <?php include('_cross_party_mp_panel.php'); ?>
                 <?php endif; ?>
@@ -71,6 +69,9 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                             <ul class="vote-descriptions">
                               <?php foreach ($segment['votes']->positions as $key_vote) {
                                 $policy_id = $key_vote['policy_id'];
+
+                                # policies where a vote is in our affected early june 2020 windows
+                                $covid_affected = in_array($policy_id, [1136, 6860]);
                                 $policy_desc = strip_tags($key_vote['policy']);
                                 $policy_direction = $key_vote["position"];
                                 $policy_group = $segment['key'];
@@ -154,6 +155,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                     <?php endif; ?>
 
                 <?php endif; ?>
+                <?php include('_covid19_panel.php'); ?>
 
                 <?php include('_vote_footer.php'); ?>
             </div>

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -50,6 +50,9 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                 <?php endif; ?>
 
                 <?php if ($has_voting_record): ?>
+                    
+                    <?php $policies_obj = new MySociety\TheyWorkForYou\Policies(); ?>
+                    <?php $covid_policy_list = $policies_obj->getCovidAffected(); ?>
 
                     <?php $displayed_votes = false; ?>
 
@@ -69,8 +72,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                             <ul class="vote-descriptions">
                               <?php foreach ($segment['votes']->positions as $key_vote) {
                                 $policy_id = $key_vote['policy_id'];
-                                $policies_obj = new MySociety\TheyWorkForYou\Policies();
-                                $covid_affected = in_array($policy_id, $policies_obj->getCovidAffected());
+                                $covid_affected = in_array($policy_id, $covid_policy_list);
                                 $policy_desc = strip_tags($key_vote['policy']);
                                 $policy_direction = $key_vote["position"];
                                 $policy_group = $segment['key'];


### PR DESCRIPTION
- Covid messaging moved to bottom to be linked to rather than at the top of all the pages.
- Removed from profile page altogether
- Absences for votes in early June 2020 have extra text.
- Policies with a vote in that time have extra text (only 1 for now, one more in new policies)

![image](https://user-images.githubusercontent.com/8157058/232818197-d8b85cb8-9524-4e81-a841-4d6edb730fab.png)

![image](https://user-images.githubusercontent.com/8157058/232818284-f8a67985-a7b7-4d59-bb20-666d9440be1f.png)


