### PR TITLE
Add TWFY_VOTES_URL to docker config

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -14,6 +14,7 @@ sed -r \
     -e 's!^(.*"OPTION_TWFY_DB_PASS", *)"[^"]*"!'"\\1'password'!" \
     -e 's!^(.*"OPTION_TWFY_DB_NAME", *)"[^"]*"!'"\\1'twfy'!" \
     -e 's!^(.*"OPTION_TWFY_MEMCACHED_HOST", *)"[^"]*"!'"\\1'memcache'!" \
+    -e 's!^(.*"TWFY_VOTES_URL", *)"[^"]*"!'"\\1'$TWFY_VOTES_URL'!" \
     -e 's!^(.*"BASEDIR", *)"[^"]*"!'"\\1'/twfy/www/docs'!" \
     -e 's!^(.*"DOMAIN", *)"[^"]*"!'"\\1'localhost'!" \
     -e 's!^(.*"COOKIEDOMAIN", *)"[^"]*"!'"\\1'localhost'!" \

--- a/conf/general-example
+++ b/conf/general-example
@@ -125,7 +125,7 @@ define ("RECESSFILE","https://www.theyworkforyou.com/pwdata/parl-recesses.txt");
 // AND amend your global php.ini to 'allow_url_fopen = On'
 //define ("RECESSFILE", RAWDATA . "/parl-recesses.txt");
 
-define('TWFY_VOTES_URL', '');
+define("TWFY_VOTES_URL", "");
 
 
 // *******************************************************************************

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       TWFY_TEST_DB_NAME: twfy
       TWFY_TEST_DB_USER: twfy
       TWFY_TEST_DB_PASS: password
+      TWFY_VOTES_URL: ${TWFY_VOTES_URL}
       DEV_MODE: 'true'
       WSL_IP:
     ports:


### PR DESCRIPTION
Some of the prepopulate scripts depend on having the variable set, but at the moment we're not storing it in the config because it's not the final URL.

This passes through a variable from codespaces secrets to the docker container, and to the php config, which lets the prebuild process gather all the data needed.

(In principle the url will then be available through the prebuild - but as it's not secret secret this is fine)