### PR TITLE
Remove some items from top navigation

### DIFF
--- a/classes/Renderer/Header.php
+++ b/classes/Renderer/Header.php
@@ -312,7 +312,7 @@ class Header
         $nav_items = array (
             array('home'),
             array('hansard', 'mps', 'peers', 'alldebatesfront', 'wranswmsfront', 'pbc_front', 'divisions_recent_commons', 'divisions_recent_lords',  'calendar_summary'),
-            array('sp_home', 'spoverview', 'msps', 'spdebatesfront', 'spwransfront', 'divisions_recent_sp'),
+            array('sp_home', 'spoverview', 'msps', 'spdebatesfront', 'divisions_recent_sp'), #'spwransfront'
             array('ni_home', 'nioverview', 'mlas'),
             array('wales_home', 'seneddoverview', 'mss', 'wales_debates', 'divisions_recent_wales'),
             array('london_home', 'lmqsfront', 'london-assembly-members'),
@@ -356,7 +356,7 @@ class Header
                 'text'    => $text
             );
             if ($toppage != "london_home"){
-            array_push($this->data['assembly_nav_links'], $top_link);
+                array_push($this->data['assembly_nav_links'], $top_link);
             }
 
             if ($toppage == $this->nav_highlights['top']) {

--- a/classes/Renderer/Header.php
+++ b/classes/Renderer/Header.php
@@ -355,7 +355,9 @@ class Header
                 'classes' => $class,
                 'text'    => $text
             );
+            if ($toppage != "london_home"){
             array_push($this->data['assembly_nav_links'], $top_link);
+            }
 
             if ($toppage == $this->nav_highlights['top']) {
 


### PR DESCRIPTION
We've currently got a few parts of the site that haven't updated in a long period of time. The London section it out of date for members and questions, and Scottish written questions doesn't work. 

We have plans to fix these in months - but for the moment I want to hide these from the top navigation so if we made more noise about our devolved content, we don't get a "hang on, this bits been broken since 2011". 