### PR TITLE
Improved division linking

### DIFF
--- a/classes/Renderer/Header.php
+++ b/classes/Renderer/Header.php
@@ -314,10 +314,10 @@ class Header
         // we're within that section.
         $nav_items = array (
             array('home'),
-            array('hansard', 'mps', 'peers', 'alldebatesfront', 'wranswmsfront', 'pbc_front', 'divisions_recent', 'calendar_summary'),
-            array('sp_home', 'spoverview', 'msps', 'spdebatesfront', 'spwransfront'),
+            array('hansard', 'mps', 'peers', 'alldebatesfront', 'wranswmsfront', 'pbc_front', 'divisions_recent_commons', 'divisions_recent_lords',  'calendar_summary'),
+            array('sp_home', 'spoverview', 'msps', 'spdebatesfront', 'spwransfront', 'divisions_recent_sp'),
             array('ni_home', 'nioverview', 'mlas'),
-            array('wales_home', 'seneddoverview', 'mss', 'wales_debates'),
+            array('wales_home', 'seneddoverview', 'mss', 'wales_debates', 'divisions_recent_wales'),
             array('london_home', 'lmqsfront', 'london-assembly-members'),
         );
 

--- a/locale/TheyWorkForYou.pot
+++ b/locale/TheyWorkForYou.pot
@@ -1628,6 +1628,26 @@ msgid "What is this?"
 msgstr ""
 
 #: www/includes/easyparliament/templates/html/divisions/index.php:47
+msgid "This list contains votes from the House of Commons."
+msgstr ""
+
+#: www/includes/easyparliament/templates/html/divisions/index.php:49
+msgid "This list contains votes from the House of Lords."
+msgstr ""
+
+#: www/includes/easyparliament/templates/html/divisions/index.php:51
+msgid "This list contains votes from Public Bill Committees."
+msgstr ""
+
+#: www/includes/easyparliament/templates/html/divisions/index.php:53
+msgid "This list contains votes from the Scottish Parliament."
+msgstr ""
+
+#: www/includes/easyparliament/templates/html/divisions/index.php:55
+msgid "This list contains votes from the Senedd."
+msgstr ""
+
+#: www/includes/easyparliament/templates/html/divisions/index.php:57
 msgid ""
 "This list contains votes from the House of Commons, House of Lords, Public "
 "Bill Committees, Senedd, and the Scottish Parliament."

--- a/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
+++ b/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
@@ -1547,6 +1547,26 @@ msgid "What is this?"
 msgstr "Beth yw hwn?"
 
 #: www/includes/easyparliament/templates/html/divisions/index.php:47
+msgid "This list contains votes from the House of Commons."
+msgstr "Mae'r rhestr hon yn cynnwys pleidleisiau o Tŷ'r Arglwyddi"
+
+#: www/includes/easyparliament/templates/html/divisions/index.php:49
+msgid "This list contains votes from the House of Lords."
+msgstr "Mae'r rhestr hon yn cynnwys pleidleisiau o Pwyllgorau Cyhoeddus"
+
+#: www/includes/easyparliament/templates/html/divisions/index.php:51
+msgid "This list contains votes from Public Bill Committees."
+msgstr "Mae'r rhestr hon yn cynnwys pleidleisiau o Pwyllgorau Cyhoeddus"
+
+#: www/includes/easyparliament/templates/html/divisions/index.php:53
+msgid "This list contains votes from the Scottish Parliament."
+msgstr "Mae'r rhestr hon yn cynnwys pleidleisiau o'r Senedd Cymru"
+
+#: www/includes/easyparliament/templates/html/divisions/index.php:55
+msgid "This list contains votes from the Senedd."
+msgstr "Mae'r rhestr hon yn cynnwys pleidleisiau o'r Senedd yr Alban"
+
+#: www/includes/easyparliament/templates/html/divisions/index.php:57
 msgid "This list contains votes from the House of Commons, House of Lords, Public Bill Committees, Senedd, and the Scottish Parliament."
 msgstr "Mae'r rhestr hon yn cynnwys pleidleisiau o Dŷ'r Cyffredin, Tŷ'r Arglwyddi, Pwyllgorau Cyhoeddus, Seneddau Cymru a’r Alban."
 

--- a/www/docs/divisions/index.php
+++ b/www/docs/divisions/index.php
@@ -3,7 +3,6 @@
 include_once '../../includes/easyparliament/init.php';
 include_once INCLUDESPATH . 'easyparliament/member.php';
 
