### PR TITLE
Separate register page

### DIFF
--- a/conf/httpd.conf
+++ b/conf/httpd.conf
@@ -74,7 +74,7 @@ RewriteRule ^/calendar/([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])$ /calendar/i
 # MP pages
 
 # Canonical, numeric MP profile pages
-RewriteRule ^(/mp/([0-9]+)(?:/.+)?/(divisions|votes|policy_set_svg|policy_set_png|recent))$  /mp/index.php?pid=$2&url=$1&pagetype=$3 [QSA]
+RewriteRule ^(/mp/([0-9]+)(?:/.+)?/([a-z_]+))$  /mp/index.php?pid=$2&url=$1&pagetype=$3 [QSA]
 RewriteRule ^(/mp/([0-9]+)(?:/.*)?)$        /mp/index.php?pid=$2&url=$1&pagetype=profile [QSA]
 
 # Assorted other ways of getting to an MP

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -475,6 +475,10 @@ switch ($pagetype) {
 
         break;
 
+    case 'register':
+        // Send the output for rendering
+        MySociety\TheyWorkForYou\Renderer::output('mp/register', $data);
+
     case 'policy_set_svg':
         policy_image($data, $MEMBER, 'svg');
         break;

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -40,9 +40,14 @@ include_once '../api/api_getGeometry.php';
 include_once '../api/api_getConstituencies.php';
 
 // Ensure that page type is set
+$allowed_page_types = ['divisions', 'votes', 'policy_set_svg', 'policy_set_png', 'recent', 'register'];
+
 if (get_http_var('pagetype')) {
     $pagetype = get_http_var('pagetype');
 } else {
+    $pagetype = 'profile';
+}
+if (!in_array($pagetype, $allowed_page_types)) {
     $pagetype = 'profile';
 }
 if ($pagetype == 'profile') {

--- a/www/includes/easyparliament/templates/html/mp/_chamber_info_panel.php
+++ b/www/includes/easyparliament/templates/html/mp/_chamber_info_panel.php
@@ -47,7 +47,7 @@ if ($standing_down_2024) {
     What you can do
     </h2>
     <ul class="rep-actions">
-        <li>Find out <a href="#profile">more about your MP</a>, including <a href="<?= $member_url ?>/votes">their voting summary</a><?php if ($register_interests) { ?>, <a href="#register">register of interests</a><?php } ?> and <a href="#appearances">recent speeches</a>.</li>
+        <li>Find out <a href="#profile">more about your MP</a>, including <a href="<?= $member_url ?>/votes">their voting summary</a><?php if ($register_interests) { ?>, <a href="<?= $member_url ?>/register">register of interests</a><?php } ?> and <a href="#appearances">recent speeches</a>.</li>
     <?php if ($current_member[1]) { ?>
         <li><a href="https://www.writetothem.com/">Write to your MP</a>, or find out about your other local representatives <a href="https://www.writetothem.com">on WriteToThem.com</a>.</li>
     <?php } ?>

--- a/www/includes/easyparliament/templates/html/mp/_person_navigation.php
+++ b/www/includes/easyparliament/templates/html/mp/_person_navigation.php
@@ -6,6 +6,9 @@
           <?php endif; ?>
           <?php if (in_array($this_page, ["mp", "msp", "ms"])): ?>
           <li <?php if ($pagetype == "recent"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/recent"><?= gettext('Recent Votes') ?></a></li>
+            <?php if ($register_interests): ?>
+                <li <?php if ($pagetype == "register"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/register"><?= gettext('Register of Interests') ?></a></li>
+            <?php endif; ?>
           <?php endif; ?>
           </ul>
 </div>

--- a/www/includes/easyparliament/templates/html/mp/_profile_footer.php
+++ b/www/includes/easyparliament/templates/html/mp/_profile_footer.php
@@ -1,6 +1,8 @@
 <div class="panel panel--secondary">
     <p><?= gettext('Note for journalists and researchers: The data on this page may be used freely, on condition that TheyWorkForYou.com is cited as the source.') ?></p>
 
+    <p><?= gettext('This data was produced by TheyWorkForYou from a variety of sources.') ?></p>
+
     <p><?= gettext('For an explanation of the vote descriptions please see our page about <a href="/voting-information">voting information on TheyWorkForYou</a>.') ?></p>
 
   <?php if(isset($data['photo_attribution_text'])) { ?>
@@ -13,4 +15,16 @@
       <?php } ?>
     </p>
   <?php } ?>
+  <?php if(!$image || !$image['exists']) { ?>
+    <p>
+        We&rsquo;re missing a photo of <?= $full_name ?>.
+        If you have a photo <em>that you can release under
+        a Creative Commons Attribution-ShareAlike license</em>
+        or can locate a <em>copyright free</em> photo,
+        <a href="mailto:<?= str_replace('@', '&#64;', CONTACTEMAIL) ?>">please email it to us</a>.
+        Please do not email us about copyrighted photos
+        elsewhere on the internet; we can&rsquo;t use them.
+    </p>
+    <?php }; ?>
+                  
 </div>

--- a/www/includes/easyparliament/templates/html/mp/divisions.php
+++ b/www/includes/easyparliament/templates/html/mp/divisions.php
@@ -249,7 +249,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                     </div>
 
                 <?php }
-                include('_vote_footer.php'); ?>
+                include('_profile_footer.php'); ?>
 
             </div>
         </div>

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -21,9 +21,6 @@ $display_wtt_stats_banner = '2015';
                         <?php if (count($recent_appearances['appearances'])): ?>
                           <li><a href="#appearances"><?= gettext('Appearances') ?></a></li>
                         <?php endif; ?>
-                        <?php if ($register_interests): ?>
-                          <li><a href="#register"><?= gettext('Register of Interests') ?></a></li>
-                        <?php endif; ?>
                       </ul>
                       <?php include '_featured_content.php'; ?>
                       <?php include '_donation.php'; ?>
@@ -248,28 +245,6 @@ $display_wtt_stats_banner = '2015';
 
                     <?php endif; ?>
 
-                </div>
-                <?php endif; ?>
-
-                <?php if ($register_interests): ?>
-                <div class="panel register">
-                    <a name="register"></a>
-                    <h2>Register of Members&rsquo; Interests</h2>
-                    <p><b>New</b>: <a href="https://www.mysociety.org/2024/01/17/improving-the-register-of-mps-interests/">Download a spreadsheet of all Members Interests.</a></p>
-
-                    <p>
-                        <a href="<?= WEBPATH ?>regmem/?p=<?= $person_id ?>">View the history of this MP&rsquo;s entries in the Register</a>
-                    </p>
-                    <?php if ($register_interests['date']): ?>
-                        <p>Last updated: <?= $register_interests['date'] ?>.</p>
-                    <?php endif; ?>
-
-                    <?= $register_interests['data'] ?>
-
-
-                    <p>
-                         <a class="moreinfo-link" href="https://www.publications.parliament.uk/pa/cm/cmregmem/100927/introduction.htm">More about the register</a>
-                    </p>
                 </div>
                 <?php endif; ?>
 

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -248,35 +248,7 @@ $display_wtt_stats_banner = '2015';
                 </div>
                 <?php endif; ?>
 
-                <div class="panel panel--secondary">
-                    <p><?= gettext('Note for journalists and researchers: The data on this page may be used freely, on condition that TheyWorkForYou.com is cited as the source.') ?></p>
-
-                    <p><?php print gettext('This data was produced by TheyWorkForYou from a variety of sources.') . ' ';
-                        printf(gettext('Voting information from <a href="%s">Public Whip</a>.'), "https://www.publicwhip.org.uk/mp.php?id=uk.org.publicwhip/member/ $member_id&amp;showall=yes"); ?></p>
-
-                  <?php if($image && $image['exists']) {
-                      if(isset($data['photo_attribution_text'])) { ?>
-                    <p>
-                      <?php if(isset($data['photo_attribution_link'])) { ?>
-                        <?= gettext('Profile photo:') ?>
-                        <a href="<?= $data['photo_attribution_link'] ?>"><?= $data['photo_attribution_text'] ?></a>
-                      <?php } else { ?>
-                        <?= gettext('Profile photo:') ?> <?= $data['photo_attribution_text'] ?>
-                      <?php } ?>
-                    </p>
-                  <?php }
-                  } else { ?>
-                    <p>
-                        We&rsquo;re missing a photo of <?= $full_name ?>.
-                        If you have a photo <em>that you can release under
-                        a Creative Commons Attribution-ShareAlike license</em>
-                        or can locate a <em>copyright free</em> photo,
-                        <a href="mailto:<?= str_replace('@', '&#64;', CONTACTEMAIL) ?>">please email it to us</a>.
-                        Please do not email us about copyrighted photos
-                        elsewhere on the internet; we can&rsquo;t use them.
-                    </p>
-                  <?php } ?>
-                </div>
+                <?php include('_profile_footer.php'); ?>
 
             </div>
         </div>

--- a/www/includes/easyparliament/templates/html/mp/recent.php
+++ b/www/includes/easyparliament/templates/html/mp/recent.php
@@ -49,7 +49,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                     </div>
                 <?php }
                 include('_covid19_panel.php');
-                include('_vote_footer.php'); ?>
+                include('_profile_footer.php'); ?>
             </div>
 
             <div class="sidebar__unit in-page-nav">

--- a/www/includes/easyparliament/templates/html/mp/register.php
+++ b/www/includes/easyparliament/templates/html/mp/register.php
@@ -1,0 +1,78 @@
+<?php
+include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
+?>
+
+<div class="full-page">
+    <div class="full-page__row">
+        <div class="full-page__unit">
+            <?php include '_person_navigation.php'; ?>
+        </div>
+        <div class="person-panels">
+            <div class="sidebar__unit in-page-nav">
+                <div>
+                    <h3 class="browse-content"><?= gettext('Browse content') ?></h3>
+                    <ul>
+                      <li><a href="https://www.mysociety.org/2024/01/17/improving-the-register-of-mps-interests/">Download a spreadsheet</a></li>
+                      <?php include '_featured_content.php'; ?>
+                      <?php include '_donation.php'; ?>
+                </div>
+            </div>
+
+            <div class="primary-content__unit">
+
+                <?php if ($register_interests): ?>
+                <div class="panel register">
+                    <a name="register"></a>
+                    <h2>Register of Members&rsquo; Interests</h2>
+                    <p><b>New</b>: <a href="https://www.mysociety.org/2024/01/17/improving-the-register-of-mps-interests/">Download a spreadsheet of all Members Interests.</a></p>
+
+                    <p>
+                        <a href="<?= WEBPATH ?>regmem/?p=<?= $person_id ?>">View the history of this MP&rsquo;s entries in the Register</a>
+                    </p>
+                    <?php if ($register_interests['date']): ?>
+                        <p>Last updated: <?= $register_interests['date'] ?>.</p>
+                    <?php endif; ?>
+
+                    <?= $register_interests['data'] ?>
+
+
+                    <p>
+                         <a class="moreinfo-link" href="https://www.parliament.uk/mps-lords-and-offices/standards-and-financial-interests/parliamentary-commissioner-for-standards/registers-of-interests/register-of-members-financial-interests/">More about the register</a>
+                    </p>
+                </div>
+                <?php endif; ?>
+
+                <div class="panel panel--secondary">
+                    <p><?= gettext('Note for journalists and researchers: The data on this page may be used freely, on condition that TheyWorkForYou.com is cited as the source.') ?></p>
+
+                    <p><?php print gettext('This data was produced by TheyWorkForYou from a variety of sources.') . ' ';
+                        printf(gettext('Voting information from <a href="%s">Public Whip</a>.'), "https://www.publicwhip.org.uk/mp.php?id=uk.org.publicwhip/member/ $member_id&amp;showall=yes"); ?></p>
+
+                  <?php if($image && $image['exists']) {
+                      if(isset($data['photo_attribution_text'])) { ?>
+                    <p>
+                      <?php if(isset($data['photo_attribution_link'])) { ?>
+                        <?= gettext('Profile photo:') ?>
+                        <a href="<?= $data['photo_attribution_link'] ?>"><?= $data['photo_attribution_text'] ?></a>
+                      <?php } else { ?>
+                        <?= gettext('Profile photo:') ?> <?= $data['photo_attribution_text'] ?>
+                      <?php } ?>
+                    </p>
+                  <?php }
+                  } else { ?>
+                    <p>
+                        We&rsquo;re missing a photo of <?= $full_name ?>.
+                        If you have a photo <em>that you can release under
+                        a Creative Commons Attribution-ShareAlike license</em>
+                        or can locate a <em>copyright free</em> photo,
+                        <a href="mailto:<?= str_replace('@', '&#64;', CONTACTEMAIL) ?>">please email it to us</a>.
+                        Please do not email us about copyrighted photos
+                        elsewhere on the internet; we can&rsquo;t use them.
+                    </p>
+                  <?php } ?>
+                </div>
+
+            </div>
+        </div>
+    </div>
+</div>

--- a/www/includes/easyparliament/templates/html/mp/register.php
+++ b/www/includes/easyparliament/templates/html/mp/register.php
@@ -42,35 +42,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                 </div>
                 <?php endif; ?>
 
-                <div class="panel panel--secondary">
-                    <p><?= gettext('Note for journalists and researchers: The data on this page may be used freely, on condition that TheyWorkForYou.com is cited as the source.') ?></p>
-
-                    <p><?php print gettext('This data was produced by TheyWorkForYou from a variety of sources.') . ' ';
-                        printf(gettext('Voting information from <a href="%s">Public Whip</a>.'), "https://www.publicwhip.org.uk/mp.php?id=uk.org.publicwhip/member/ $member_id&amp;showall=yes"); ?></p>
-
-                  <?php if($image && $image['exists']) {
-                      if(isset($data['photo_attribution_text'])) { ?>
-                    <p>
-                      <?php if(isset($data['photo_attribution_link'])) { ?>
-                        <?= gettext('Profile photo:') ?>
-                        <a href="<?= $data['photo_attribution_link'] ?>"><?= $data['photo_attribution_text'] ?></a>
-                      <?php } else { ?>
-                        <?= gettext('Profile photo:') ?> <?= $data['photo_attribution_text'] ?>
-                      <?php } ?>
-                    </p>
-                  <?php }
-                  } else { ?>
-                    <p>
-                        We&rsquo;re missing a photo of <?= $full_name ?>.
-                        If you have a photo <em>that you can release under
-                        a Creative Commons Attribution-ShareAlike license</em>
-                        or can locate a <em>copyright free</em> photo,
-                        <a href="mailto:<?= str_replace('@', '&#64;', CONTACTEMAIL) ?>">please email it to us</a>.
-                        Please do not email us about copyrighted photos
-                        elsewhere on the internet; we can&rsquo;t use them.
-                    </p>
-                  <?php } ?>
-                </div>
+                <?php include('_profile_footer.php'); ?>
 
             </div>
         </div>

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -269,7 +269,7 @@ $covid_policy_list = $policies_obj->getCovidAffected();
                 <?php endif; ?>
                 <?php include('_covid19_panel.php'); ?>
 
-                <?php include('_vote_footer.php'); ?>
+                <?php include('_profile_footer.php'); ?>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Move register of interests to separate sub profile page.

- Clearer top navigation from overview page (We should do the same to debates at some point)
- Track interest in this feature
- More room for text about whofundsthem. 

Room for improving this with new boilerplate text - but this does a few things quickly. 

As we want to do this with recent debates/future features(!?) i've moved the list of allowed sub-profile pages from httpd.conf into the profile php page to have more of the logic in one place. But we add new features rarely enough if the other approach is better for some reason can switch back. 

![image](https://github.com/mysociety/theyworkforyou/assets/8157058/0ab2ce53-8c65-4415-ad45-e3b8f8da330b)

