### PR TITLE
Show party explanation for former MPs

### DIFF
--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -83,12 +83,12 @@ $covid_policy_list = $policies_obj->getCovidAffected();
                 </div>
                 <?php endif; ?>
 
-                <?php if ($current_member[HOUSE_TYPE_COMMONS] && $party_member_count > 1) { ?>
+                <?php if ($party_member_count > 1) { ?>
                 <div class="panel">
                     <a name="votes"></a>
                     <h2><?= $full_name ?>&rsquo;s voting in Parliament</h2>
 
-                    <?php if ($party_switcher == true) { ?>
+                    <?php if ($party_switcher == true or $current_member[HOUSE_TYPE_COMMONS] == false) { ?>
                         <p> 
                         <?= $full_name ?> was previously a <?= $unslugified_comparison_party ?> MP, and on the <b>vast majority</b> of issues <a href="/voting-information/#party-and-individual-responsibility-for-decisions">would have followed instructions from their party</a> and voted the <b>same way</b> as <?= $unslugified_comparison_party ?> MPs.
                         </p>


### PR DESCRIPTION
Our party explanation dialogue works for former MPs, but is turned off: this enables that.

![image](https://github.com/mysociety/theyworkforyou/assets/8157058/dd2dc62c-5830-4c37-922c-f640591c9d41)

Originally this was because the comparison system was *only* for current MPs, but it's been independent of that for a few years. 