### PR TITLE
Add force option to mirror action

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -3,6 +3,11 @@ name: Push mirror to git.mysociety.org
 on:
   push:
   workflow_dispatch:
+    inputs:
+      force_push:
+        description: 'Force push branch'
+        type: boolean
+        required: false
 
 jobs:
   sync:
@@ -11,15 +16,28 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: '0'
 
     - name: Push branch to git.mysociety.org
       id: push_to_mirror
-      uses: mysociety/action-git-pusher@v1.1.1
+      if: ${{ github.event.inputs.force_push == 'false' || !github.event.inputs.force_push }}
+      uses: mysociety/action-git-pusher@v1.2.0
       with:
         git_ssh_key: ${{ secrets.PUBLICCVS_GIT_KEY }}
         ssh_known_hosts: ${{ secrets.GIT_KNOWN_HOSTS }}
         tag: ${{ github.ref_name }} 
         remote: 'ssh://gh-public@git.mysociety.org/data/git/public/theyworkforyou.git'
+
+
+    - name: Push branch to git.mysociety.org (force)
+      id: push_to_mirror_force
+      if: ${{ github.event.inputs.force_push == 'true' }}
+      uses: mysociety/action-git-pusher@v1.2.0
+      with:
+        git_ssh_key: ${{ secrets.PUBLICCVS_GIT_KEY }}
+        ssh_known_hosts: ${{ secrets.GIT_KNOWN_HOSTS }}
+        tag: ${{ github.ref_name }} 
+        remote: 'ssh://gh-public@git.mysociety.org/data/git/public/theyworkforyou.git'
+        extra_git_config: --force


### PR DESCRIPTION
A tidy up for my github based workflow. This PR adds a manual option to the mirror action to force push a branch back to git.mysociety.org. The default is still that git.mysociety.org takes priority. 

This works as expected in the twfy-votes repo. 

Reasoning:

Because git.mysociety.org is the primary, if I rewrite the history in a branch, to get that into git.mysociety.org I need to open up a local theyworkforyou, pull from one, and force push to the other. This moves that into a few buttons on github - while not being an automatic process. 