### PR TITLE
Change Galloway comparison party

### DIFF
--- a/classes/Member.php
+++ b/classes/Member.php
@@ -82,7 +82,7 @@ class Member extends \MEMBER {
 
         // MPs who have switched parties but should be compared against their
         // current party can go here.
-        $use_last_party = array(10172, 14031, 25873);
+        $use_last_party = array(10172, 14031, 25873, 10218);
 
         if (in_array($person_id, $use_last_party)) {
             $direction = "last";


### PR DESCRIPTION
Now elected under another party, use most recent party rather than oldest.

This will compare him to respect (so a small party that doesn't get comparisons) rather than Labour.

In general having a broad rule about the party you're elected under being the primary might be good - but also being able to show all the possible comparisons through twfy-votes gives a better fall back in future.