### PR TITLE
Minor changes to division display

### DIFF
--- a/classes/Divisions.php
+++ b/classes/Divisions.php
@@ -621,7 +621,6 @@ class Divisions {
             if ( !array_key_exists($policy_id, $policies) ) {
                 $policies[$policy_id] = array(
                     'policy_id' => $policy_id,
-                    'weak_count' => 0,
                     'divisions' => array()
                 );
                 if ( $this->policies ) {
@@ -633,11 +632,8 @@ class Divisions {
                 }
             }
 
+            
             $division = $this->getDivisionDetails($row);
-
-            if ( !$division['strong'] ) {
-                $policies[$policy_id]['weak_count']++;
-            }
 
             $policies[$policy_id]['divisions'][] = $division;
         };

--- a/classes/Divisions.php
+++ b/classes/Divisions.php
@@ -29,11 +29,11 @@ class Divisions {
      * @param Member   $member   The member to get positions for.
      */
 
-    public function __construct(Member $member = null, PolicyPositions $positions = null, Policies $policies = null)
+    public function __construct(Member $member = null, PolicyPositions $positions = null)
     {
         $this->member = $member;
         $this->positions = $positions;
-        $this->policies = $policies;
+        $this->policies = new Policies;
         $this->db = new \ParlDB;
     }
 
@@ -231,7 +231,7 @@ class Divisions {
             ORDER by policy_id, division_date DESC",
             $args
         );
-
+        # possibly add another query here to get related policies that use the same votes
         return $this->divisionsByPolicy($q);
     }
 
@@ -584,6 +584,29 @@ class Divisions {
 
         # Policy-related information
 
+        # So one option is just to query for it here
+        # we want to add an array of policies aside the current policy
+        # and if they have the same or different direction as thie current division
+        # in the row
+
+        # fetch related policies from database
+        $q = $this->db->query(
+            "SELECT policy_id, direction
+            FROM policydivisions
+            WHERE division_id = :division_id",
+            array(':division_id' => $row['division_id'])
+        );
+        $division['related_policies'] = array();
+
+        $policy_lookup = $this->policies->getPolicies();
+        foreach ($q as $policy) {
+            $division['related_policies'][] = array(
+                'policy_id' => $policy['policy_id'],
+                'policy_title' => $policy_lookup[$policy['policy_id']],
+                'direction' => $policy['direction'],
+            );
+        }
+
         if (array_key_exists('direction', $row)) {
             $division['direction'] = $row['direction'];
             if ( strpos( $row['direction'], 'strong') !== false ) {
@@ -615,18 +638,19 @@ class Divisions {
     private function divisionsByPolicy($q) {
         $policies = array();
 
+        # iterate through each division, and adds it to an array of policies
+        # if there is only one policy being queried, it will be an array of 1
         foreach ($q as $row) {
             $policy_id = $row['policy_id'];
 
+            # if this policy hasn't come up yet, create the key for it
             if ( !array_key_exists($policy_id, $policies) ) {
                 $policies[$policy_id] = array(
                     'policy_id' => $policy_id,
                     'divisions' => array()
                 );
-                if ( $this->policies ) {
-                    $policies[$policy_id]['desc'] = $this->policies->getPolicies()[$policy_id];
-                    $policies[$policy_id]['header'] = $this->policies->getPolicyDetails($policy_id);
-                }
+                $policies[$policy_id]['desc'] = $this->policies->getPolicies()[$policy_id];
+                $policies[$policy_id]['header'] = $this->policies->getPolicyDetails($policy_id);
                 if ( $this->positions ) {
                     $policies[$policy_id]['position'] = $this->positions->positionsById[$policy_id];
                 }

--- a/tests/DivisionsTest.php
+++ b/tests/DivisionsTest.php
@@ -101,15 +101,14 @@ class DivisionsTest extends FetchPageTestCase
 
     public function testStrongIndicators() {
         $page = $this->fetch_division_page();
-        $this->assertContains('<li id="pw-2013-01-01-3-commons" class="policy-vote--minor', $page);
-        $this->assertContains('<li id="pw-2013-01-01-4-commons" class="policy-vote--major', $page);
-        $this->assertContains('<li id="pw-2013-01-01-5-commons" class="policy-vote--major', $page);
-        $this->assertContains('<li id="pw-2013-01-01-6-commons" class="policy-vote--minor', $page);
-    }
-
-    public function testWeakCount() {
-        $page = $this->fetch_division_page();
-        $this->assertContains('including 5 less important votes', $page);
+        preg_match('#Major votes</h3>.*?</ul>#s', $page, $m);
+        $major = $m[0];
+        $this->assertContains('<li id="pw-2013-01-01-4-commons"', $major);
+        $this->assertContains('<li id="pw-2013-01-01-5-commons"', $major);
+        preg_match('#Minor votes</h3>.*?</ul>#s', $page, $m);
+        $minor = $m[0];
+        $this->assertContains('<li id="pw-2013-01-01-3-commons"', $minor);
+        $this->assertContains('<li id="pw-2013-01-01-6-commons"', $minor);
     }
 
     public function testNotEnoughInfoStatement() {
@@ -119,8 +118,8 @@ class DivisionsTest extends FetchPageTestCase
 
     public function testRecentDivisionsForMP() {
         $page = $this->fetch_mp_recent_page();
-        $this->assertContains('<li id="pw-2013-01-01-3-commons" class="policy-vote--major', $page);
-        $this->assertNotContains('<li id="pw-2012-01-01-13-commons" class="policy-vote--major', $page);
+        $this->assertContains('<li id="pw-2013-01-01-3-commons"', $page);
+        $this->assertNotContains('<li id="pw-2012-01-01-13-commons"', $page);
     }
 
     public function testSingleDivision() {

--- a/www/docs/js/main.js
+++ b/www/docs/js/main.js
@@ -308,12 +308,6 @@ $(function(){
     t.parent().next(".nav-menu").toggleClass('closed');
   });
 
-  $('.js-show-all-votes').on('click', function(){
-    $(this).fadeOut();
-    $('.policy-vote--minor').slideDown();
-    $('#policy-votes-type').text('All');
-  });
-
   $('a[href="#past-list-dates"]').on('click', function(e){
     e.preventDefault();
     $(this).trigger('blur');

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -437,7 +437,7 @@ switch ($pagetype) {
             $policiesList = new MySociety\TheyWorkForYou\Policies;
         }
         $positions = new MySociety\TheyWorkForYou\PolicyPositions( $policiesList, $MEMBER );
-        $divisions = new MySociety\TheyWorkForYou\Divisions($MEMBER, $positions, $policiesList);
+        $divisions = new MySociety\TheyWorkForYou\Divisions($MEMBER, $positions);
 
         if ( $policyID ) {
             $data['policydivisions'] = $divisions->getMemberDivisionsForPolicy($policyID);

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -610,26 +610,6 @@
   }
 }
 
-html.js {
-    .policy-vote--minor {
-        display: none;
-    }
-}
-
-.policy-vote--minor {
-    padding-left: 1.5em;
-    line-height: 1.3em !important; // override .vote-descriptions .policy-votes > li
-
-    .policy-vote__text,
-    .policy-vote__date {
-        font-size: 0.9em;
-    }
-
-    .policy-vote__text {
-        color: #666;
-    }
-}
-
 .policy-vote__date {
     display: block;
     color: #b5af9d; // desaturated taupe colour
@@ -709,14 +689,6 @@ html.js {
             margin-bottom: 0;
         }
     }
-
-    .js-show-all-votes {
-        display: none;
-    }
-}
-
-html.js .policy-votes-list-footer .js-show-all-votes {
-    display: block;
 }
 
 .voting-information-provenance {

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -507,6 +507,10 @@
     line-height: 1.2em;
 }
 
+.policy-vote__related-policies-title {
+    margin-top: 1em;
+}
+
 .policy-votes-hero {
     position: relative;
     margin-bottom: 0;

--- a/www/includes/easyparliament/templates/html/mp/_division_description.php
+++ b/www/includes/easyparliament/templates/html/mp/_division_description.php
@@ -1,4 +1,4 @@
-<li id="<?= $division['division_id'] ?>" class="<?= $show_all || $division['strong'] ? 'policy-vote--major' : 'policy-vote--minor' ?>">
+<li id="<?= $division['division_id'] ?>">
     <span class="policy-vote__date">On <?= strftime('%e %b %Y', strtotime($division['date'])) ?>:</span>
     <span class="policy-vote__text"><?= $full_name ?><?= $division['text'] ?></span>
     <?php if ($division['date'] > '2020-06-01' && $division['date'] < '2020-06-10' && $division['vote'] == 'absent') { ?>

--- a/www/includes/easyparliament/templates/html/mp/_division_description.php
+++ b/www/includes/easyparliament/templates/html/mp/_division_description.php
@@ -5,5 +5,64 @@
         <p class="vote-description__covid">This absence may have been affected by <a href="<?= $member_url ?>/votes#covid-19">COVID-19 restrictions</a>.</p> 
     <?php } ?>
     <a class="vote-description__source" href="/divisions/<?= $division['division_id'] ?>/mp/<?= $person_id ?>">Show vote</a>
-</li>
 
+    <?php
+    # remove the current policy from the list of related policies
+    $division['related_policies'] = array_filter($division['related_policies'], function($related_policy) use ($policy) {
+        return $related_policy['policy_id'] != $policy['policy_id'];
+    });
+
+    if (count($division['related_policies']) > 0) {
+        # We want to split the related policies into two groups:
+        # 1. those that are the same direction as the current policy (e.g. the vote is in favour of both policies)
+        # 2. those that are the opposite direction to the current policy (e.g. the vote is read positive in one police, and negative in another)
+        $same_direction = array();
+        $other_direction = array();
+        foreach ($division['related_policies'] as $related_policy) {
+            $current_policy_direction_for_vote = $division["direction"];
+            $related_policy_direction_for_vote = $related_policy["direction"];
+            # remove " (strong)" from the end of the direction if it's present
+            $current_policy_direction_for_vote = preg_replace("/ \(strong\)$/", "", $current_policy_direction_for_vote);
+            $related_policy_direction_for_vote = preg_replace("/ \(strong\)$/", "", $related_policy_direction_for_vote);
+            $is_same_direction = $current_policy_direction_for_vote == $related_policy_direction_for_vote;
+            # if related direction is 'abstention' then it's the same direction
+            if ($related_policy_direction_for_vote == "abstention") {
+                $is_same_direction = true;
+            }
+            if ($is_same_direction) {
+                $same_direction[] = $related_policy;
+            } else {
+                $other_direction[] = $related_policy;
+            }
+        }
+
+        # get an array of the two sets so we can loop through them both in the same code
+        $related_policies = [
+            [
+                "set" => $same_direction,
+                "title" => "This vote is also related to:",
+                "class" => "policy-vote__related-policies",
+            ],
+            [
+                "set" => $other_direction,
+                "title" => "This policy conflicts with:",
+                "class" => "policy-vote__opposing-policies",
+            ],
+        ];
+
+        foreach ($related_policies as $related_policy_batch) { ?>
+            <?php if (count($related_policy_batch["set"]) > 0) { ?>
+                <p class="policy-vote__related-policies-title"><?= $related_policy_batch["title"] ?></p>
+                <ul class="<?= $related_policy_batch["class"] ?>">
+                    <?php foreach ($related_policy_batch["set"] as $related_policy) { ?>
+                        <li>
+                            <a href="<?= $member_url ?>/divisions?policy=<?= $related_policy['policy_id'] ?>">
+                                <?= $related_policy['policy_title'] ?>
+                            </a>
+                        </li>
+                    <?php } ?>
+                </ul>
+            <?php } ?>
+        <?php } ?>
+    <?php } ?>
+</li>

--- a/www/includes/easyparliament/templates/html/mp/divisions.php
+++ b/www/includes/easyparliament/templates/html/mp/divisions.php
@@ -23,6 +23,8 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                     <?php } ?>
                     <h3 class="browse-content"><?= gettext('Browse content') ?></h3>
                     <ul>
+                        <li><a href="#scoring">Major votes</a></li>
+                        <li><a href="#informative">Minor votes</a></li>
                         <li><a href="<?= $member_url ?>/votes">Back to all topics</a></li>
                     </ul>
                     <?php include '_featured_content.php'; ?>
@@ -39,19 +41,31 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                 <?php endif; ?>
 
                 <?php $displayed_votes = false; ?>
-                <?php if ( isset($policydivisions) && $policydivisions ) { ?>
 
-                    <?php if ($has_voting_record) { ?>
+                <?php
+                    # $policydivisions contains all the relevant divisions for this MP
+                    # $has_voting_record is true if the MP has voted on any policy
+                    if (isset($policydivisions) && $policydivisions && $has_voting_record) {
+                        # for some historical reason, the divisions page actually
+                        # does all divisions, but generally this is an array of one
+                        # (the current policy)
+                        foreach ($policydivisions as $policy) { ?>
 
-                        <?php foreach ($policydivisions as $policy) { ?>
                             <?php
-                                $show_all = false;
-                                if ( $policy['weak_count'] == 0 || $policy['weak_count'] == count($policy['divisions']) ) {
-                                    $show_all = true;
+                                $divisions_scoring = [];
+                                $divisions_informative = [];
+                                foreach ($policy['divisions'] as $division) {
+                                    if ($division['strong']) {
+                                        $divisions_scoring[] = $division;
+                                    } else {
+                                        $divisions_informative[] = $division;
+                                    }
                                 }
                             ?>
 
-                            <?php if ( isset($policy['header']) ) { ?>
+                            <?php
+                                # a header dict is used to give human information about the specific policy
+                                if ( isset($policy['header']) ) { ?>
                                 <div class="panel policy-votes-hero" style="background-image: url('<?php echo $policy['header']['image']; ?>');">
                                     <h2><?php echo $policy['header']['title']; ?></h2>
                                     <p><?php echo $policy['header']['description']; ?>.</p>
@@ -69,8 +83,9 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                                 </div>
                             <?php } ?>
 
-
-                            <?php if ( isset($policy['position']) ) { ?>
+                            <?php
+                                # display the calculated position for the policy on this page
+                                if ( isset($policy['position']) ) { ?>
                                 <div class="panel">
                                     <?php if ( $policy['position']['has_strong'] ) { ?>
                                         <h3 class="policy-vote-overall-stance">
@@ -84,9 +99,6 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                                             data on PublicWhip.org.uk</a>.
                                         </p>
 
-                                        <h3 class="policy-votes-list-header"><span id="policy-votes-type"><?=
-                                            $show_all ? 'All' : 'Key';
-                                        ?></span> votes about <?= $policy['desc'] ?>:</h3>
                                     <?php } else { ?>
                                         <h3 class="policy-vote-overall-stance">
                                             We don&rsquo;t have enough information to calculate <?= $full_name ?>&rsquo;s position on this issue
@@ -97,17 +109,28 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                                         </p>
                                     <?php } ?>
 
+                                <?php if ($divisions_scoring) { ?>
+                                    <a name="scoring"></a>
+                                    <h3 class="policy-votes-list-header">Major votes</h3>
                                     <ul class="vote-descriptions policy-votes">
-                                    <?php foreach ($policy['divisions'] as $division) {
+                                    <?php foreach ($divisions_scoring as $division) {
                                         include('_division_description.php');
                                         $displayed_votes = true;
                                     } ?>
                                     </ul>
+                                <?php } ?>
+                                <?php if ($divisions_informative) { ?>
+                                    <a name="informative"></a>
+                                    <h3 class="policy-votes-list-header">Minor votes</h3>
+                                    <ul class="vote-descriptions policy-votes">
+                                        <?php foreach ($divisions_informative as $division) {
+                                            include('_division_description.php');
+                                            $displayed_votes = true;
+                                        } ?>
+                                    </ul>
+                                <?php } ?>
 
                                     <div class="policy-votes-list-footer">
-                                      <?php if ( !$show_all && $policy['weak_count'] > 0 ) { ?>
-                                        <p><button class="button secondary-button small js-show-all-votes">Show all votes, including <?= $policy['weak_count'] ?> less important <?= $policy['weak_count'] == 1 ? 'vote' : 'votes' ?></button></p>
-                                      <?php } ?>
                                         <p class="voting-information-provenance">
                                             Vote information from <a href="https://www.publicwhip.org.uk/mp.php?mpid=<?= $member_id ?>&amp;dmp=<?= $policy['policy_id'] ?>">PublicWhip</a>.
                                             Last updated: <?= $policy_last_update[$policy['policy_id']] ?>.
@@ -117,7 +140,6 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
                                 </div>
                             <?php } ?>
-                        <?php } ?>
                     <?php } ?>
 
                 <?php } ?>

--- a/www/includes/easyparliament/templates/html/mp/recent.php
+++ b/www/includes/easyparliament/templates/html/mp/recent.php
@@ -26,7 +26,6 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                 <?php
 
                 $displayed_votes = false;
-                $show_all = true;
                 $current_date = '';
                 $sidebar_links = array();
 


### PR DESCRIPTION
Fixes #1744 and #1745. Differences from the draft branch:
* Changed Divisions class to always have access to full set of Policies (seemed needless to restrict this);
* Got rid of more knock-on unneeded code (anything to do with weak_count or the JS for that button);
* Changed related_policies to be a two-entry array of array rather than separate two-entry arrays;
* reduced number of close/open PHP blocks a bit.
