### PR TITLE
Revert "Move back to Debian Buster and PHP 7.3"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysocietyorg/debian:buster
+FROM mysocietyorg/debian:bullseye
 
 # Apache.
 RUN apt-get -qq update && apt-get -qq install \
@@ -23,13 +23,6 @@ RUN apt-get -qq update && apt-get -qq install \
       rsync \
     --no-install-recommends && \
     rm -r /var/lib/apt/lists/*
-
-# Xapian things from backports
-RUN apt-get update -qq && \
-      apt-get install -qq -t buster-backports \
-        xapian-tools \
-        libxapian30 && \
-      rm -r /var/lib/apt/lists/*
 
 # `conf/packages` - do last, so changes to runtime dependencies
 # don't invalidate caches for the above.

--- a/www/docs/fcgi/php-basic
+++ b/www/docs/fcgi/php-basic
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-PHP_FCGI_CHILDREN=0 PHPRC=/etc/php/7.3/fcgi exec /usr/bin/php-cgi -d apc.enabled=1 -d apc.stat=0 -d realpath_cache_ttl=86400 -d cgi.check_shebang_line=0 -d extension=xapian.so -d pcre.jit=0
+PHP_FCGI_CHILDREN=0 PHPRC=/etc/php/7.4/fcgi exec /usr/bin/php-cgi -d apc.enabled=1 -d apc.stat=0 -d realpath_cache_ttl=86400 -d cgi.check_shebang_line=0 -d extension=xapian.so -d pcre.jit=0


### PR DESCRIPTION
This reverts commit e47a27dbddc8a2eb5607b235f846c8ccca0534ab.

We're testing the deploy on Bullseye again.