### PR TITLE
GA4 analytics

### DIFF
--- a/www/docs/js/main.js
+++ b/www/docs/js/main.js
@@ -9,46 +9,15 @@ var trackEvent = function(eventName, params) {
       dfd.resolve();
   };
 
-  // Returns either an array, or undefined.
-  var measurementProtocolDetails = window.dataLayer.filter(function(row){
-      return row[0] === 'measurement_protocol';
-  })[0];
+  // Tell Gtag to resolve our promise when it's done.
+  var params = $.extend(params, {
+      event_callback: callback
+  });
 
-  if (measurementProtocolDetails) {
-      var measurementParams = {
-          measurement_id: measurementProtocolDetails[1],
-          api_secret: measurementProtocolDetails[2]
-      }
-      if (measurementProtocolDetails[3]) {
-          params['debug_mode'] = '1';
-      }
+  gtag('event', eventName, params);
 
-      // Set a random client_id (2 32-bit integers seperated by a dot).
-      // Note this random approach means the GA debugView won't work.
-      // (To get that to work, you need to turn back on the cookies,
-      // then use the same client_id as in in the _ga cookie.)
-      var client_id = Math.floor(Math.random() * 1000000000) + '.' + Math.floor(Math.random() * 1000000000);
-
-      // print response to console
-      $.ajax({
-          url: 'https://www.google-analytics.com/mp/collect?' + $.param(measurementParams),
-          method: 'POST',
-          data: JSON.stringify({
-              client_id: client_id,
-              events: [{
-                  name: eventName,
-                  params: params
-              }]
-          })
-      }).always(callback);
-
-      // Wait a maximum of 2 seconds for ajax to resolve.
-      setTimeout(callback, 2000);
-
-  } else {
-      // Measurement Protocol not available. Resolve promise immediately.
-      callback();
-  }
+  // Wait a maximum of 2 seconds for Gtag to resolve promise.
+  setTimeout(callback, 2000);
 
   return dfd.promise();
 };

--- a/www/docs/js/main.js
+++ b/www/docs/js/main.js
@@ -257,13 +257,6 @@ $(function(){
 
   });
 
