### PR TITLE
Devolved navigation

### DIFF
--- a/classes/Renderer/Header.php
+++ b/classes/Renderer/Header.php
@@ -278,7 +278,7 @@ class Header
             array('hansard', 'mps', 'peers', 'alldebatesfront', 'wranswmsfront', 'pbc_front', 'divisions_recent', 'calendar_summary'),
             array('sp_home', 'spoverview', 'msps', 'spdebatesfront', 'spwransfront'),
             array('ni_home', 'nioverview', 'mlas'),
-            array('wales_home', 'seneddoverview', 'mss'),
+            array('wales_home', 'seneddoverview', 'mss', 'wales_debates'),
             array('london_home', 'lmqsfront', 'london-assembly-members'),
         );
 

--- a/classes/Renderer/Header.php
+++ b/classes/Renderer/Header.php
@@ -259,6 +259,45 @@ class Header
             $section = '';
         }
 
+        // if we're searching within a parliament, put this in the top bar
+        if ($this_page == "search") {
+            if (isset($_GET['section'])) {
+                $section = $_GET['section'];
+                if ($section == 'scotland') {
+                    $selected_top_link['text'] = 'Scotland';
+                } elseif ($section == 'ni') {
+                    $selected_top_link['text'] = 'Northern Ireland';
+                } elseif ($section == 'wales') {
+                    $selected_top_link['text'] = gettext('Wales');
+                } elseif ($section == 'london') {
+                    $selected_top_link['text'] = 'London Assembly';
+                } else {
+                    $selected_top_link['text'] = 'UK';
+                }
+            }
+        }
+
+        // for the alerts page, put the most recent membership's house
+        // in the top bar
+        if ($this_page == "alert"){
+            if (isset($_GET['pid'])) {
+                $pid = $_GET['pid'];
+                $person = new \MySociety\TheyWorkForYou\Member(array('person_id' => $pid));
+                $membership = $person->getMostRecentMembership();
+                $parliament = $membership['house'];
+                if ($parliament == 'ni') {
+                    $selected_top_link['text'] = 'Northern Ireland';
+                } elseif ($parliament == HOUSE_TYPE_SCOTLAND) {
+                    $selected_top_link['text'] = 'Scotland';
+                } elseif ($parliament == HOUSE_TYPE_WALES) {
+                    $selected_top_link['text'] = gettext('Wales');
+                } elseif ($parliament == HOUSE_TYPE_LONDON_ASSEMBLY) {
+                    $selected_top_link['text'] = 'London Assembly';
+                }
+            }
+
+        }
+
         $this->nav_highlights = array(
             'top' => $top_highlight,
             'bottom' => $bottom_highlight,

--- a/locale/TheyWorkForYou.pot
+++ b/locale/TheyWorkForYou.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-15 10:28+0000\n"
+"POT-Creation-Date: 2023-06-16 05:24+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -165,7 +165,8 @@ msgid ""
 "represents you, how they’ve voted and what they’ve said in debates."
 msgstr ""
 
-#: classes/Renderer/Header.php:254
+#: classes/Renderer/Header.php:254 classes/Renderer/Header.php:271
+#: classes/Renderer/Header.php:293
 msgid "Wales"
 msgstr ""
 
@@ -481,8 +482,8 @@ msgid "London Mayoral questions"
 msgstr ""
 
 #: scripts/alertmailer.php:141 scripts/alertmailer.php:142
-#: www/includes/easyparliament/metadata.php:1089
-#: www/includes/easyparliament/metadata.php:1092
+#: www/includes/easyparliament/metadata.php:1098
+#: www/includes/easyparliament/metadata.php:1101
 msgid "Senedd debates"
 msgstr ""
 
@@ -1033,15 +1034,16 @@ msgstr ""
 msgid "Debates in the Senedd"
 msgstr ""
 
+#: www/includes/easyparliament/metadata.php:1056
 msgid "Find your MS"
 msgstr ""
 
-#: www/includes/easyparliament/metadata.php:1052
-#: www/includes/easyparliament/metadata.php:1057
+#: www/includes/easyparliament/metadata.php:1061
+#: www/includes/easyparliament/metadata.php:1066
 msgid "Your MSs"
 msgstr ""
 
-#: www/includes/easyparliament/metadata.php:1053
+#: www/includes/easyparliament/metadata.php:1062
 msgid "Find out about your Members of the Senedd"
 msgstr ""
 
@@ -1051,16 +1053,16 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: www/includes/easyparliament/metadata.php:1065
+#: www/includes/easyparliament/metadata.php:1074
 msgid "Overview of the Senedd debates"
 msgstr ""
 
-#: www/includes/easyparliament/metadata.php:1205
-#: www/includes/easyparliament/metadata.php:1209
+#: www/includes/easyparliament/metadata.php:1214
+#: www/includes/easyparliament/metadata.php:1218
 msgid "Your MP"
 msgstr ""
 
-#: www/includes/easyparliament/metadata.php:1206
+#: www/includes/easyparliament/metadata.php:1215
 msgid "Find out about your Member of Parliament"
 msgstr ""
 
@@ -1111,7 +1113,7 @@ msgstr ""
 #: www/includes/easyparliament/templates/html/search/form_main.php:5
 #: www/includes/easyparliament/templates/html/search/form_options.php:96
 #: www/includes/easyparliament/templates/html/section/_search.php:10
-#: www/includes/easyparliament/templates/html/senedd/index.php:67
+#: www/includes/easyparliament/templates/html/senedd/index.php:52
 msgid "Search"
 msgstr ""
 
@@ -1835,11 +1837,6 @@ msgstr ""
 msgid "That name is not unique. Please select from the following:"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/profile.php:20
-#: www/includes/easyparliament/templates/html/mp/recent.php:10
-msgid "Overview"
-msgstr ""
-
 #: www/includes/easyparliament/templates/html/mp/profile.php:21
 #: www/includes/easyparliament/templates/html/mp/recent.php:11
 msgid "Voting Record"
@@ -2208,12 +2205,6 @@ msgstr ""
 msgid "Future Business"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/search/form_options.php:66
-#: www/includes/easyparliament/templates/html/search/form_options.php:70
-#: www/includes/easyparliament/templates/html/search/form_options.php:74
-msgid "Debates"
-msgstr ""
-
 #: www/includes/easyparliament/templates/html/search/form_options.php:69
 msgid "All Scotland"
 msgstr ""
@@ -2350,8 +2341,8 @@ msgstr ""
 
 #. end of !isset($error)
 #: www/includes/easyparliament/templates/html/search/sidebar.php:3
-#: www/includes/easyparliament/templates/html/senedd/index.php:49
-#: www/includes/easyparliament/templates/html/senedd/index.php:52
+#: www/includes/easyparliament/templates/html/senedd/index.php:77
+#: www/includes/easyparliament/templates/html/senedd/index.php:80
 msgid "Create an alert"
 msgstr ""
 
@@ -2427,12 +2418,12 @@ msgid "Search %s"
 msgstr ""
 
 #: www/includes/easyparliament/templates/html/section/_search.php:7
-#: www/includes/easyparliament/templates/html/senedd/index.php:64
+#: www/includes/easyparliament/templates/html/senedd/index.php:49
 msgid "Enter a keyword, phrase, or person"
 msgstr ""
 
 #: www/includes/easyparliament/templates/html/section/_search.php:30
-#: www/includes/easyparliament/templates/html/senedd/index.php:74
+#: www/includes/easyparliament/templates/html/senedd/index.php:59
 msgid "Popular searches today"
 msgstr ""
 
@@ -2547,7 +2538,7 @@ msgid ""
 "&ndash; <a href=\"https://en.wikipedia.org/wiki/Senedd\">Wikipedia</a>\n"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/section/senedd_index.php:10
+#: www/includes/easyparliament/templates/html/section/senedd_index.php:9
 msgid "Search Senedd debates"
 msgstr ""
 
@@ -2596,18 +2587,17 @@ msgstr ""
 msgid "About TheyWorkForYou"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/senedd/index.php:50
+#: www/includes/easyparliament/templates/html/senedd/index.php:46
+msgid "Search debates"
+msgstr ""
+
 msgid "Stay informed!"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/senedd/index.php:51
+#: www/includes/easyparliament/templates/html/senedd/index.php:79
 msgid ""
 "Get an email every time an issue you care about is mentioned in the Senedd "
 "(and more)"
-msgstr ""
-
-#: www/includes/easyparliament/templates/html/senedd/index.php:61
-msgid "Search debates"
 msgstr ""
 
 #: www/includes/easyparliament/templates/html/senedd/index.php:87

--- a/locale/TheyWorkForYou.pot
+++ b/locale/TheyWorkForYou.pot
@@ -1022,7 +1022,17 @@ msgstr ""
 msgid "List of Members of the Senedd (MSs)"
 msgstr ""
 
-#: www/includes/easyparliament/metadata.php:1047
+#: www/includes/easyparliament/metadata.php:1048
+#: www/includes/easyparliament/templates/html/search/form_options.php:66
+#: www/includes/easyparliament/templates/html/search/form_options.php:70
+#: www/includes/easyparliament/templates/html/search/form_options.php:74
+msgid "Debates"
+msgstr ""
+
+#: www/includes/easyparliament/metadata.php:1049
+msgid "Debates in the Senedd"
+msgstr ""
+
 msgid "Find your MS"
 msgstr ""
 
@@ -1035,8 +1045,10 @@ msgstr ""
 msgid "Find out about your Members of the Senedd"
 msgstr ""
 
-#: www/includes/easyparliament/metadata.php:1064
-msgid "Record"
+#: www/includes/easyparliament/metadata.php:1073
+#: www/includes/easyparliament/templates/html/mp/profile.php:20
+#: www/includes/easyparliament/templates/html/mp/recent.php:10
+msgid "Overview"
 msgstr ""
 
 #: www/includes/easyparliament/metadata.php:1065

--- a/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
+++ b/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
@@ -969,7 +969,14 @@ msgstr "Pe baech chi eisoes wedi ymuno, mewngofnodwch  i'ch  cyfrif"
 msgid "List of Members of the Senedd (MSs)"
 msgstr "Rhestr Aelodau o'r Senedd (ASau)"
 
-#: www/includes/easyparliament/metadata.php:1047
+#: www/includes/easyparliament/metadata.php:1048
+msgid "Recent debates"
+msgstr "Dadleuon diweddar Y Senedd"
+
+#: www/includes/easyparliament/metadata.php:1049
+msgid "Recent Senedd debates"
+msgstr "Dadleuon diweddar Y Senedd"
+
 msgid "Find your MS"
 msgstr "Dewch o hyd i'ch Aelod o’r Senedd"
 

--- a/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
+++ b/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
@@ -989,13 +989,15 @@ msgstr "Eich ASau"
 msgid "Find out about your Members of the Senedd"
 msgstr "Dysgwch am eich Aelodau Senedd Cymru"
 
-#: www/includes/easyparliament/metadata.php:1064
-msgid "Record"
-msgstr "Cofnod"
+#: www/includes/easyparliament/metadata.php:1073
+#: www/includes/easyparliament/templates/html/mp/profile.php:20
+#: www/includes/easyparliament/templates/html/mp/recent.php:10
+msgid "Overview"
+msgstr "Trosolwg"
 
 #: www/includes/easyparliament/metadata.php:1065
 msgid "Overview of the Senedd debates"
-msgstr "Trosolwg o ddadleuon  y Senedd"
+msgstr "Trosolwg o ddadleuon y Senedd"
 
 #: www/includes/easyparliament/metadata.php:1205
 #: www/includes/easyparliament/metadata.php:1209

--- a/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
+++ b/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-15 10:28+0000\n"
+"POT-Creation-Date: 2023-06-16 05:24+0000\n"
 "PO-Revision-Date: 2023-03-20 17:59-0000\n"
 "Language-Team: mySociety\n"
 "Language: fr\n"
@@ -152,7 +152,8 @@ msgstr "URI"
 msgid "Making it easy to keep an eye on the UK’s parliaments. Discover who represents you, how they’ve voted and what they’ve said in debates."
 msgstr "Yn gwneud hi'n hawdd cadw llygad barcud ar seneddau'r DU.  Darganfyddwch pwy sy'n eich cynrychioli chi, sut maen nhw wedi pleidleisio a beth maen nhw wedi dweud mewn dadleuon."
 
-#: classes/Renderer/Header.php:254
+#: classes/Renderer/Header.php:254 classes/Renderer/Header.php:271
+#: classes/Renderer/Header.php:293
 msgid "Wales"
 msgstr "Cymru"
 
@@ -466,8 +467,8 @@ msgid "London Mayoral questions"
 msgstr "Cwestiynau Maer Llundain"
 
 #: scripts/alertmailer.php:141 scripts/alertmailer.php:142
-#: www/includes/easyparliament/metadata.php:1089
-#: www/includes/easyparliament/metadata.php:1092
+#: www/includes/easyparliament/metadata.php:1098
+#: www/includes/easyparliament/metadata.php:1101
 msgid "Senedd debates"
 msgstr "Dadleuon y Senedd"
 
@@ -970,22 +971,26 @@ msgid "List of Members of the Senedd (MSs)"
 msgstr "Rhestr Aelodau o'r Senedd (ASau)"
 
 #: www/includes/easyparliament/metadata.php:1048
-msgid "Recent debates"
-msgstr "Dadleuon diweddar Y Senedd"
+#: www/includes/easyparliament/templates/html/search/form_options.php:66
+#: www/includes/easyparliament/templates/html/search/form_options.php:70
+#: www/includes/easyparliament/templates/html/search/form_options.php:74
+msgid "Debates"
+msgstr "Dadleuon"
 
 #: www/includes/easyparliament/metadata.php:1049
-msgid "Recent Senedd debates"
-msgstr "Dadleuon diweddar Y Senedd"
+msgid "Debates in the Senedd"
+msgstr "Ddadleuon y Senedd"
 
+#: www/includes/easyparliament/metadata.php:1056
 msgid "Find your MS"
 msgstr "Dewch o hyd i'ch Aelod o’r Senedd"
 
-#: www/includes/easyparliament/metadata.php:1052
-#: www/includes/easyparliament/metadata.php:1057
+#: www/includes/easyparliament/metadata.php:1061
+#: www/includes/easyparliament/metadata.php:1066
 msgid "Your MSs"
 msgstr "Eich ASau"
 
-#: www/includes/easyparliament/metadata.php:1053
+#: www/includes/easyparliament/metadata.php:1062
 msgid "Find out about your Members of the Senedd"
 msgstr "Dysgwch am eich Aelodau Senedd Cymru"
 
@@ -995,16 +1000,16 @@ msgstr "Dysgwch am eich Aelodau Senedd Cymru"
 msgid "Overview"
 msgstr "Trosolwg"
 
-#: www/includes/easyparliament/metadata.php:1065
+#: www/includes/easyparliament/metadata.php:1074
 msgid "Overview of the Senedd debates"
 msgstr "Trosolwg o ddadleuon y Senedd"
 
-#: www/includes/easyparliament/metadata.php:1205
-#: www/includes/easyparliament/metadata.php:1209
+#: www/includes/easyparliament/metadata.php:1214
+#: www/includes/easyparliament/metadata.php:1218
 msgid "Your MP"
 msgstr "Eich AS"
 
-#: www/includes/easyparliament/metadata.php:1206
+#: www/includes/easyparliament/metadata.php:1215
 msgid "Find out about your Member of Parliament"
 msgstr "Dysgwch am eich Aelod Seneddol"
 
@@ -1055,7 +1060,7 @@ msgstr "Addasu’r chwilio"
 #: www/includes/easyparliament/templates/html/search/form_main.php:5
 #: www/includes/easyparliament/templates/html/search/form_options.php:96
 #: www/includes/easyparliament/templates/html/section/_search.php:10
-#: www/includes/easyparliament/templates/html/senedd/index.php:67
+#: www/includes/easyparliament/templates/html/senedd/index.php:52
 msgid "Search"
 msgstr "Chwilio"
 
@@ -1736,11 +1741,6 @@ msgstr "Derbyn diweddariadau e-bost"
 msgid "That name is not unique. Please select from the following:"
 msgstr " Nid yw'r enw hwnnw'n unigryw.  Dewiswch o'r canlynol:"
 
-#: www/includes/easyparliament/templates/html/mp/profile.php:20
-#: www/includes/easyparliament/templates/html/mp/recent.php:10
-msgid "Overview"
-msgstr "Trosolwg"
-
 #: www/includes/easyparliament/templates/html/mp/profile.php:21
 #: www/includes/easyparliament/templates/html/mp/recent.php:11
 msgid "Voting Record"
@@ -2087,12 +2087,6 @@ msgstr "Pwyllgorau"
 msgid "Future Business"
 msgstr "Busnes y Dyfodol"
 
-#: www/includes/easyparliament/templates/html/search/form_options.php:66
-#: www/includes/easyparliament/templates/html/search/form_options.php:70
-#: www/includes/easyparliament/templates/html/search/form_options.php:74
-msgid "Debates"
-msgstr "Dadleuon"
-
 #: www/includes/easyparliament/templates/html/search/form_options.php:69
 msgid "All Scotland"
 msgstr "Alban i gyd"
@@ -2222,8 +2216,8 @@ msgstr "Tudalen olaf"
 
 #. end of !isset($error)
 #: www/includes/easyparliament/templates/html/search/sidebar.php:3
-#: www/includes/easyparliament/templates/html/senedd/index.php:49
-#: www/includes/easyparliament/templates/html/senedd/index.php:52
+#: www/includes/easyparliament/templates/html/senedd/index.php:77
+#: www/includes/easyparliament/templates/html/senedd/index.php:80
 msgid "Create an alert"
 msgstr "Creu hysbysiad"
 
@@ -2297,12 +2291,12 @@ msgid "Search %s"
 msgstr "Chwilio %s"
 
 #: www/includes/easyparliament/templates/html/section/_search.php:7
-#: www/includes/easyparliament/templates/html/senedd/index.php:64
+#: www/includes/easyparliament/templates/html/senedd/index.php:49
 msgid "Enter a keyword, phrase, or person"
 msgstr "Nodwch allweddair, ymadrodd, neu berson"
 
 #: www/includes/easyparliament/templates/html/section/_search.php:30
-#: www/includes/easyparliament/templates/html/senedd/index.php:74
+#: www/includes/easyparliament/templates/html/senedd/index.php:59
 msgid "Popular searches today"
 msgstr "Chwiliadau poblogaidd heddiw"
 
@@ -2419,7 +2413,7 @@ msgstr ""
 "\n"
 "Senedd Cymru (Saesneg: Welsh Parliament) neu'r Senedd yw'r corff datganoledig sy'n cael ei ethol yn ddemocrataidd i drafod polisïau ac sy'n cymeradwyo deddfwriaeth sy'n ymwneud â Chymru. Rhan o'i waith yw dwyn Llywodraeth Cymru i gyfrif. Rhwng mis Mai 1999 a mis Mai 2020, enw'r sefydliad oedd Cynulliad Cenedlaethol Cymru (Saesneg: National Assembly for Wales). &ndash; <a href=\"https://cy.wikipedia.org/wiki/Senedd_Cymru\">Wicipedia</a>\n"
 
-#: www/includes/easyparliament/templates/html/section/senedd_index.php:10
+#: www/includes/easyparliament/templates/html/section/senedd_index.php:9
 msgid "Search Senedd debates"
 msgstr "Dadleuon y Senedd"
 
@@ -2465,17 +2459,17 @@ msgstr "Mae TheyWorkForYou yn cymryd data agored o Seneddau'r Deyrnas Unedig, ac
 msgid "About TheyWorkForYou"
 msgstr "Ynglŷn â TheyWorkForYou"
 
-#: www/includes/easyparliament/templates/html/senedd/index.php:50
+#: www/includes/easyparliament/templates/html/senedd/index.php:46
+msgid "Search debates"
+msgstr "Chwilio dadleuon"
+
+#: www/includes/easyparliament/templates/html/senedd/index.php:78
 msgid "Stay informed!"
 msgstr "Byddwch wybodus!"
 
-#: www/includes/easyparliament/templates/html/senedd/index.php:51
+#: www/includes/easyparliament/templates/html/senedd/index.php:79
 msgid "Get an email every time an issue you care about is mentioned in the Senedd (and more)"
 msgstr "Hawliwch e-bost bob tro mae mater yr ydych yn poeni amdano yn cael ei grybwyll yn Y Senedd (a mwy)"
-
-#: www/includes/easyparliament/templates/html/senedd/index.php:61
-msgid "Search debates"
-msgstr "Chwilio dadleuon"
 
 #: www/includes/easyparliament/templates/html/senedd/index.php:87
 msgid "Recently in the Senedd"
@@ -2711,6 +2705,15 @@ msgstr "Ymddiheuriadau, mae gwall wedi digwydd"
 #: www/includes/utility.php:175
 msgid "We've been notified by email and will try to fix the problem soon!"
 msgstr "Rydym wedi derbyn y wybodaeth trwy e-bost, a byddwn yn ceisio datrys y broblem yn fuan!"
+
+#~ msgid "Recent debates"
+#~ msgstr "Dadleuon diweddar Y Senedd"
+
+#~ msgid "Recent Senedd debates"
+#~ msgstr "Dadleuon diweddar Y Senedd"
+
+#~ msgid "Record"
+#~ msgstr "Cofnod"
 
 #~ msgid "What is the Welsh Parliament?"
 #~ msgstr "Beth yw Senedd Cymru?"

--- a/scripts/quick-populate
+++ b/scripts/quick-populate
@@ -16,6 +16,9 @@ echo 'Downloading minimal Senedd'
 rsync -az --progress --exclude '.svn' --exclude 'tmp/' --relative data.theyworkforyou.com::parldata/scrapedxml/senedd/en/senedd2022-01* data/pwdata
 rsync -az --progress --exclude '.svn' --exclude 'tmp/' --relative data.theyworkforyou.com::parldata/scrapedxml/senedd/cy/senedd2022-01* data/pwdata
 
+echo 'Downloading minimal Scottish Parliament'
+rsync -az --progress --exclude '.svn' --exclude 'tmp/' --relative data.theyworkforyou.com::parldata/scrapedxml/sp-new/meeting-of-the-parliament/2022-01* data/pwdata
+
 echo 'Load people into database'
 scripts/load-people
 
@@ -23,7 +26,7 @@ echo 'Load divisions/policies from json'
 scripts/json2db.pl --verbose
 
 echo 'Load Jan 2022 debates and divisions'
-scripts/xml2db.pl --debates --wales --all
+scripts/xml2db.pl --debates --wales --scotland --all
 
 # this only imports public whip, run with different arguments to pull in members expenses
 echo 'Importing MP extra info for voting comparison'

--- a/www/docs/style/sass/pages/_home.scss
+++ b/www/docs/style/sass/pages/_home.scss
@@ -177,6 +177,34 @@ input.homepage-search__button {
     margin-top: emCalc(40);
 }
 
+.parl-top-link{
+    font-weight: 600;
+}
+
+.top-level-parl{
+    list-style-type: none;
+}
+
+
+.homepage-parl-column {
+    @include grid-column(12);
+    padding-top: 0em;
+    padding-bottom: 0em;
+    @media (min-width: $large-screen) {
+        @include grid-column(3);
+        border-right: 1px solid $colour_off_white;
+    }
+}
+
+.homepage-parl-list {
+    padding-top: 2em;
+    padding-bottom: 2em;
+}
+
+.homepage-parl-nav {
+    margin:0px 0px 0px 0px
+}
+
 .homepage-featured-content {
     @include grid-column(12);
     padding-top: 2em;

--- a/www/includes/easyparliament/metadata.php
+++ b/www/includes/easyparliament/metadata.php
@@ -1042,6 +1042,15 @@ $page = array (
         'title' => '',
         'url' => 'mss/'
     ),
+    'wales_debates' => array (
+        'parent' => 'wales_home',
+        'menu' => array (
+            'text' => gettext('Debates'),
+            'title' => gettext("Debates in the Senedd")
+        ),
+        'title' => '',
+        'url' => 'senedd/?more=1'
+    ),
     'ms' => array (
         'parent' => 'mss',
         'title' => gettext('Find your MS'),

--- a/www/includes/easyparliament/metadata.php
+++ b/www/includes/easyparliament/metadata.php
@@ -622,7 +622,7 @@ $page = array (
         ),
         'title'			=> '',
         'rss'			=> 'rss/ni.rss',
-        'url'			=> 'ni/'
+        'url'			=> 'ni/?more=1'
     ),
     'nidebate'  => array (
         'parent'		=> 'nidebatesfront',
@@ -1070,7 +1070,7 @@ $page = array (
     'seneddoverview' => array (
         'parent' => 'wales_home',
         'menu' => array (
-            'text' => gettext('Record'),
+            'text' => gettext('Overview'),
             'title' => gettext("Overview of the Senedd debates")
         ),
         'title' => '',

--- a/www/includes/easyparliament/metadata.php
+++ b/www/includes/easyparliament/metadata.php
@@ -537,7 +537,7 @@ $page = array (
     'peers' => array (
             'menu'			=> array (
             'text'			=> 'Lords',
-            'title'			=> "List of all Lords"
+            'title'			=> "List of Lords"
         ),
         'parent'		=> 'hansard',
         'title'			=> '',
@@ -562,7 +562,7 @@ $page = array (
         'parent'		=> 'ni_home',
         'menu'			=> array (
             'text'			=> 'MLAs',
-            'title'			=> "List of all Members of the Northern Ireland Assembly (MLAs)"
+            'title'			=> "List of Members of the Northern Ireland Assembly (MLAs)"
         ),
         'title'			=> '',
         'url'			=> 'mlas/'
@@ -598,7 +598,7 @@ $page = array (
     'mps' => array (
             'menu'			=> array (
             'text'			=> 'MPs',
-            'title'			=> "List of all Members of Parliament (MPs)"
+            'title'			=> "List of Members of Parliament (MPs)"
         ),
         'parent'		=> 'hansard',
         'title'			=> '',
@@ -618,7 +618,7 @@ $page = array (
         'parent'		=> 'ni_home',
         'menu'			=> array (
             'text'			=> 'Debates',
-            'title'			=> "Overview of the Northern Ireland Assembly debates"
+            'title'			=> "Debates in the Northern Ireland Assembly"
         ),
         'title'			=> '',
         'rss'			=> 'rss/ni.rss',
@@ -879,7 +879,7 @@ $page = array (
     'spdebatesfront' => array (
         'menu'			=> array (
             'text'			=> 'Debates',
-            'title'			=> ''
+            'title'			=> 'Debates in the Scottish Parliament'
         ),
         'parent'		=> 'sp_home',
         'title'			=> 'Scottish Parliament debates',
@@ -902,7 +902,7 @@ $page = array (
     'spwransfront'  => array (
         'menu'			=> array (
             'text'			=> 'Written Answers',
-            'title'			=> ''
+            'title'			=> 'Written Answers and Statements'
         ),
         'parent'		=> 'sp_home',
         'title'			=> 'Scottish Parliament Written answers',

--- a/www/includes/easyparliament/templates/html/homepage/devolved-list.php
+++ b/www/includes/easyparliament/templates/html/homepage/devolved-list.php
@@ -1,0 +1,51 @@
+<?php 
+$nav_items = array (
+    array('hansard', 'alldebatesfront', 'mps', 'peers', 'wranswmsfront'),
+    array('sp_home', 'sp_home', 'spdebatesfront', 'msps',  'spwransfront'),
+    array('wales_home', 'wales_home', 'wales_debates', 'mss', 'welshlanguage'),
+    array('ni_home', 'ni_home', 'nioverview', 'mlas'),
+);
+
+?>  
+    <nav>
+    <ul class="homepage-parl-nav">
+    <div class="row nested-row">
+    <?php
+        foreach ($nav_items as $item_list) {
+        $top_level = $item_list[0];
+        $remaining = array_slice($item_list, 1);
+        $menu_data = $DATA->page_metadata($top_level, 'menu');
+        $URL = new \MySociety\TheyWorkForYou\Url($top_level);
+        $url = $URL->generate();
+    ?>
+    <div class="homepage-parl-column">
+    <li class="top-level-parl">
+        <p class="parl-top-link"><?= $menu_data['text'] ?></p>
+        <?php if (count($remaining)) { ?>
+            <ul>
+                <?php foreach ($remaining as $item) {
+                if ($item == "welshlanguage") {
+                    $menu_data = $DATA->page_metadata('wales_home', 'menu');
+                    $menu_data["title"] = "Welsh language / Cymraeg";
+                    $URL = new \MySociety\TheyWorkForYou\Url('wales_home');
+                    $url = "//cy." . DOMAIN . $URL->generate();
+                } else {
+                    $menu_data = $DATA->page_metadata($item, 'menu');
+                    $URL = new \MySociety\TheyWorkForYou\Url($item);
+                    $url = $URL->generate();
+            }
+                ?>  
+                    <?php if ($item == $top_level) { ?>
+                    <li><a href="<?= $url ?>">Homepage</a></li>
+                    <?php } else { ?>
+                        <li><a href="<?= $url ?>"><?= $menu_data['title'] ?></a></li>
+                    <?php } ?>
+                <?php } ?>
+            </ul>
+        <?php } ?>
+    </li>
+    </div>
+    <?php } ?>
+    </div>
+    </ul>
+</nav>

--- a/www/includes/easyparliament/templates/html/index.php
+++ b/www/includes/easyparliament/templates/html/index.php
@@ -48,22 +48,6 @@
 
 <div class="full-page__row">
     <div class="homepage-panels">
-        <div class="panel panel--flushtop clearfix">
-            <div class="row nested-row">
-                <div class="homepage-featured-content homepage-content-section">
-                    <?php $featured_debate_shown = false; ?>
-                    <?php include 'homepage/featured-content.php'; ?>
-            </div>
-            
-            <div class="homepage-create-alert homepage-content-section">
-                    <h2>Create an alert</h2>
-                    <h3 class="create-alert__heading">Stay informed!</h3>
-                    <p>Get an email every time an issue you care about is mentioned in Parliament (and more)</p>
-                    <a href="<?= $urls['alert'] ?>" class="button create-alert__button button--violet">Create an alert &rarr;</a>
-                </div>
-                </div>
-        </div>
-
 
 
         <div class="panel panel--inverted">
@@ -92,6 +76,31 @@
                     <?php } ?>
                 </div>
             </div>
+        </div>
+
+        <div class="panel panel--flushtop clearfix">
+            <div class="row nested-row">
+            <div class="homepage-content-section homepage-parl-list">
+            <h2>The UK's Parliaments and Assemblies</h2>
+            <?php include 'homepage/devolved-list.php'; ?>    
+            </div>
+            </div>
+        </div>
+
+        <div class="panel panel--flushtop clearfix">
+            <div class="row nested-row">
+                <div class="homepage-featured-content homepage-content-section">
+                    <?php $featured_debate_shown = false; ?>
+                    <?php include 'homepage/featured-content.php'; ?>
+            </div>
+            
+            <div class="homepage-create-alert homepage-content-section">
+                    <h2>Create an alert</h2>
+                    <h3 class="create-alert__heading">Stay informed!</h3>
+                    <p>Get an email every time an issue you care about is mentioned in Parliament (and more)</p>
+                    <a href="<?= $urls['alert'] ?>" class="button create-alert__button button--violet">Create an alert &rarr;</a>
+                </div>
+                </div>
         </div>
 
         <?php if ( $featured_debate_shown == false && count($topics) > 0) { ?>

--- a/www/includes/easyparliament/templates/html/ni/index.php
+++ b/www/includes/easyparliament/templates/html/ni/index.php
@@ -93,15 +93,7 @@
                     <div class="homepage-upcoming homepage-content-section">
                         <h2>What is the Northern Ireland Assembly?</h2>
 
-                        <p>The current <strong>Northern Ireland Assembly</strong> was established in
-                        1998 as part of the Belfast Agreement. It was suspended on the 14th of October
-                        2002, and remained suspended until 8th May 2007.</p>
-
-                        <p>Between 8 May 2006 and 22 November 2006 the <strong>Assembly established
-                        under the Northern Ireland Act 2006</strong>, and between November 2006 and
-                        January 2007 the <strong>Transitional Assembly</strong> created by the Northern
-                        Ireland (St Andrews Agreement) Act 2006, met in order to prepare for the
-                        restoration of devolved government.</p>
+                        <?php include dirname(__FILE__) . '/../section/_ni_desc.php' ?>
                     </div>
                 </div>
             </div>

--- a/www/includes/easyparliament/templates/html/ni/index.php
+++ b/www/includes/easyparliament/templates/html/ni/index.php
@@ -37,22 +37,7 @@
     </div>
     <div class="full-page__row">
         <div class="homepage-panels">
-            <div class="panel panel--flushtop clearfix">
-                <div class="row nested-row">
-                    <div class="homepage-featured-content homepage-content-section">
-                        <?php if ( $featured ) {
-                             include dirname(__FILE__) . "/../homepage/featured.php";
-                        } ?>
-                    </div>
-                    <div class="homepage-create-alert homepage-content-section">
-                        <h2>Create an alert</h2>
-                        <h3 class="create-alert__heading">Stay informed!</h3>
-                        <p>Get an email every time an issue you care about is mentioned in the Northern Ireland Assembly (and more)</p>
-                        <a href="<?= $urls['alert'] ?>" class="button create-alert__button button--violet">Create an alert &rarr;</a>
-                    </div>
-                </div>
-            </div>
-            <div class="panel panel--inverted">
+        <div class="panel panel--inverted">
                 <div class="row nested-row">
                     <div class="home__search">
                         <form action="<?= $urls['search'] ?>" method="GET"onsubmit="trackFormSubmit(this, 'Search', 'Submit', 'Home'); return false;">
@@ -77,6 +62,21 @@
                             <?php } ?>
                         </ul>
                         <?php } ?>
+                    </div>
+                </div>
+            </div>
+            <div class="panel panel--flushtop clearfix">
+                <div class="row nested-row">
+                    <div class="homepage-featured-content homepage-content-section">
+                        <?php if ( $featured ) {
+                             include dirname(__FILE__) . "/../homepage/featured.php";
+                        } ?>
+                    </div>
+                    <div class="homepage-create-alert homepage-content-section">
+                        <h2>Create an alert</h2>
+                        <h3 class="create-alert__heading">Stay informed!</h3>
+                        <p>Get an email every time an issue you care about is mentioned in the Northern Ireland Assembly (and more)</p>
+                        <a href="<?= $urls['alert'] ?>" class="button create-alert__button button--violet">Create an alert &rarr;</a>
                     </div>
                 </div>
             </div>

--- a/www/includes/easyparliament/templates/html/scotland/index.php
+++ b/www/includes/easyparliament/templates/html/scotland/index.php
@@ -54,22 +54,7 @@
     </div>
     <div class="full-page__row">
         <div class="homepage-panels">
-            <div class="panel panel--flushtop clearfix">
-                <div class="row nested-row">
-                    <div class="homepage-featured-content homepage-content-section">
-                        <?php if ( $featured ) {
-                             include dirname(__FILE__) . "/../homepage/featured.php";
-                        } ?>
-                    </div>
-                    <div class="homepage-create-alert homepage-content-section">
-                        <h2>Create an alert</h2>
-                        <h3 class="create-alert__heading">Stay informed!</h3>
-                        <p>Get an email every time an issue you care about is mentioned in the Scottish Parliament (and more)</p>
-                        <a href="<?= $urls['alert'] ?>" class="button create-alert__button button--violet">Create an alert &rarr;</a>
-                    </div>
-                </div>
-            </div>
-            <div class="panel panel--inverted">
+        <div class="panel panel--inverted">
                 <div class="row nested-row">
                     <div class="home__search">
                         <form action="<?= $urls['search'] ?>" method="GET"onsubmit="trackFormSubmit(this, 'Search', 'Submit', 'Home'); return false;">
@@ -94,6 +79,21 @@
                             <?php } ?>
                         </ul>
                         <?php } ?>
+                    </div>
+                </div>
+            </div>
+            <div class="panel panel--flushtop clearfix">
+                <div class="row nested-row">
+                    <div class="homepage-featured-content homepage-content-section">
+                        <?php if ( $featured ) {
+                             include dirname(__FILE__) . "/../homepage/featured.php";
+                        } ?>
+                    </div>
+                    <div class="homepage-create-alert homepage-content-section">
+                        <h2>Create an alert</h2>
+                        <h3 class="create-alert__heading">Stay informed!</h3>
+                        <p>Get an email every time an issue you care about is mentioned in the Scottish Parliament (and more)</p>
+                        <a href="<?= $urls['alert'] ?>" class="button create-alert__button button--violet">Create an alert &rarr;</a>
                     </div>
                 </div>
             </div>

--- a/www/includes/easyparliament/templates/html/section/_ni_desc.php
+++ b/www/includes/easyparliament/templates/html/section/_ni_desc.php
@@ -1,12 +1,11 @@
                 <p>
-                The current Northern Ireland Assembly was established in 1998 as part of the
-                Belfast Agreement. It was suspended on the 14th of October 2002, and remained
-                suspended until 8th May 2007.
+                The current <b>Northern Ireland Assembly</b> was established in 1998 as part of the
+                Belfast Agreement.
                 </p>
 
                 <p>
-                Between 8 May 2006 and 22 November 2006 the Assembly established under the
-                Northern Ireland Act 2006, and between November 2006 and January 2007 the
-                Transitional Assembly created by the Northern Ireland (St Andrews Agreement)
-                Act 2006, met in order to prepare for the restoration of devolved government.
+                As of 2023, the assembly has sitting MLAs,
+                <a href="https://www.theyworkforyou.com/ni/?id=2023-02-14.1.2#g1.25"> has been unable to reach the cross-community agreement required to elect a speaker</a>.
+                
+                As such, there will be no debates in the Assembly until a speaker is elected.
                 </p>

--- a/www/includes/easyparliament/templates/html/section/ni_index.php
+++ b/www/includes/easyparliament/templates/html/section/ni_index.php
@@ -5,7 +5,6 @@
             $urls['day'] = $urls['niday'];
             include '_business_section.php';
         ?>
-    </div>
 
     <?php $search_title = 'Search Northern Ireland Assembly debates'; include '_search.php'; ?>
 

--- a/www/includes/easyparliament/templates/html/section/senedd_index.php
+++ b/www/includes/easyparliament/templates/html/section/senedd_index.php
@@ -5,7 +5,6 @@
             $urls['day'] = $urls['seneddday'];
             include '_business_section.php';
         ?>
-    </div>
 
     <?php $search_title = gettext('Search Senedd debates'); include '_search.php'; ?>
 

--- a/www/includes/easyparliament/templates/html/senedd/index.php
+++ b/www/includes/easyparliament/templates/html/senedd/index.php
@@ -38,21 +38,6 @@
     </div>
     <div class="full-page__row">
         <div class="homepage-panels">
-            <div class="panel panel--flushtop clearfix">
-                <div class="row nested-row">
-                    <div class="homepage-featured-content homepage-content-section">
-                        <?php if ( $featured ) {
-                             include dirname(__FILE__) . "/../homepage/featured.php";
-                        } ?>
-                    </div>
-                    <div class="homepage-create-alert homepage-content-section">
-                        <h2><?= gettext('Create an alert') ?></h2>
-                        <h3 class="create-alert__heading"><?= gettext('Stay informed!') ?></h3>
-                        <p><?= gettext('Get an email every time an issue you care about is mentioned in the Senedd (and more)') ?></p>
-                        <a href="<?= $urls['alert'] ?>" class="button create-alert__button button--violet"><?= gettext('Create an alert') ?> &rarr;</a>
-                    </div>
-                </div>
-            </div>
             <div class="panel panel--inverted">
                 <div class="row nested-row">
                     <div class="home__search">
@@ -78,6 +63,21 @@
                             <?php } ?>
                         </ul>
                         <?php } ?>
+                    </div>
+                </div>
+            </div>
+            <div class="panel panel--flushtop clearfix">
+                <div class="row nested-row">
+                    <div class="homepage-featured-content homepage-content-section">
+                        <?php if ( $featured ) {
+                             include dirname(__FILE__) . "/../homepage/featured.php";
+                        } ?>
+                    </div>
+                    <div class="homepage-create-alert homepage-content-section">
+                        <h2><?= gettext('Create an alert') ?></h2>
+                        <h3 class="create-alert__heading"><?= gettext('Stay informed!') ?></h3>
+                        <p><?= gettext('Get an email every time an issue you care about is mentioned in the Senedd (and more)') ?></p>
+                        <a href="<?= $urls['alert'] ?>" class="button create-alert__button button--violet"><?= gettext('Create an alert') ?> &rarr;</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION

# Adds a multi Parliament menu to home page.

London excluded for moment because it needs some sorting out.

![image](https://github.com/mysociety/theyworkforyou/assets/8157058/ec1ea33f-3ae7-4228-a60c-ec1e71794084)

# Link to recent debates in top bar of Senedd

![image](https://github.com/mysociety/theyworkforyou/assets/8157058/874976c8-7136-4eeb-b808-95d873410766)

# Contextual parliament selection for search and alerts

Because these are general pages, they don't have the devolved parliament in their parent tree.

This adds additional checks to see if the alert is linked to a specific person, or the search is limited to a particular parliament, and changes the top bar:

<img width="782" alt="image" src="https://github.com/mysociety/theyworkforyou/assets/8157058/fb2e7226-9aeb-43f3-bf1b-ab240019912c">

![image](https://github.com/mysociety/theyworkforyou/assets/8157058/5a87f222-ca38-4cfe-9ff0-0d2148c9a082)


