### PR TITLE
Donate and language switch in top bar nav

### DIFF
--- a/classes/Renderer/User.php
+++ b/classes/Renderer/User.php
@@ -27,6 +27,21 @@ class User
 
     private function setupNavLinks() {
         $this->data['user_nav_links'] = array();
+
+        // We may want to send the user back to this current page after they've
+        // joined, logged out or logged in. So we put the URL in $returl.
+        $URL = new \MySociety\TheyWorkForYou\Url($this->page);
+        $this->returl = $URL->generate('none');
+
+        //user logged in
+        if ($this->user->isloggedin()) {
+            $this->addLoggedInLinks();
+        } else {
+            $this->addLoggedOutLinks();
+        }
+    }
+
+    private function AddLangSwitcher(){
         if (preg_match('#^(senedd|wales|ms(?!p))#', $this->page)) {
             $href = $_SERVER['REQUEST_URI'];
             if (LANGUAGE == 'cy') {
@@ -46,18 +61,6 @@ class User
                 'title' => '',
                 'text' => $text,
             );
-        }
-
-        // We may want to send the user back to this current page after they've
-        // joined, logged out or logged in. So we put the URL in $returl.
-        $URL = new \MySociety\TheyWorkForYou\Url($this->page);
-        $this->returl = $URL->generate('none');
-
-        //user logged in
-        if ($this->user->isloggedin()) {
-            $this->addLoggedInLinks();
-        } else {
-            $this->addLoggedOutLinks();
         }
     }
 
@@ -105,6 +108,7 @@ class User
 
         $this->addContactLink();
         $this->addDonateLink();
+        $this->AddLangSwitcher();
     }
 
     private function addLoggedOutLinks() {
@@ -165,6 +169,7 @@ class User
         $this->addRepLinks();
         $this->addContactLink();
         $this->addDonateLink();
+        $this->AddLangSwitcher();
     }
 
     // add links to your MP etc if postcode set

--- a/classes/Renderer/User.php
+++ b/classes/Renderer/User.php
@@ -104,6 +104,7 @@ class User
         );
 
         $this->addContactLink();
+        $this->addDonateLink();
     }
 
     private function addLoggedOutLinks() {
@@ -163,6 +164,7 @@ class User
 
         $this->addRepLinks();
         $this->addContactLink();
+        $this->addDonateLink();
     }
 
     // add links to your MP etc if postcode set
@@ -207,4 +209,22 @@ class User
         );
     }
 
+    private function addDonateLink() {
+        // In the long run, we should have a little page on this site and go through the normal metadata process
+        // for storing the link.
+
+        if (LANGUAGE == 'cy') {
+            $text = 'Cyfrannwch';
+        } else {
+            $text = 'Donate';
+        }
+
+        $this->data['user_nav_links'][] = array(
+            'href'    => "https://www.mysociety.org/donate?utm_source=theyworkforyou.com&utm_content=top-bar&utm_medium=link&utm_campaign=mysoc_header",
+            'title'   => $text,
+            'classes' => '',
+            'text'    => $text
+        );
+    }
+    
 }


### PR DESCRIPTION
This PR:

* Adds a link to the mySociety donate page in the top bar.
* Moved the language selector to the top right (https://github.com/mysociety/theyworkforyou/issues/1727)

Doesn't entirely solve #1727 because of it doesn't change the hamburger approach.

Donate approach is a bit hacky - didn't want to add it to the metadata file because it's not a page. Is weird to have an external link in the normal navigation - but it's how we've got things set up at the moment.