### PR TITLE
Update summary page

### DIFF
--- a/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
+++ b/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
@@ -1798,9 +1798,7 @@ msgstr "Derbyn diweddariadau e-bost"
 msgid "That name is not unique. Please select from the following:"
 msgstr " Nid yw'r enw hwnnw'n unigryw.  Dewiswch o'r canlynol:"
 
-#: www/includes/easyparliament/templates/html/mp/profile.php:21
-#: www/includes/easyparliament/templates/html/mp/recent.php:11
-msgid "Voting Record"
+msgid "Voting Summary"
 msgstr "Record bleidleisio"
 
 #: www/includes/easyparliament/templates/html/mp/profile.php:33

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -302,6 +302,7 @@ if (file_exists(BASEDIR . '/' . $feedurl)) {
 }
 
 // Prepare data for the template
+$data["pagetype"] = $pagetype;
 $data['full_name'] = $MEMBER->full_name();
 $data['person_id'] = $MEMBER->person_id();
 $data['member_id'] = $MEMBER->member_id();

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -897,13 +897,6 @@ function person_useful_links($member) {
         );
     }
 
-    if ($member->house(HOUSE_TYPE_COMMONS)) {
-        $out[] = array(
-                'href' => 'http://www.edms.org.uk/mps/' . $member->person_id(),
-                'text' => 'Early Day Motions signed by this MP'
-        );
-    }
-
     if (isset($links['journa_list_link'])) {
         $out[] = array(
                 'href' => $links['journa_list_link'],

--- a/www/includes/easyparliament/templates/html/mp/_chamber_info_panel.php
+++ b/www/includes/easyparliament/templates/html/mp/_chamber_info_panel.php
@@ -1,0 +1,23 @@
+<?php if ($this_page == "mp"): ?>
+<div class="panel">
+    <h2>About your Member of Parliament</h2>
+    <p>
+    Your MP (<?= ucfirst($full_name) ?>) represents you, and all of the people who live in <?= $latest_membership['constituency'] ?>,
+        at the UK Parliament in Westminster.
+    </p>
+    <p>
+    MPs split their time between Parliament and their constituency.
+        In Parliament, they debate and vote on new laws, review existing laws, and question the Government.
+        In the constituency, their focus is on supporting local people and championing local issues.
+        They have a small staff team who help with casework, maintain their diaries, and monitor their inbox.
+    </p>
+    <h2>
+    What you can do
+    </h2>
+    <ul class="rep-actions" style="li: > list-style: default">
+        <li>Find out <a href="#profile">more about your MP</a>, including <a href="<?= $member_url ?>/votes">their voting summary</a> and <a href="#appearances">recent speeches</a>.</li>
+        <li><a href="https://www.writetothem.com/">Write to your MP</a>, or find out about your other local representatives <a href="https://www.writetothem.com">on WriteToThem.com</a>.</li>
+        <li>Find out more about <a href="https://www.localintelligencehub.com/area/WMC/<?= $latest_membership['constituency'] ?>"><?= $latest_membership['constituency'] ?></a> on the <a href="https://www.localintelligencehub.com/">Local Intelligence Hub</a>.</li>
+    </ul>
+</div>
+<?php endif; ?>

--- a/www/includes/easyparliament/templates/html/mp/_person_navigation.php
+++ b/www/includes/easyparliament/templates/html/mp/_person_navigation.php
@@ -1,0 +1,11 @@
+<div class="person-navigation">
+    <ul>
+        <li <?php if ($pagetype == ""): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>"><?= gettext('Overview') ?></a></li>
+          <?php if ($this_page == "mp"): ?>
+            <li <?php if ($pagetype == "votes"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/votes"><?= gettext('Voting Summary') ?></a></li>
+          <?php endif; ?>
+          <?php if (in_array($this_page, ["mp", "msp", "ms"])): ?>
+          <li <?php if ($pagetype == "recent"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/recent"><?= gettext('Recent Votes') ?></a></li>
+          <?php endif; ?>
+          </ul>
+</div>

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -10,13 +10,7 @@ $display_wtt_stats_banner = '2015';
 <div class="full-page">
     <div class="full-page__row">
         <div class="full-page__unit">
-            <div class="person-navigation">
-                <ul>
-                    <li class="active"><a href="<?= $member_url ?>"><?= gettext('Overview') ?></a></li>
-                    <li><a href="<?= $member_url ?>/votes"><?= gettext('Voting Record') ?></a></li>
-                    <li><a href="<?= $member_url ?>/recent"><?= gettext('Recent Votes') ?></a></li>
-                </ul>
-            </div>
+            <?php include '_person_navigation.php'; ?>
         </div>
         <div class="person-panels">
             <div class="sidebar__unit in-page-nav">

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -23,10 +23,10 @@ $display_wtt_stats_banner = '2015';
                 <div>
                     <h3 class="browse-content"><?= gettext('Browse content') ?></h3>
                     <ul>
+                        <li><a href="#profile"><?= gettext('Profile') ?></a></li>
                         <?php if (count($recent_appearances['appearances'])): ?>
                           <li><a href="#appearances"><?= gettext('Appearances') ?></a></li>
                         <?php endif; ?>
-                          <li><a href="#profile"><?= gettext('Profile') ?></a></li>
                         <?php if ($register_interests): ?>
                           <li><a href="#register"><?= gettext('Register of Interests') ?></a></li>
                         <?php endif; ?>
@@ -60,40 +60,7 @@ $display_wtt_stats_banner = '2015';
                 </div>
               <?php endif; ?>
 
-                <?php if (count($recent_appearances['appearances'])): ?>
-                <div class="panel">
-                    <a name="appearances"></a>
-                    <h2><?=gettext('Recent appearances') ?></h2>
-
-                    <?php if (count($recent_appearances['appearances']) > 0): ?>
-
-                        <ul class="appearances">
-
-                        <?php foreach ($recent_appearances['appearances'] as $recent_appearance): ?>
-
-                            <li>
-                                <h4><a href="<?= $recent_appearance['listurl'] ?>"><?= $recent_appearance['parent']['body'] ?></a> <span class="date"><?= date('j M Y', strtotime($recent_appearance['hdate'])) ?></span></h4>
-                                <blockquote><?= $recent_appearance['extract'] ?></blockquote>
-                            </li>
-
-                        <?php endforeach; ?>
-
-                        </ul>
-
-                        <p><a href="<?= $recent_appearances['more_href'] ?>"><?= $recent_appearances['more_text'] ?></a></p>
-
-                        <?php if (isset($recent_appearances['additional_links'])): ?>
-                        <?= $recent_appearances['additional_links'] ?>
-                        <?php endif; ?>
-
-                    <?php else: ?>
-
-                        <p><?=gettext('No recent appearances to display.') ?></p>
-
-                    <?php endif; ?>
-
-                </div>
-                <?php endif; ?>
+                <?php include "_chamber_info_panel.php"; ?>
 
                 <div class="panel">
                     <a name="profile"></a>
@@ -253,6 +220,42 @@ $display_wtt_stats_banner = '2015';
                     <?php endif; ?>
 
                 </div>
+
+
+                <?php if (count($recent_appearances['appearances'])): ?>
+                <div class="panel">
+                    <a name="appearances"></a>
+                    <h2><?=gettext('Recent appearances') ?></h2>
+
+                    <?php if (count($recent_appearances['appearances']) > 0): ?>
+
+                        <ul class="appearances">
+
+                        <?php foreach ($recent_appearances['appearances'] as $recent_appearance): ?>
+
+                            <li>
+                                <h4><a href="<?= $recent_appearance['listurl'] ?>"><?= $recent_appearance['parent']['body'] ?></a> <span class="date"><?= date('j M Y', strtotime($recent_appearance['hdate'])) ?></span></h4>
+                                <blockquote><?= $recent_appearance['extract'] ?></blockquote>
+                            </li>
+
+                        <?php endforeach; ?>
+
+                        </ul>
+
+                        <p><a href="<?= $recent_appearances['more_href'] ?>"><?= $recent_appearances['more_text'] ?></a></p>
+
+                        <?php if (isset($recent_appearances['additional_links'])): ?>
+                        <?= $recent_appearances['additional_links'] ?>
+                        <?php endif; ?>
+
+                    <?php else: ?>
+
+                        <p><?=gettext('No recent appearances to display.') ?></p>
+
+                    <?php endif; ?>
+
+                </div>
+                <?php endif; ?>
 
                 <?php if ($register_interests): ?>
                 <div class="panel register">

--- a/www/includes/easyparliament/templates/html/mp/recent.php
+++ b/www/includes/easyparliament/templates/html/mp/recent.php
@@ -5,13 +5,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 <div class="full-page">
     <div class="full-page__row">
         <div class="full-page__unit">
-            <div class="person-navigation">
-                <ul>
-                    <li><a href="<?= $member_url ?>"><?= gettext('Overview') ?></a></li>
-                    <li><a href="<?= $member_url ?>/votes"><?= gettext('Voting Record') ?></a></li>
-                    <li class="active"><a href="<?= $member_url ?>/recent"><?= gettext('Recent Votes') ?></a></li>
-                </ul>
-            </div>
+            <?php include '_person_navigation.php'; ?>
         </div>
         <div class="person-panels">
             <div class="primary-content__unit">

--- a/www/includes/easyparliament/templates/html/mp/recent.php
+++ b/www/includes/easyparliament/templates/html/mp/recent.php
@@ -30,7 +30,6 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                 $sidebar_links = array();
 
                 if ( isset($divisions) && $divisions ) {
-                    if ($has_voting_record) {
                         foreach ($divisions as $division) {
                           $displayed_votes = true;
 
@@ -48,7 +47,6 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                           include('_division_description.php');
                         }
                         echo('</div>');
-                    }
                 } ?>
 
                 <?php if (!$displayed_votes) { ?>

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -9,13 +9,7 @@ $covid_policy_list = $policies_obj->getCovidAffected();
 <div class="full-page">
     <div class="full-page__row">
         <div class="full-page__unit">
-            <div class="person-navigation">
-                <ul>
-                    <li><a href="<?= $member_url ?>">Overview</a></li>
-                    <li class="active"><a href="<?= $member_url ?>/votes">Voting Record</a></li>
-                    <li><a href="<?= $member_url ?>/recent">Recent Votes</a></li>
-                </ul>
-            </div>
+            <?php include '_person_navigation.php'; ?>
         </div>
         <div class="person-panels">
             <div class="sidebar__unit in-page-nav">


### PR DESCRIPTION
As we've now moved the voting summary out of the main page, we want something to take its place when people get to the MP page after entering their postcode. 

## Intro to MP

This introduces a basic "intro to your MP" page, that we can expand later - basic links to other mySociety services. 

This also switches around the profile and the recent appearances - ideally we'd be moving the recent appearance into its own tab - so that it's a bit towards for the bottom for the moment is fine.  More aspects of the profile might move into the  'intro' paragraph. 

<img width="548" alt="image" src="https://github.com/mysociety/theyworkforyou/assets/8157058/3acf165a-ace2-48db-bb7b-6dbcd7c5e5de">

## Abstract person navigation

This menu is now shared between the various views - being clearer about the logic of what is and isn't included for different kinds of representative rather than this being implicit in who did or didn't have various options enabled. 

Technically not *needed* for this PR - but is a stepping stone towards moving the register and recent appearances into their own fuller pages. 

<img width="219" alt="image" src="https://github.com/mysociety/theyworkforyou/assets/8157058/16947e3d-c8df-4aad-9cb0-83c83f839669">

This fixes https://github.com/mysociety/theyworkforyou/issues/1771 and also enables the 'recent votes' menu (which worked but wasn't linked) for devolved reps:

<img width="148" alt="image" src="https://github.com/mysociety/theyworkforyou/assets/8157058/99926b62-495b-4719-92ff-4f32db0f70fe">