-  $('[data-track-click]').on('click', function(e){
-    if ( window.analytics ) {
-      window.analytics.trackLinkClick(e, {
-        eventCategory: $(this).attr('data-track-click')
-      });
-    }
-  });
 
   if ( ! ( 'open' in document.createElement('details') ) ) {
     $('summary').siblings().hide();

--- a/www/docs/js/main.js
+++ b/www/docs/js/main.js
@@ -1,3 +1,58 @@
+var trackEvent = function(eventName, params) {
+  // We'll return a promise, and resolve it when either Gtag handles
+  // our event, or a maximum fallback period elapses. Promises can
+  // only be resolved once, so this also ensures whatever callbacks
+  // are attached to the promise only execute once.
+  var dfd = $.Deferred();
+
+  var callback = function(){
+      dfd.resolve();
+  };
+
+  // Returns either an array, or undefined.
+  var measurementProtocolDetails = window.dataLayer.filter(function(row){
+      return row[0] === 'measurement_protocol';
+  })[0];
+
+  if (measurementProtocolDetails) {
+      var measurementParams = {
+          measurement_id: measurementProtocolDetails[1],
+          api_secret: measurementProtocolDetails[2]
+      }
+      if (measurementProtocolDetails[3]) {
+          params['debug_mode'] = '1';
+      }
+
+      // Set a random client_id (2 32-bit integers seperated by a dot).
+      // Note this random approach means the GA debugView won't work.
+      // (To get that to work, you need to turn back on the cookies,
+      // then use the same client_id as in in the _ga cookie.)
+      var client_id = Math.floor(Math.random() * 1000000000) + '.' + Math.floor(Math.random() * 1000000000);
+
+      // print response to console
+      $.ajax({
+          url: 'https://www.google-analytics.com/mp/collect?' + $.param(measurementParams),
+          method: 'POST',
+          data: JSON.stringify({
+              client_id: client_id,
+              events: [{
+                  name: eventName,
+                  params: params
+              }]
+          })
+      }).always(callback);
+
+      // Wait a maximum of 2 seconds for ajax to resolve.
+      setTimeout(callback, 2000);
+
+  } else {
+      // Measurement Protocol not available. Resolve promise immediately.
+      callback();
+  }
+
+  return dfd.promise();
+};
+
 function swapCalendar(direction) {
   var current = $('.cal-wrapper.visible');
   var num = parseInt(current.attr('data-count'), 10);
@@ -323,19 +378,18 @@ $(function(){
 
 // Backwards-compatible functions for the click/submit trackers on MP pages
 function trackFormSubmit(form, category, name, value) {
-  window.analytics.trackEvent({
-    eventCategory: category,
-    eventAction: name,
-    eventLabel: value
+  trackEvent("form_submit",
+    { category: category,
+      event_action: name,
+      event_label: value
   }).always(function(){
     form.submit();
   });
 }
 function trackLinkClick(link, category, name, value) {
-  window.analytics.trackEvent({
-    eventCategory: category,
-    eventAction: name,
-    eventLabel: value
+  trackEvent(category, {
+    event_action: name,
+    event_label: value
   }).always(function(){
     document.location.href = link.href;
   })

--- a/www/includes/easyparliament/templates/html/footer.php
+++ b/www/includes/easyparliament/templates/html/footer.php
@@ -103,7 +103,6 @@
 <script src="<?= cache_version("js/jquery-1.11.3.min.js") ?>"></script>
 <script src="<?= cache_version("js/jquery.cookie.js") ?>"></script>
 <script src="<?= cache_version("js/accessible-autocomplete.min.js") ?>"></script>
-<script src="<?= cache_version("js/analytics/analytics.js") ?>"></script>
 <script src="<?= cache_version("js/main.js") ?>"></script>
 
 <script>

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -63,21 +63,15 @@
   <?php if (!DEVSITE): ?>
 
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-W8M9N1MJFT"></script>
+    <script defer>var capturedCookies={};Object.defineProperty(document,"cookie",{get:function(){var t=Object.getOwnPropertyDescriptor(Document.prototype,"cookie").get.call(document);for(var e in capturedCookies)t+=" "+e+"="+capturedCookies[e]+";";return t},set:function(t){var e=t.split("="),o=e[0].trim(),r=e[1].trim();o.startsWith("_ga")?capturedCookies[o]=r:Object.getOwnPropertyDescriptor(Document.prototype,"cookie").set.call(document,t)}});</script>
+    <script defer src="https://www.googletagmanager.com/gtag/js?id=G-W8M9N1MJFT"></script>
   
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag("consent", "default", {
-            ad_storage: "denied",
-            analytics_storage: "denied",
-            functionality_storage: "denied",
-            personalization_storage: "denied",
-            security_storage: "denied"
-        });
-      gtag('config', 'G-W8M9N1MJFT');
-      gtag("measurement_protocol", "G-W8M9N1MJFT", "BAQyGdKSTUyeDjwSxG9V-w" );
+        var client_id = Math.floor(Math.random() * 1000000000) + '.' + Math.floor(Math.random() * 1000000000);
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config','G-W8M9N1MJFT', {'client_id': client_id, 'cookie_expires': 0 });
     </script>
 
     <script>

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -61,6 +61,25 @@
     <script async src="<?= cache_version("js/loading-attribute-polyfill.min.js") ?>"></script>
 
   <?php if (!DEVSITE): ?>
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-W8M9N1MJFT"></script>
+  
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag("consent", "default", {
+            ad_storage: "denied",
+            analytics_storage: "denied",
+            functionality_storage: "denied",
+            personalization_storage: "denied",
+            security_storage: "denied"
+        });
+      gtag('config', 'G-W8M9N1MJFT');
+      gtag("measurement_protocol", "G-W8M9N1MJFT", "BAQyGdKSTUyeDjwSxG9V-w" );
+    </script>
+
     <script>
         (function (i,s,o,g,r,a,m) {i['GoogleAnalyticsObject']=r;i[r]=i[r]||function () {
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -63,7 +63,7 @@
   <?php if (!DEVSITE): ?>
 
     <!-- Google tag (gtag.js) -->
-    <script defer>var capturedCookies={};Object.defineProperty(document,"cookie",{get:function(){var t=Object.getOwnPropertyDescriptor(Document.prototype,"cookie").get.call(document);for(var e in capturedCookies)t+=" "+e+"="+capturedCookies[e]+";";return t},set:function(t){var e=t.split("="),o=e[0].trim(),r=e[1].trim();o.startsWith("_ga")?capturedCookies[o]=r:Object.getOwnPropertyDescriptor(Document.prototype,"cookie").set.call(document,t)}});</script>
+    <script defer>Object.defineProperty(document,"cookie",{get:function(){var t=Object.getOwnPropertyDescriptor(Document.prototype,"cookie").get.call(document);return t.trim().length>0&&(t+="; "),t+="_ga=GA1.1."+Math.floor(1e9*Math.random())+"."+Math.floor(1e9*Math.random())},set:function(t){t.trim().startsWith("_ga")||Object.getOwnPropertyDescriptor(Document.prototype,"cookie").set.call(document,t)}});</script>
     <script defer src="https://www.googletagmanager.com/gtag/js?id=G-W8M9N1MJFT"></script>
   
     <script>
@@ -71,7 +71,7 @@
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config','G-W8M9N1MJFT', {'client_id': client_id, 'cookie_expires': 0 });
+        gtag('config','G-W8M9N1MJFT', {'client_id': client_id, 'cookie_expires': 1 });
     </script>
 
     <script>

--- a/www/includes/easyparliament/templates/html/mp/header.php
+++ b/www/includes/easyparliament/templates/html/mp/header.php
@@ -34,7 +34,7 @@
               <?php if (count($social_links) > 0) { ?>
                 <p class="person-header__about__media">
                   <?php foreach ($social_links as $link){ ?>
-                      <a href="<?= $link['href'] ?>" onclick="trackLinkClick(this, 'Social-Link', '<?= $link['type'] ?>', '<?= $link['text'] ?>'); return false;"><?= $link['text'] ?></a>
+                      <a href="<?= $link['href'] ?>" onclick="trackLinkClick(this, 'social_link', '<?= $link['type'] ?>', '<?= $link['text'] ?>'); return false;"><?= $link['text'] ?></a>
                   <?php } ?>
                 </p>
               <?php } ?>
@@ -60,10 +60,10 @@
                     $wtt_url = $wtt_url . "?a=WMC&amp;pc=" . _htmlentities(urlencode($user_postcode));
                 }
               ?>
-                <a href="<?= $wtt_url ?>" class="button" onclick="trackLinkClick(this, 'Links', 'WriteToThem', 'Person'); return false;">Send a message</a>
+                <a href="<?= $wtt_url ?>" class="button" onclick="trackLinkClick(this, 'link_click', 'WriteToThem', 'Person'); return false;">Send a message</a>
               <?php } ?>
               <?php if ($has_email_alerts) { ?>
-                <a href="<?= WEBPATH ?>alert/?pid=<?= $person_id ?>" class="button tertiary" onclick="trackLinkClick(this, 'Alert', 'Search', 'Person'); return false;">Get email updates</a>
+                <a href="<?= WEBPATH ?>alert/?pid=<?= $person_id ?>" class="button tertiary" onclick="trackLinkClick(this, 'alert_click', 'Search', 'Person'); return false;">Get email updates</a>
               <?php } ?>
             </div>
           <?php } ?>

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -58,7 +58,7 @@ $covid_policy_list = $policies_obj->getCovidAffected();
                     <p>When <?= $full_name ?> starts to speak in debates and vote on bills, that information will appear on this page.</p>
 
                   <?php if ($has_email_alerts) { ?>
-                    <a href="<?= WEBPATH ?>alert/?pid=<?= $person_id ?>#" onclick="trackLinkClick(this, 'Alert', 'Search', 'Person'); return false;">Sign up for email alerts to be the first to know when that happens.</a>
+                    <a href="<?= WEBPATH ?>alert/?pid=<?= $person_id ?>#" onclick="trackLinkClick(this, 'alert_click', 'Search', 'Person'); return false;">Sign up for email alerts to be the first to know when that happens.</a>
                   <?php } ?>
                 </div>
               <?php endif; ?>
@@ -268,7 +268,7 @@ $covid_policy_list = $policies_obj->getCovidAffected();
                     <h3>Social Media</h3>
                     <ul>
                         <?php foreach ($social_links as $link): ?>
-                        <li><a class="fi-social-<?= $link['type'] ?>" href="<?= $link['href'] ?>" onclick="trackLinkClick(this, 'Social-Link', '<?= $link['type'] ?>', '<?= $link['text'] ?>'); return false;"><?= $link['text'] ?></a></li>
+                        <li><a class="fi-social-<?= $link['type'] ?>" href="<?= $link['href'] ?>" onclick="trackLinkClick(this, 'social_link', '<?= $link['type'] ?>', '<?= $link['text'] ?>'); return false;"><?= $link['text'] ?></a></li>
                         <?php endforeach; ?>
                     </ul>
                     <?php endif; ?>


### PR DESCRIPTION
Uses the cookieless GA4 approach described in https://docs.google.com/document/d/1ZXbkXoLE0eLnUWJaVv_8xpnVOlOHGCxPP_Uo7cfoFJo/edit

- Adds GA4 config
- monkey-patches `document.cookies` to prevent ga setting cookies.

This PR originally used the measurement protocol - but those commits will come out in a final squish.