### PR TITLE
[Wales] Translate the standard form error messages

### DIFF
--- a/classes/AlertView/Standard.php
+++ b/classes/AlertView/Standard.php
@@ -120,10 +120,10 @@ class Standard extends \MySociety\TheyWorkForYou\AlertView {
 
         // Check email address is valid and unique.
         if (!$this->data['email']) {
-            $errors["email"] = "Please enter your email address";
+            $errors["email"] = gettext("Please enter your email address");
         } elseif (!validate_email($this->data["email"])) {
             // validate_email() is in includes/utilities.php
-            $errors["email"] = "Please enter a valid email address";
+            $errors["email"] = gettext("Please enter a valid email address");
         }
 
         if ($this->data['pid'] && !ctype_digit($this->data['pid'])) {

--- a/classes/User.php
+++ b/classes/User.php
@@ -162,18 +162,18 @@ class User {
 
                 // Only *must* enter a password if they're joining.
                 if ($details["password"] == "") {
-                    $errors["password"] = "Please enter a password";
+                    $errors["password"] = gettext("Please enter a password");
 
                 } elseif (strlen($details["password"]) < 6) {
-                    $errors["password"] = "Please enter at least six characters";
+                    $errors["password"] = gettext("Please enter at least six characters");
                 }
 
                 if ($details["password2"] == "") {
-                    $errors["password2"] = "Please enter a password again";
+                    $errors["password2"] = gettext("Please enter a password again");
                 }
 
                 if ($details["password"] != "" && $details["password2"] != "" && $details["password"] != $details["password2"]) {
-                    $errors["password"] = "The passwords did not match. Please try again.";
+                    $errors["password"] = gettext("The passwords did not match. Please try again.");
                 }
 
             } else {
@@ -181,11 +181,11 @@ class User {
                 // Update details pages.
 
                 if ($details["password"] != "" && strlen($details["password"]) < 6) {
-                    $errors["password"] = "Please enter at least six characters";
+                    $errors["password"] = gettext("Please enter at least six characters");
                 }
 
                 if ($details["password"] != $details["password2"]) {
-                    $errors["password"] = "The passwords did not match. Please try again.";
+                    $errors["password"] = gettext("The passwords did not match. Please try again.");
                 }
             }
         }
@@ -193,7 +193,7 @@ class User {
         // Check postcode (which is not a compulsory field).
         if ($details["postcode"] != "") {
             if (!validate_postcode($details["postcode"])) {
-                $errors["postcode"] = "Sorry, this isn't a valid UK postcode.";
+                $errors["postcode"] = gettext("Sorry, this isn't a valid UK postcode.");
             } else {
                 try {
                     new \MySociety\TheyWorkForYou\Member(array(
@@ -201,7 +201,7 @@ class User {
                         'house' => HOUSE_TYPE_COMMONS,
                     ));
                 } catch (MemberException $e) {
-                    $errors["postcode"] = "Sorry, we could not find an MP for that postcode.";
+                    $errors["postcode"] = gettext("Sorry, we could not find an MP for that postcode.");
                 }
             }
         }

--- a/locale/TheyWorkForYou.pot
+++ b/locale/TheyWorkForYou.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-13 09:38+0000\n"
+"POT-Creation-Date: 2023-06-13 15:56+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,17 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: classes/AlertView/Standard.php:123 www/docs/user/login/index.php:34
+#: www/docs/user/password/index.php:33
+msgid "Please enter your email address"
+msgstr ""
+
+#. validate_email() is in includes/utilities.php
+#: classes/AlertView/Standard.php:126 www/docs/user/login/index.php:36
+#: www/docs/user/password/index.php:35
+msgid "Please enter a valid email address"
+msgstr ""
 
 #: classes/AlertView/Standard.php:139
 msgid "Please enter what you want to be alerted about"
@@ -166,6 +177,30 @@ msgstr ""
 
 #: classes/Search.php:76
 msgid "You cannot search for more than one date range."
+msgstr ""
+
+#: classes/User.php:165
+msgid "Please enter a password"
+msgstr ""
+
+#: classes/User.php:168 classes/User.php:184
+msgid "Please enter at least six characters"
+msgstr ""
+
+#: classes/User.php:172
+msgid "Please enter a password again"
+msgstr ""
+
+#: classes/User.php:176 classes/User.php:188
+msgid "The passwords did not match. Please try again."
+msgstr ""
+
+#: classes/User.php:196
+msgid "Sorry, this isn't a valid UK postcode."
+msgstr ""
+
+#: classes/User.php:204
+msgid "Sorry, we could not find an MP for that postcode."
 msgstr ""
 
 #: classes/Utility/House.php:44
@@ -733,6 +768,22 @@ msgid ""
 "href=\"%s\">WriteToThem.com</a>."
 msgstr ""
 
+#: www/docs/user/login/index.php:39
+msgid "Please enter your password"
+msgstr ""
+
+#: www/docs/user/login/index.php:86
+msgid "Confirmation email resent"
+msgstr ""
+
+#: www/docs/user/login/index.php:87
+#: www/includes/easyparliament/templates/html/user/welcome.php:7
+msgid ""
+"You should receive an email shortly which will contain a link. You will need "
+"to follow that link to confirm your email address before you can log in. "
+"Thanks."
+msgstr ""
+
 #: www/docs/user/login/index.php:123
 msgid "Or sign in by email:"
 msgstr ""
@@ -1043,7 +1094,7 @@ msgstr ""
 #. end of isset($speakers)
 #: www/includes/easyparliament/page.php:642
 #: www/includes/easyparliament/templates/html/alert/index.php:324
-#: www/includes/easyparliament/templates/html/header.php:144
+#: www/includes/easyparliament/templates/html/header.php:157
 #: www/includes/easyparliament/templates/html/mp/header.php:58
 #: www/includes/easyparliament/templates/html/search/form_main.php:5
 #: www/includes/easyparliament/templates/html/search/form_options.php:96
@@ -1528,7 +1579,7 @@ msgid "Division number %s"
 msgstr ""
 
 #: www/includes/easyparliament/templates/html/divisions/index.php:45
-#: www/includes/easyparliament/templates/html/section/_business_section.php:14
+#: www/includes/easyparliament/templates/html/section/_business_section.php:18
 #: www/includes/easyparliament/templates/html/section/day.php:72
 msgid "What is this?"
 msgstr ""
@@ -1672,11 +1723,11 @@ msgstr[1] ""
 msgid "No data to display."
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/header.php:138
+#: www/includes/easyparliament/templates/html/header.php:151
 msgid "Search TheyWorkForYou"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/header.php:141
+#: www/includes/easyparliament/templates/html/header.php:154
 msgid "e.g. a postcode, person, or topic"
 msgstr ""
 
@@ -2313,12 +2364,12 @@ msgstr ""
 msgid "What is RSS?"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/section/_business_section.php:4
+#: www/includes/easyparliament/templates/html/section/_business_section.php:7
 #, php-format
 msgid "Recent %s"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/section/_business_section.php:26
+#: www/includes/easyparliament/templates/html/section/_business_section.php:30
 #, php-format
 msgid "RSS feed of %s"
 msgstr ""
@@ -2828,13 +2879,6 @@ msgstr ""
 
 #: www/includes/easyparliament/templates/html/user/view_user.php:3
 msgid "User details"
-msgstr ""
-
-#: www/includes/easyparliament/templates/html/user/welcome.php:7
-msgid ""
-"You should receive an email shortly which will contain a link. You will need "
-"to follow that link to confirm your email address before you can log in. "
-"Thanks."
 msgstr ""
 
 #: www/includes/utility.php:174

--- a/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
+++ b/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-13 09:38+0000\n"
+"POT-Creation-Date: 2023-06-13 15:56+0000\n"
 "PO-Revision-Date: 2023-03-20 17:59-0000\n"
 "Language-Team: mySociety\n"
 "Language: fr\n"
@@ -10,6 +10,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 " Project-Id-Version: 1.0\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+#: classes/AlertView/Standard.php:123 www/docs/user/login/index.php:34
+#: www/docs/user/password/index.php:33
+msgid "Please enter your email address"
+msgstr "Nodwch eich cyfeiriad e-bost"
+
+#. validate_email() is in includes/utilities.php
+#: classes/AlertView/Standard.php:126 www/docs/user/login/index.php:36
+#: www/docs/user/password/index.php:35
+msgid "Please enter a valid email address"
+msgstr "Mewnbynnwch gyfeiriad e-bost dilys"
 
 #: classes/AlertView/Standard.php:139
 msgid "Please enter what you want to be alerted about"
@@ -152,6 +163,30 @@ msgstr "Ni allwch chwilio am ystod dyddiad yn unig, dewiswch rai meini prawf era
 #: classes/Search.php:76
 msgid "You cannot search for more than one date range."
 msgstr "Ni allwch chwilio am fwy nag un ystod o ddyddiadau."
+
+#: classes/User.php:165
+msgid "Please enter a password"
+msgstr "Rhowch eich cyfrinair"
+
+#: classes/User.php:168 classes/User.php:184
+msgid "Please enter at least six characters"
+msgstr "Mae angen o leiaf chwe mewnbwn"
+
+#: classes/User.php:172
+msgid "Please enter a password again"
+msgstr "Nodwch eich cyfrinair eto"
+
+#: classes/User.php:176 classes/User.php:188
+msgid "The passwords did not match. Please try again."
+msgstr "Mae’n rhaid i’r cyfrineiriau fod yr un fath. Ceisiwch eto os gwelwch yn dda."
+
+#: classes/User.php:196
+msgid "Sorry, this isn't a valid UK postcode."
+msgstr "Mae'n ddrwg gennym, nid yw hwn yn gôd post dilys"
+
+#: classes/User.php:204
+msgid "Sorry, we could not find an MP for that postcode."
+msgstr "Mae'n ddrwg gennym, ni allwn ddod o hyd i AS ar gyfer y côd post hwnnw."
 
 #: classes/Utility/House.php:44
 msgid "MS"
@@ -683,6 +718,19 @@ msgstr "Mae eich Aelod Senddol yn eich cynrychioli yn Nhŷ'r Cyffredin. Tŷ'r Cy
 msgid "You can write to any representative, or your local councillors through <a href=\"%s\">WriteToThem.com</a>."
 msgstr "Gallwch ysgrifennu at unrhyw gynrychiolydd, neu'ch cynghorwyr lleol drwy <a href=\"%s\">WriteToThem.com</a>."
 
+#: www/docs/user/login/index.php:39
+msgid "Please enter your password"
+msgstr "Rhowch eich cyfrinair"
+
+#: www/docs/user/login/index.php:86
+msgid "Confirmation email resent"
+msgstr "E-bost cadarnhau wedi’i anfon eto"
+
+#: www/docs/user/login/index.php:87
+#: www/includes/easyparliament/templates/html/user/welcome.php:7
+msgid "You should receive an email shortly which will contain a link. You will need to follow that link to confirm your email address before you can log in. Thanks."
+msgstr "Dylech dderbyn e-bost yn fuan a fydd yn cynnwys dolen. Bydd angen i chi ddilyn y ddolen honno i gadarnhau eich cyfeiriad e-bost cyn y gallwch fewngofnodi.  Diolch."
+
 #: www/docs/user/login/index.php:123
 msgid "Or sign in by email:"
 msgstr "Neu fewngofnodwch drwy e-bost:"
@@ -993,7 +1041,7 @@ msgstr "Addasu’r chwilio"
 #. end of isset($speakers)
 #: www/includes/easyparliament/page.php:642
 #: www/includes/easyparliament/templates/html/alert/index.php:324
-#: www/includes/easyparliament/templates/html/header.php:144
+#: www/includes/easyparliament/templates/html/header.php:157
 #: www/includes/easyparliament/templates/html/mp/header.php:58
 #: www/includes/easyparliament/templates/html/search/form_main.php:5
 #: www/includes/easyparliament/templates/html/search/form_options.php:96
@@ -1450,7 +1498,7 @@ msgid "Division number %s"
 msgstr "Rhif adran  %s"
 
 #: www/includes/easyparliament/templates/html/divisions/index.php:45
-#: www/includes/easyparliament/templates/html/section/_business_section.php:14
+#: www/includes/easyparliament/templates/html/section/_business_section.php:18
 #: www/includes/easyparliament/templates/html/section/day.php:72
 msgid "What is this?"
 msgstr "Beth yw hwn?"
@@ -1584,11 +1632,11 @@ msgstr[1] "%s areithiau"
 msgid "No data to display."
 msgstr "Dim data i'w arddangos."
 
-#: www/includes/easyparliament/templates/html/header.php:138
+#: www/includes/easyparliament/templates/html/header.php:151
 msgid "Search TheyWorkForYou"
 msgstr "Chwiliwch TheyWorkForYou"
 
-#: www/includes/easyparliament/templates/html/header.php:141
+#: www/includes/easyparliament/templates/html/header.php:154
 msgid "e.g. a postcode, person, or topic"
 msgstr "e.e. côd post, person, neu bwnc"
 
@@ -2189,12 +2237,12 @@ msgstr "Neu <a href=\"%s\">cael ffrwd RSS</a> o gemau newydd fel maen nhw'n digw
 msgid "What is RSS?"
 msgstr "Beth yw RSS?"
 
-#: www/includes/easyparliament/templates/html/section/_business_section.php:4
+#: www/includes/easyparliament/templates/html/section/_business_section.php:7
 #, php-format
 msgid "Recent %s"
 msgstr "%s diweddar"
 
-#: www/includes/easyparliament/templates/html/section/_business_section.php:26
+#: www/includes/easyparliament/templates/html/section/_business_section.php:30
 #, php-format
 msgid "RSS feed of %s"
 msgstr "Porthiant RSS o %s"
@@ -2646,10 +2694,6 @@ msgstr "(Os ydych eisoes yn derbyn hysbysiadau e-bost, peidiwch â phoeni am hyn
 #: www/includes/easyparliament/templates/html/user/view_user.php:3
 msgid "User details"
 msgstr "Manylion defnyddiwr"
-
-#: www/includes/easyparliament/templates/html/user/welcome.php:7
-msgid "You should receive an email shortly which will contain a link. You will need to follow that link to confirm your email address before you can log in. Thanks."
-msgstr "Dylech dderbyn e-bost yn fuan a fydd yn cynnwys dolen. Bydd angen i chi ddilyn y ddolen honno i gadarnhau eich cyfeiriad e-bost cyn y gallwch fewngofnodi.  Diolch."
 
 #: www/includes/utility.php:174
 msgid "Sorry, an error has occurred"

--- a/www/docs/user/login/index.php
+++ b/www/docs/user/login/index.php
@@ -31,12 +31,12 @@ if (get_http_var("submitted") == "true") {
     $errors = array();
 
     if ($email == "") {
-        $errors["email"] = "Please enter your email address";
+        $errors["email"] = gettext("Please enter your email address");
     } elseif (!validate_email($email)) {
-        $errors["email"] = "Please enter a valid email address";
+        $errors["email"] = gettext("Please enter a valid email address");
     }
     if ($password == "") {
-        $errors["password"] = "Please enter your password";
+        $errors["password"] = gettext("Please enter your password");
     }
 
     if (sizeof($errors) > 0) {
@@ -83,8 +83,8 @@ if (get_http_var("submitted") == "true") {
         $PAGE->page_start();
         $PAGE->stripe_start();
         $message = array(
-            'title' => "Confirmation email resent",
-            'text' => "You should receive an email shortly which will contain a link. You will need to follow that link to confirm your email address before you can log in. Thanks."
+            'title' => gettext("Confirmation email resent"),
+            'text' => gettext("You should receive an email shortly which will contain a link. You will need to follow that link to confirm your email address before you can log in. Thanks.")
         );
         $PAGE->message($message);
         $PAGE->stripe_end();

--- a/www/docs/user/password/index.php
+++ b/www/docs/user/password/index.php
@@ -30,9 +30,9 @@ if (get_http_var("submitted")) {
 
 
     if ($email == "") {
-        $errors["email"] = "Please enter your email address";
+        $errors["email"] = gettext("Please enter your email address");
     } elseif (!validate_email($email)) {
-        $errors["email"] = "Please enter a valid email address";
+        $errors["email"] = gettext("Please enter a valid email address");
     } else {
 
         $USER = new USER;


### PR DESCRIPTION
Finishes off a few translations that appear as validation errors in the standard alert and user sign-up forms ("enter your email", etc).