-$this_page = 'divisions_recent';
 
 $MEMBER = null;
 if ($THEUSER->postcode_is_set()) {
@@ -11,6 +10,20 @@ if ($THEUSER->postcode_is_set()) {
 }
 
 $houses = get_http_var('house', '', true);
+
+// Set to a special version of the page name to get right parliament menus
+if ($houses == 'scotland') {
+    $this_page = 'divisions_recent_sp';
+} elseif ($houses == 'senedd') {
+    $this_page = "divisions_recent_wales";
+} elseif ($houses == 'commons') {
+    $this_page = 'divisions_recent_commons';
+} elseif ($houses == 'lords') {
+    $this_page = 'divisions_recent_lords';
+} else {
+    $this_page = 'divisions_recent';
+}
+
 $divisions = new MySociety\TheyWorkForYou\Divisions($MEMBER);
 $data = $divisions->getRecentDivisions(30, $houses);
 

--- a/www/docs/divisions/index.php
+++ b/www/docs/divisions/index.php
@@ -32,6 +32,7 @@ if (isset($MEMBER)) {
 }
 
 $data['last_updated'] = MySociety\TheyWorkForYou\Divisions::getMostRecentDivisionDate()['latest'];
+$data["houses"] = $houses;
 
 $template = 'divisions/index';
 MySociety\TheyWorkForYou\Renderer::output($template, $data);

--- a/www/includes/easyparliament/metadata.php
+++ b/www/includes/easyparliament/metadata.php
@@ -386,6 +386,42 @@ $page = array (
         'title'			=> 'Recent Votes',
         'url'			=> 'divisions/'
     ),
+    'divisions_recent_commons' => array (
+        'menu'			=> array (
+            'text'			=> 'Recent Votes (Commons)',
+            'title'			=> 'Recent Votes (Commons)'
+        ),
+        'parent'		=> 'hansard',
+        'title'			=> 'Recent Votes',
+        'url'			=> 'divisions/?house=commons'
+    ),
+    'divisions_recent_lords' => array (
+        'menu'			=> array (
+            'text'			=> 'Recent Votes (Lords)',
+            'title'			=> 'Recent Votes (Lords)'
+        ),
+        'parent'		=> 'hansard',
+        'title'			=> 'Recent Votes',
+        'url'			=> 'divisions/?house=lords'
+    ),
+    'divisions_recent_wales' => array (
+        'menu'			=> array (
+            'text'			=> gettext('Recent Votes'),
+            'title'			=> gettext('Recent Votes')
+        ),
+        'parent'		=> 'wales_home',
+        'title'			=> gettext('Recent Votes'),
+        'url'			=> 'divisions/?house=senedd'
+    ),
+    'divisions_recent_sp' => array (
+        'menu'			=> array (
+            'text'			=> 'Recent Votes',
+            'title'			=> 'Recent Votes'
+        ),
+        'parent'		=> 'sp_home',
+        'title'			=> 'Recent Votes',
+        'url'			=> 'divisions/?house=scotland'
+    ),
     'divisions_vote' => array (
         'parent'		=> 'divisions_recent',
         'title'			=> 'Vote',

--- a/www/includes/easyparliament/templates/html/divisions/index.php
+++ b/www/includes/easyparliament/templates/html/divisions/index.php
@@ -43,8 +43,19 @@
             <div class="business-section__secondary">
                 <div class="business-section__secondary__item">
                     <h3><?= gettext('What is this?') ?></h3>
-
+                    <?php if ($houses == 'commons') { ?>
+                    <p><?= gettext('This list contains votes from the House of Commons.') ?></p>
+                    <?php } elseif ($houses == 'lords') { ?>
+                    <p><?= gettext('This list contains votes from the House of Lords.') ?></p>
+                    <?php } elseif ($houses == 'pbc') { ?>
+                    <p><?= gettext('This list contains votes from Public Bill Committees.') ?></p>
+                    <?php } elseif ($houses == 'scotland') { ?>
+                    <p><?= gettext('This list contains votes from the Scottish Parliament.') ?></p>
+                    <?php } elseif ($houses == 'senedd') { ?>
+                    <p><?= gettext('This list contains votes from the Senedd.') ?></p>
+                    <?php } else { ?>
                     <p><?= gettext('This list contains votes from the House of Commons, House of Lords, Public Bill Committees, Senedd, and the Scottish Parliament.') ?></p>
+                    <?php } ?>
 
                     <p><?= gettext('Only show votes from:') ?></p>
                     <ul>

--- a/www/includes/easyparliament/templates/html/homepage/devolved-list.php
+++ b/www/includes/easyparliament/templates/html/homepage/devolved-list.php
@@ -1,8 +1,8 @@
 <?php 
 $nav_items = array (
-    array('hansard', 'alldebatesfront', 'mps', 'peers', 'wranswmsfront'),
-    array('sp_home', 'sp_home', 'spdebatesfront', 'msps',  'spwransfront'),
-    array('wales_home', 'wales_home', 'wales_debates', 'mss', 'welshlanguage'),
+    array('hansard', 'alldebatesfront', 'mps', 'peers', 'wranswmsfront', 'divisions_recent_commons', 'divisions_recent_lords'),
+    array('sp_home', 'sp_home', 'spdebatesfront', 'msps',  'spwransfront', 'divisions_recent_sp'),
+    array('wales_home', 'wales_home', 'wales_debates', 'mss', 'welshlanguage', 'divisions_recent_wales'),
     array('ni_home', 'ni_home', 'nioverview', 'mlas'),
 );
 


### PR DESCRIPTION
@dracos made it possible to filter the recent votes screen by chamber.

This PR solidifies this a bit - adding chamber specific links to the menus, and more specific descriptions. to the page

Using multiple at once should still work fine as it as before. 

E.g. the Senedd:
<img width="620" alt="image" src="https://github.com/mysociety/theyworkforyou/assets/8157058/84a34fef-f5ae-406b-a72c-45ed6cbbceaa">
