### PR TITLE
Fix loose name appearing on voting records

### DIFF
--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -194,8 +194,10 @@ $covid_policy_list = $policies_obj->getCovidAffected();
                         <p>No votes to display.</p>
 
                     <?php endif; ?>
-
+                    
+                    <?php if ($rebellion_rate) { ?>
                     <p><?= $full_name ?> <?= $rebellion_rate ?></p>
+                    <?php } ?>
 
                 </div>
                 <?php endif; ?>


### PR DESCRIPTION
If rebellion rate isn't loaded you just get this:

<img width="393" alt="image" src="https://github.com/mysociety/theyworkforyou/assets/8157058/caaa837c-98ef-43f0-ab4a-fee103be56fe">
