### PR TITLE
Homepage class tidy and tweaks

### DIFF
--- a/classes/Divisions.php
+++ b/classes/Divisions.php
@@ -171,6 +171,7 @@ class Divisions {
                 'url' => $url->generate() . $anchor,
                 'title' => "$debate[section_body] : $debate[subsection_body]",
                 'date' => $debate['hdate'],
+                'major' => $debate['major'],
             ];
         }
 

--- a/classes/Homepage/Base.php
+++ b/classes/Homepage/Base.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace MySociety\TheyWorkForYou\Homepage;
+
+abstract class Base {
+    public function display() {
+        global $this_page;
+        $this_page = $this->page;
+
+        $data = [];
+
+        $common = new \MySociety\TheyWorkForYou\Common();
+
+        $data['debates'] = $this->getDebatesData();
+
+        $user = new \MySociety\TheyWorkForYou\User();
+        $data['mp_data'] = $user->getRep($this->cons_type, $this->mp_house);
+
+        $data['regional'] = $this->getRegionalList();
+        $data['popular_searches'] = $common->getPopularSearches();
+        $data['featured'] = $this->getEditorialContent();
+        $data['divisions'] = $this->getRecentDivisions();
+        $data['search_box'] = $this->getSearchBox($data);
+
+        return $data;
+    }
+
+    abstract protected function getSearchBox(array $data): \MySociety\TheyWorkForYou\Search\SearchBox;
+    abstract protected function getEditorialContent();
+
+    protected function getRegionalList() {
+        return null;
+    }
+
+    private function getRecentDivisions() {
+        $divisions = new \MySociety\TheyWorkForYou\Divisions();
+        return $divisions->getRecentDebatesWithDivisions(5, $this->houses);
+    }
+
+    protected function getDebatesData() {
+        $debates = []; // holds the most recent data there is data for, indexed by type
+
+        $recent_content = [];
+
+        foreach ($this->recent_types as $class => $recent) {
+            $class = "\\$class";
+            $instance = new $class();
+            $more_url = new \MySociety\TheyWorkForYou\Url($recent[1]);
+            if ($recent[0] == 'recent_pbc_debates') {
+                $content = [ 'data' => $instance->display($recent[0], ['num' => 5], 'none') ];
+            } else {
+                $content = $instance->display($recent[0], ['days' => 7, 'num' => 1], 'none');
+                if (isset($content['data']) && count($content['data'])) {
+                    $content = $content['data'][0];
+                } else {
+                    $content = [];
+                }
+            }
+            if ($content) {
+                $content['more_url'] = $more_url->generate();
+                $content['desc'] = $recent[2];
+                $recent_content[] = $content;
+            }
+        }
+
+        $debates['recent'] = $recent_content;
+
+        return $debates;
+    }
+}

--- a/classes/Homepage/Base.php
+++ b/classes/Homepage/Base.php
@@ -18,7 +18,7 @@ abstract class Base {
 
         $data['regional'] = $this->getRegionalList();
         $data['popular_searches'] = $common->getPopularSearches();
-        $data['featured'] = $this->getEditorialContent();
+        $data['featured'] = $this->getEditorialContent($data);
         $data['divisions'] = $this->getRecentDivisions();
         $data['search_box'] = $this->getSearchBox($data);
 
@@ -26,7 +26,7 @@ abstract class Base {
     }
 
     abstract protected function getSearchBox(array $data): \MySociety\TheyWorkForYou\Search\SearchBox;
-    abstract protected function getEditorialContent();
+    abstract protected function getEditorialContent(array &$data);
 
     protected function getRegionalList() {
         return null;
@@ -48,6 +48,15 @@ abstract class Base {
             $more_url = new \MySociety\TheyWorkForYou\Url($recent[1]);
             if ($recent[0] == 'recent_pbc_debates') {
                 $content = [ 'data' => $instance->display($recent[0], ['num' => 5], 'none') ];
+            } elseif ($recent[1] == 'senedddebatesfront' || $recent[1] == 'nidebatesfront') {
+                $content = $instance->display($recent[0], ['days' => 30, 'num' => 6], 'none');
+                # XXX Bit hacky, for now
+                foreach ($content['data'] as $d) {
+                    $d['more_url'] = $more_url->generate();
+                    $d['desc'] = '';
+                    $recent_content[] = $d;
+                }
+                $content = [];
             } else {
                 $content = $instance->display($recent[0], ['days' => 7, 'num' => 1], 'none');
                 if (isset($content['data']) && count($content['data'])) {

--- a/classes/Homepage/NI.php
+++ b/classes/Homepage/NI.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace MySociety\TheyWorkForYou\Homepage;
+
+class NI extends Base {
+    protected $mp_house = 3;
+    protected $cons_type = 'NIE';
+    protected $page = 'nioverview';
+    protected $houses = [5];
+    protected $recent_types = [
+        'NILIST' => ['recent_debates', 'nidebatesfront', 'Northern Ireland Assembly debates'],
+    ];
+
+    public function display() {
+        $data = parent::display();
+        $data['popular_searches'] = null;
+        $data['template'] = 'ni/index';
+        return $data;
+    }
+
+    protected function getEditorialContent(&$data) {
+        $featured = [];
+        if (count($data['debates']['recent'])) {
+            $MOREURL = new \MySociety\TheyWorkForYou\Url('nidebatesfront');
+            $MOREURL->insert([ 'more' => 1 ]);
+            $featured = array_shift($data['debates']['recent']);
+            $featured['more_url'] = $MOREURL->generate();
+            $featured['desc'] = 'Northern Ireland Assembly debate';
+            $featured['related'] = [];
+            $featured['featured'] = false;
+        }
+        return $featured;
+    }
+
+    protected function getSearchBox(array $data): \MySociety\TheyWorkForYou\Search\SearchBox {
+
+        global $THEUSER;
+
+        if ($THEUSER->isloggedin() && $THEUSER->postcode() != '' || $THEUSER->postcode_is_set()) {
+            $postcode = $THEUSER->postcode();
+        } else {
+            $postcode = null;
+        }
+
+        $search_box = new \MySociety\TheyWorkForYou\Search\SearchBox();
+        $search_box->homepage_panel_class = "panel--homepage--niassembly";
+        $search_box->homepage_subhead = "Northern Ireland Assembly";
+        $search_box->homepage_desc = "";
+        $search_box->search_section = "ni";
+        $search_box->quick_links = [];
+        if (count($data["regional"])) {
+            $constituency = $data["regional"][0]["constituency"];
+            $search_box->add_quick_link('Find out more about your MLAs for ' . $constituency, '/postcode/?pc=' . $postcode, 'torso');
+        }
+        $search_box->add_quick_link('Create and manage email alerts', '/alert/', 'megaphone');
+        $search_box->add_quick_link(gettext('Subscribe to our newsletter'), '/about/#about-mysociety', 'mail');
+        $search_box->add_quick_link('Donate to support our work', '/support-us/', 'heart');
+        $search_box->add_quick_link('Learn more about TheyWorkForYou', '/about/', 'magnifying-glass');
+        return $search_box;
+    }
+
+    protected function getRegionalList() {
+        global $THEUSER;
+
+        $mreg = [];
+        if ($THEUSER->isloggedin() && $THEUSER->postcode() != '' || $THEUSER->postcode_is_set()) {
+            return \MySociety\TheyWorkForYou\Member::getRegionalList($THEUSER->postcode, 3, 'NIE');
+        }
+
+        return $mreg;
+    }
+}

--- a/classes/Homepage/Scotland.php
+++ b/classes/Homepage/Scotland.php
@@ -34,7 +34,7 @@ class Scotland extends Base {
     protected function getEditorialContent(&$data) {
         $debatelist = new \SPLIST();
         $item = $debatelist->display('recent_debates', ['days' => 7, 'num' => 1], 'none');
-        if (isset($item['data']) && count($item['data'])) {
+        if (count($item['data'])) {
             $item = $item['data'][0];
             $more_url = new \MySociety\TheyWorkForYou\Url('spdebatesfront');
             $item['more_url'] = $more_url->generate();

--- a/classes/Homepage/Scotland.php
+++ b/classes/Homepage/Scotland.php
@@ -47,13 +47,9 @@ class Scotland extends Base {
 
     protected function getRegionalList() {
         global $THEUSER;
-
-        $mreg = [];
-
         if ($THEUSER->isloggedin() && $THEUSER->postcode() != '' || $THEUSER->postcode_is_set()) {
-            return Member::getRegionalList($THEUSER->postcode, 4, 'SPE');
+            return \MySociety\TheyWorkForYou\Member::getRegionalList($THEUSER->postcode, 4, 'SPE');
         }
-
-        return $mreg;
+        return [];
     }
 }

--- a/classes/Homepage/Scotland.php
+++ b/classes/Homepage/Scotland.php
@@ -2,7 +2,7 @@
 
 namespace MySociety\TheyWorkForYou\Homepage;
 
-class Scotland extends UK {
+class Scotland extends Base {
     protected $mp_house = 4;
     protected $cons_type = 'SPC';
     protected $mp_url = 'yourmsp';
@@ -45,20 +45,6 @@ class Scotland extends UK {
         }
         return $item;
     }
-
-    protected function getURLs() {
-        $urls = [];
-
-        $regional = new \MySociety\TheyWorkForYou\Url('msp');
-        $urls['regional'] = $regional->generate();
-
-        return $urls;
-    }
-
-    protected function getCalendarData() {
-        return null;
-    }
-
 
     protected function getRegionalList() {
         global $THEUSER;

--- a/classes/Homepage/Scotland.php
+++ b/classes/Homepage/Scotland.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace MySociety\TheyWorkForYou;
+namespace MySociety\TheyWorkForYou\Homepage;
 
-class SPHomepage extends Homepage {
+class Scotland extends UK {
     protected $mp_house = 4;
     protected $cons_type = 'SPC';
     protected $mp_url = 'yourmsp';
@@ -14,8 +14,8 @@ class SPHomepage extends Homepage {
         'SPWRANSLIST' => ['recent_wrans', 'spwransfront', 'Written answers'],
     ];
 
-    protected function getSearchBox(array $data): Search\SearchBox {
-        $search_box = new Search\SearchBox();
+    protected function getSearchBox(array $data): \MySociety\TheyWorkForYou\Search\SearchBox {
+        $search_box = new \MySociety\TheyWorkForYou\Search\SearchBox();
         $search_box->homepage_panel_class = "panel--homepage--scotland";
         $search_box->homepage_subhead = "Scottish Parliament";
         $search_box->homepage_desc = "";
@@ -35,21 +35,21 @@ class SPHomepage extends Homepage {
     protected function getEditorialContent() {
         $debatelist = new \SPLIST();
         $item = $debatelist->display('recent_debates', ['days' => 7, 'num' => 1], 'none');
-
-        $item = $item['data'][0];
-        $more_url = new Url('spdebatesfront');
-        $item['more_url'] = $more_url->generate();
-        $item['desc'] = 'Scottish Parliament debate';
-        $item['related'] = [];
-        $item['featured'] = false;
-
+        if (isset($item['data']) && count($item['data'])) {
+            $item = $item['data'][0];
+            $more_url = new \MySociety\TheyWorkForYou\Url('spdebatesfront');
+            $item['more_url'] = $more_url->generate();
+            $item['desc'] = 'Scottish Parliament debate';
+            $item['related'] = [];
+            $item['featured'] = false;
+        }
         return $item;
     }
 
     protected function getURLs() {
         $urls = [];
 
-        $regional = new Url('msp');
+        $regional = new \MySociety\TheyWorkForYou\Url('msp');
         $urls['regional'] = $regional->generate();
 
         return $urls;

--- a/classes/Homepage/Scotland.php
+++ b/classes/Homepage/Scotland.php
@@ -5,7 +5,6 @@ namespace MySociety\TheyWorkForYou\Homepage;
 class Scotland extends Base {
     protected $mp_house = 4;
     protected $cons_type = 'SPC';
-    protected $mp_url = 'yourmsp';
     protected $page = 'spoverview';
     protected $houses = [7];
 
@@ -32,7 +31,7 @@ class Scotland extends Base {
         return $search_box;
     }
 
-    protected function getEditorialContent() {
+    protected function getEditorialContent(&$data) {
         $debatelist = new \SPLIST();
         $item = $debatelist->display('recent_debates', ['days' => 7, 'num' => 1], 'none');
         if (isset($item['data']) && count($item['data'])) {

--- a/classes/Homepage/UK.php
+++ b/classes/Homepage/UK.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace MySociety\TheyWorkForYou;
+namespace MySociety\TheyWorkForYou\Homepage;
 
-class Homepage {
+class UK {
     private $db;
 
     protected $mp_house = 1;
@@ -30,12 +30,12 @@ class Homepage {
 
         $data = [];
 
-        $common = new Common();
+        $common = new \MySociety\TheyWorkForYou\Common();
         $dissolution = Dissolution::dates();
 
         $data['debates'] = $this->getDebatesData();
 
-        $user = new User();
+        $user = new \MySociety\TheyWorkForYou\User();
         $data['mp_data'] = $user->getRep($this->cons_type, $this->mp_house);
         $data["commons_dissolved"] = isset($dissolution[1]);
 
@@ -51,8 +51,8 @@ class Homepage {
         return $data;
     }
 
-    protected function getSearchBox(array $data): Search\SearchBox {
-        $search_box = new Search\SearchBox();
+    protected function getSearchBox(array $data): \MySociety\TheyWorkForYou\Search\SearchBox {
+        $search_box = new \MySociety\TheyWorkForYou\Search\SearchBox();
         $search_box->homepage_panel_class = "panel--homepage--overall";
         $search_box->homepage_subhead = "";
         $search_box->homepage_desc = "Understand who represents you, across the UK’s Parliaments.";
@@ -74,9 +74,9 @@ class Homepage {
 
     protected function getEditorialContent() {
         $debatelist = new \DEBATELIST();
-        $featured = new Model\Featured();
+        $featured = new \MySociety\TheyWorkForYou\Model\Featured();
         $gid = $featured->get_gid();
-        $gidCheck = new Gid($gid);
+        $gidCheck = new \MySociety\TheyWorkForYou\Gid($gid);
         $gid = $gidCheck->checkForRedirect();
         if ($gid) {
             $title = $featured->get_title();
@@ -87,7 +87,7 @@ class Homepage {
             $item = $debatelist->display('recent_debates', ['days' => 7, 'num' => 1], 'none');
             if (isset($item['data']) && count($item['data'])) {
                 $item = $item['data'][0];
-                $more_url = new Url('debates');
+                $more_url = new \MySociety\TheyWorkForYou\Url('debates');
                 $item['more_url'] = $more_url->generate();
                 $item['desc'] = 'Commons Debates';
                 $item['related'] = [];
@@ -127,12 +127,12 @@ class Homepage {
     }
 
     protected function getFrontPageTopics() {
-        $topics = new Topics();
+        $topics = new \MySociety\TheyWorkForYou\Topics();
         return $topics->getFrontPageTopics();
     }
 
     private function getRecentDivisions() {
-        $divisions = new Divisions();
+        $divisions = new \MySociety\TheyWorkForYou\Divisions();
         return $divisions->getRecentDebatesWithDivisions(5, $this->houses);
     }
 
@@ -150,7 +150,7 @@ class Homepage {
         foreach ($this->recent_types as $class => $recent) {
             $class = "\\$class";
             $instance = new $class();
-            $more_url = new Url($recent[1]);
+            $more_url = new \MySociety\TheyWorkForYou\Url($recent[1]);
             if ($recent[0] == 'recent_pbc_debates') {
                 $content = [ 'data' => $instance->display($recent[0], ['num' => 5], 'none') ];
             } else {
@@ -174,7 +174,7 @@ class Homepage {
     }
 
     private function getCalendarData() {
-        return Utility\Calendar::fetchFuture();
+        return \MySociety\TheyWorkForYou\Utility\Calendar::fetchFuture();
     }
 
 }

--- a/classes/Homepage/UK.php
+++ b/classes/Homepage/UK.php
@@ -2,9 +2,7 @@
 
 namespace MySociety\TheyWorkForYou\Homepage;
 
-class UK {
-    private $db;
-
+class UK extends Base {
     protected $mp_house = 1;
     protected $cons_type = 'WMC';
     protected $mp_url = 'yourmp';
@@ -20,34 +18,10 @@ class UK {
         'StandingCommittee' => ['recent_pbc_debates', 'pbcfront', 'Public Bill committees'],
     ];
 
-    public function __construct() {
-        $this->db = new \ParlDB();
-    }
-
     public function display() {
-        global $this_page;
-        $this_page = $this->page;
-
-        $data = [];
-
-        $common = new \MySociety\TheyWorkForYou\Common();
-        $dissolution = Dissolution::dates();
-
-        $data['debates'] = $this->getDebatesData();
-
-        $user = new \MySociety\TheyWorkForYou\User();
-        $data['mp_data'] = $user->getRep($this->cons_type, $this->mp_house);
-        $data["commons_dissolved"] = isset($dissolution[1]);
-
-        $data['regional'] = $this->getRegionalList();
-        $data['popular_searches'] = []; # $common->getPopularSearches();
-        $data['urls'] = $this->getURLs();
+        $data = parent::display();
         $data['calendar'] = $this->getCalendarData();
-        $data['featured'] = $this->getEditorialContent();
         $data['topics'] = $this->getFrontPageTopics();
-        $data['divisions'] = $this->getRecentDivisions();
-        $data['search_box'] = $this->getSearchBox($data);
-
         return $data;
     }
 
@@ -66,10 +40,6 @@ class UK {
         $search_box->add_quick_link('Donate to support our work', '/support-us/', 'heart');
         $search_box->add_quick_link('Learn more about TheyWorkForYou', '/about/', 'magnifying-glass');
         return $search_box;
-    }
-
-    protected function getRegionalList() {
-        return null;
     }
 
     protected function getEditorialContent() {
@@ -129,48 +99,6 @@ class UK {
     protected function getFrontPageTopics() {
         $topics = new \MySociety\TheyWorkForYou\Topics();
         return $topics->getFrontPageTopics();
-    }
-
-    private function getRecentDivisions() {
-        $divisions = new \MySociety\TheyWorkForYou\Divisions();
-        return $divisions->getRecentDebatesWithDivisions(5, $this->houses);
-    }
-
-    protected function getURLs() {
-        $urls = [];
-
-        return $urls;
-    }
-
-    protected function getDebatesData() {
-        $debates = []; // holds the most recent data there is data for, indexed by type
-
-        $recent_content = [];
-
-        foreach ($this->recent_types as $class => $recent) {
-            $class = "\\$class";
-            $instance = new $class();
-            $more_url = new \MySociety\TheyWorkForYou\Url($recent[1]);
-            if ($recent[0] == 'recent_pbc_debates') {
-                $content = [ 'data' => $instance->display($recent[0], ['num' => 5], 'none') ];
-            } else {
-                $content = $instance->display($recent[0], ['days' => 7, 'num' => 1], 'none');
-                if (isset($content['data']) && count($content['data'])) {
-                    $content = $content['data'][0];
-                } else {
-                    $content = [];
-                }
-            }
-            if ($content) {
-                $content['more_url'] = $more_url->generate();
-                $content['desc'] = $recent[2];
-                $recent_content[] = $content;
-            }
-        }
-
-        $debates['recent'] = $recent_content;
-
-        return $debates;
     }
 
     private function getCalendarData() {

--- a/classes/Homepage/UK.php
+++ b/classes/Homepage/UK.php
@@ -55,7 +55,7 @@ class UK extends Base {
             $item = $this->getFeaturedDebate($gid, $title, $context, $related);
         } else {
             $item = $debatelist->display('recent_debates', ['days' => 7, 'num' => 1], 'none');
-            if (isset($item['data']) && count($item['data'])) {
+            if (count($item['data'])) {
                 $item = $item['data'][0];
                 $more_url = new \MySociety\TheyWorkForYou\Url('debates');
                 $item['more_url'] = $more_url->generate();

--- a/classes/Homepage/UK.php
+++ b/classes/Homepage/UK.php
@@ -5,9 +5,9 @@ namespace MySociety\TheyWorkForYou\Homepage;
 class UK extends Base {
     protected $mp_house = 1;
     protected $cons_type = 'WMC';
-    protected $mp_url = 'yourmp';
     protected $page = 'overview';
     protected $houses = [1, 101];
+    private $mp_url = 'yourmp';
 
     protected $recent_types = [
         'DEBATELIST' => ['recent_debates', 'debatesfront', 'Commons debates'],
@@ -42,7 +42,7 @@ class UK extends Base {
         return $search_box;
     }
 
-    protected function getEditorialContent() {
+    protected function getEditorialContent(&$data) {
         $debatelist = new \DEBATELIST();
         $featured = new \MySociety\TheyWorkForYou\Model\Featured();
         $gid = $featured->get_gid();

--- a/classes/Homepage/Wales.php
+++ b/classes/Homepage/Wales.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace MySociety\TheyWorkForYou\Homepage;
+
+class Wales extends Base {
+    protected $mp_house = 5;
+    protected $cons_type = 'WAC';
+    protected $page = 'seneddoverview';
+
+    # Due to language, set things here
+    public function __construct() {
+        if (LANGUAGE == 'cy') {
+            $this->houses = [11];
+            $class = 'SENEDDCYLIST';
+        } else {
+            $this->houses = [10];
+            $class = 'SENEDDENLIST';
+        }
+        $this->recent_types = [
+            $class => ['recent_debates', 'senedddebatesfront', 'Senedd'],
+        ];
+    }
+
+    public function display() {
+        $data = parent::display();
+        $data['popular_searches'] = null;
+        $data['template'] = 'senedd/index';
+        return $data;
+    }
+
+    protected function getEditorialContent(&$data) {
+        $featured = [];
+        if (count($data['debates']['recent'])) {
+            $MOREURL = new \MySociety\TheyWorkForYou\Url('senedddebatesfront');
+            $MOREURL->insert([ 'more' => 1 ]);
+            $featured = array_shift($data['debates']['recent']);
+            $featured['more_url'] = $MOREURL->generate();
+            $featured['desc'] = 'Senedd';
+            $featured['related'] = [];
+            $featured['featured'] = false;
+        }
+        return $featured;
+    }
+
+    protected function getSearchBox(array $data): \MySociety\TheyWorkForYou\Search\SearchBox {
+        $search_box = new \MySociety\TheyWorkForYou\Search\SearchBox();
+        $search_box->homepage_panel_class = "panel--homepage--senedd";
+        $search_box->homepage_subhead = gettext("Senedd / Welsh Parliament");
+        $search_box->homepage_desc = "";
+        $search_box->search_section = "senedd";
+        $search_box->quick_links = [];
+        if (count($data["regional"])) {
+            // get all unique constituencies
+            $constituencies = [];
+            foreach ($data["regional"] as $member) {
+                $constituencies[$member["constituency"]] = 1;
+            }
+            $constituencies = array_keys($constituencies);
+            $search_box->add_quick_link(sprintf(gettext('Find out more about your MSs for %s and %s'), $constituencies[0], $constituencies[1]), '/postcode/?pc=' . $data["mp_data"]['postcode'], 'torso');
+        }
+        $search_box->add_quick_link(gettext('Create and manage email alerts'), '/alert/', 'megaphone');
+        $search_box->add_quick_link(gettext('Subscribe to our newsletter'), '/about/#about-mysociety', 'mail');
+        $search_box->add_quick_link(gettext('Donate to support our work'), '/support-us/', 'heart');
+        $search_box->add_quick_link(gettext('Learn more about TheyWorkForYou'), '/about/', 'magnifying-glass');
+        return $search_box;
+    }
+
+    protected function getRegionalList() {
+        global $THEUSER;
+
+        $mreg = [];
+        if ($THEUSER->isloggedin() && $THEUSER->postcode() != '' || $THEUSER->postcode_is_set()) {
+            return array_merge(
+                \MySociety\TheyWorkForYou\Member::getRegionalList($THEUSER->postcode, 5, 'WAC'),
+                \MySociety\TheyWorkForYou\Member::getRegionalList($THEUSER->postcode, 5, 'WAE')
+            );
+        }
+
+        return $mreg;
+    }
+}

--- a/classes/SectionView/NiView.php
+++ b/classes/SectionView/NiView.php
@@ -11,7 +11,8 @@ class NiView extends SectionView {
         if (get_http_var('more')) {
             return parent::display_front();
         } else {
-            return $this->display_front_ni();
+            $homepage = new \MySociety\TheyWorkForYou\Homepage\NI();
+            return $homepage->display();
         }
     }
 
@@ -34,101 +35,5 @@ class NiView extends SectionView {
         return [
             [ 'section' => 'ni' ],
         ];
-    }
-
-    protected function display_front_ni() {
-        global $this_page;
-        $this_page = "nioverview";
-
-        $data = [];
-
-        $data['popular_searches'] = null;
-
-
-        $data['urls'] = $this->getURLs($data);
-
-        $DEBATELIST = new \NILIST();
-
-        $debates = $DEBATELIST->display('recent_debates', ['days' => 30, 'num' => 6], 'none');
-        $MOREURL = new \MySociety\TheyWorkForYou\Url('nidebatesfront');
-        $MOREURL->insert([ 'more' => 1 ]);
-
-        // this makes sure that we don't repeat this debate in the list below
-        $random_debate = null;
-        if (isset($debates['data']) && count($debates['data'])) {
-            $random_debate = $debates['data'][0];
-        }
-
-        $recent = [];
-        if (isset($debates['data']) && count($debates['data'])) {
-            // at the start of a session there may be less than 6
-            // debates
-            $max = 6;
-            if (count($debates['data']) < 6) {
-                $max = count($debates['data']);
-            }
-            for ($i = 1; $i < $max; $i++) {
-                $debate = $debates['data'][$i];
-                $debate['desc'] = "Northern Ireland Assembly debates";
-                $debate['more_url'] = $MOREURL->generate();
-                $recent[] = $debate;
-            }
-        }
-
-        $featured = [];
-        if ($random_debate) {
-            $featured = $random_debate;
-            $featured['more_url'] = $MOREURL->generate();
-            $featured['desc'] = 'Northern Ireland Assembly debate';
-            $featured['related'] = [];
-            $featured['featured'] = false;
-        }
-
-        $data['featured'] = $featured;
-        $data['debates'] = [ 'recent' => $recent];
-
-        $data['regional'] = $this->getMLAList();
-        $data['search_box'] = $this->getSearchBox($data);
-        $data['template'] = 'ni/index';
-
-        return $data;
-    }
-
-    protected function getSearchBox(array $data): \MySociety\TheyWorkForYou\Search\SearchBox {
-
-        global $THEUSER;
-
-        if ($THEUSER->isloggedin() && $THEUSER->postcode() != '' || $THEUSER->postcode_is_set()) {
-            $postcode = $THEUSER->postcode();
-        } else {
-            $postcode = null;
-        }
-
-        $search_box = new \MySociety\TheyWorkForYou\Search\SearchBox();
-        $search_box->homepage_panel_class = "panel--homepage--niassembly";
-        $search_box->homepage_subhead = "Northern Ireland Assembly";
-        $search_box->homepage_desc = "";
-        $search_box->search_section = "ni";
-        $search_box->quick_links = [];
-        if (count($data["regional"])) {
-            $constituency = $data["regional"][0]["constituency"];
-            $search_box->add_quick_link('Find out more about your MLAs for ' . $constituency, '/postcode/?pc=' . $postcode, 'torso');
-        }
-        $search_box->add_quick_link('Create and manage email alerts', '/alert/', 'megaphone');
-        $search_box->add_quick_link(gettext('Subscribe to our newsletter'), '/about/#about-mysociety', 'mail');
-        $search_box->add_quick_link('Donate to support our work', '/support-us/', 'heart');
-        $search_box->add_quick_link('Learn more about TheyWorkForYou', '/about/', 'magnifying-glass');
-        return $search_box;
-    }
-
-    protected function getMLAList() {
-        global $THEUSER;
-
-        $mreg = [];
-        if ($THEUSER->isloggedin() && $THEUSER->postcode() != '' || $THEUSER->postcode_is_set()) {
-            return \MySociety\TheyWorkForYou\Member::getRegionalList($THEUSER->postcode, 3, 'NIE');
-        }
-
-        return $mreg;
     }
 }

--- a/classes/SectionView/SeneddView.php
+++ b/classes/SectionView/SeneddView.php
@@ -20,7 +20,8 @@ class SeneddView extends SectionView {
         if (get_http_var('more')) {
             return parent::display_front();
         } else {
-            return $this->display_front_senedd();
+            $homepage = new \MySociety\TheyWorkForYou\Homepage\Wales();
+            return $homepage->display();
         }
     }
 
@@ -42,102 +43,5 @@ class SeneddView extends SectionView {
         return [
             [ 'section' => 'wales' ],
         ];
-    }
-
-    protected function display_front_senedd() {
-        global $this_page;
-        $this_page = "seneddoverview";
-
-        $data = [];
-
-        $data['popular_searches'] = null;
-
-        $user = new \MySociety\TheyWorkForYou\User();
-        $data['mp_data'] = $user->getRep("WMC", 1);
-
-        $data['urls'] = $this->getURLs($data);
-
-        $DEBATELIST = new $this->class();
-
-        $debates = $DEBATELIST->display('recent_debates', ['days' => 30, 'num' => 6], 'none');
-        $MOREURL = new \MySociety\TheyWorkForYou\Url('senedddebatesfront');
-        $MOREURL->insert([ 'more' => 1 ]);
-
-        // this makes sure that we don't repeat this debate in the list below
-        $random_debate = null;
-        if (isset($debates['data']) && count($debates['data'])) {
-            $random_debate = $debates['data'][0];
-        }
-
-        $recent = [];
-        if (isset($debates['data']) && count($debates['data'])) {
-            // at the start of a session there may be less than 6
-            // debates
-            $max = 6;
-            if (count($debates['data']) < 6) {
-                $max = count($debates['data']);
-            }
-            for ($i = 1; $i < $max; $i++) {
-                $debate = $debates['data'][$i];
-                $debate['desc'] = "Senedd";
-                $debate['more_url'] = $MOREURL->generate();
-                $recent[] = $debate;
-            }
-        }
-
-        $featured = [];
-        if ($random_debate) {
-            $featured = $random_debate;
-            $featured['more_url'] = $MOREURL->generate();
-            $featured['desc'] = 'Senedd';
-            $featured['related'] = [];
-            $featured['featured'] = false;
-        }
-
-        $data['featured'] = $featured;
-        $data['debates'] = [ 'recent' => $recent];
-
-        $data['regional'] = $this->getMSList();
-        $data['search_box'] = $this->getSearchBox($data);
-        $data['template'] = 'senedd/index';
-
-        return $data;
-    }
-
-    protected function getSearchBox(array $data): \MySociety\TheyWorkForYou\Search\SearchBox {
-        $search_box = new \MySociety\TheyWorkForYou\Search\SearchBox();
-        $search_box->homepage_panel_class = "panel--homepage--senedd";
-        $search_box->homepage_subhead = gettext("Senedd / Welsh Parliament");
-        $search_box->homepage_desc = "";
-        $search_box->search_section = "senedd";
-        $search_box->quick_links = [];
-        if (count($data["regional"])) {
-            // get all unique constituencies
-            $constituencies = [];
-            foreach ($data["regional"] as $member) {
-                $constituencies[$member["constituency"]] = 1;
-            }
-            $constituencies = array_keys($constituencies);
-            $search_box->add_quick_link(sprintf(gettext('Find out more about your MSs for %s and %s'), $constituencies[0], $constituencies[1]), '/postcode/?pc=' . $data["mp_data"]['postcode'], 'torso');
-        }
-        $search_box->add_quick_link(gettext('Create and manage email alerts'), '/alert/', 'megaphone');
-        $search_box->add_quick_link(gettext('Subscribe to our newsletter'), '/about/#about-mysociety', 'mail');
-        $search_box->add_quick_link(gettext('Donate to support our work'), '/support-us/', 'heart');
-        $search_box->add_quick_link(gettext('Learn more about TheyWorkForYou'), '/about/', 'magnifying-glass');
-        return $search_box;
-    }
-
-    protected function getMSList() {
-        global $THEUSER;
-
-        $mreg = [];
-        if ($THEUSER->isloggedin() && $THEUSER->postcode() != '' || $THEUSER->postcode_is_set()) {
-            return array_merge(
-                \MySociety\TheyWorkForYou\Member::getRegionalList($THEUSER->postcode, 5, 'WAC'),
-                \MySociety\TheyWorkForYou\Member::getRegionalList($THEUSER->postcode, 5, 'WAE')
-            );
-        }
-
-        return $mreg;
     }
 }

--- a/www/docs/admin/featured.php
+++ b/www/docs/admin/featured.php
@@ -114,7 +114,7 @@ function preview_featured() {
 
     print "<h2>Preview Content</h2>";
     if ($gid !== null) {
-        $h = new MySociety\TheyWorkForYou\Homepage();
+        $h = new MySociety\TheyWorkForYou\Homepage\UK();
         $featured = $h->getFeaturedDebate($gid, $title, $context, [ $related_gid1, $related_gid2, $related_gid3 ]);
 
         include INCLUDESPATH . 'easyparliament/templates/html/homepage/featured.php';

--- a/www/docs/index.php
+++ b/www/docs/index.php
@@ -3,7 +3,7 @@
 include_once '../includes/easyparliament/init.php';
 include_once '../includes/easyparliament/recess.php';
 
-$view = new MySociety\TheyWorkForYou\Homepage();
+$view = new MySociety\TheyWorkForYou\Homepage\UK();
 $data = $view->display();
 
 MySociety\TheyWorkForYou\Renderer::output('index', $data);

--- a/www/docs/scotland/index.php
+++ b/www/docs/scotland/index.php
@@ -2,7 +2,7 @@
 
 include_once '../../includes/easyparliament/init.php';
 
-$view = new MySociety\TheyWorkForYou\SPHomepage();
+$view = new MySociety\TheyWorkForYou\Homepage\Scotland();
 $data = $view->display();
 
 MySociety\TheyWorkForYou\Renderer::output('scotland/index', $data);

--- a/www/includes/easyparliament/hansardlist.php
+++ b/www/includes/easyparliament/hansardlist.php
@@ -2920,7 +2920,7 @@ class DEBATELIST extends HANSARDLIST {
         // $args['days'] is the number of days back to look for biggest debates (1 by default).
         // $args['num'] is the number of links to return (1 by default).
 
-        $data = [];
+        $data = ['info' => [], 'data' => []];
 
         $params = [];
 
@@ -3016,7 +3016,7 @@ class DEBATELIST extends HANSARDLIST {
             $childbody = $r['body'];
             $speaker = $this->_get_speaker($r['person_id'], $r['hdate'], $r['htime'], $this->major);
 
-            $data[] = [
+            $data['data'][] = [
                 'contentcount'  => $contentcount,
                 'body'          => $body,
                 'hdate'         => $hdate,
@@ -3034,13 +3034,7 @@ class DEBATELIST extends HANSARDLIST {
 
         }
 
-        $data =  [
-            'info' => [],
-            'data' => $data,
-        ];
-
         return $data;
-
     }
 
     public function _get_data_by_biggest_debates($args = []) {

--- a/www/includes/easyparliament/templates/html/homepage/recent-debates.php
+++ b/www/includes/easyparliament/templates/html/homepage/recent-debates.php
@@ -2,7 +2,9 @@
                             <li class="parliamentary-excerpt">
                             <h3 class="excerpt__title"><a href="<?= $recent['list_url'] ?>"><?= $recent['parent']['body'] ? $recent['parent']['body'] . ' : ' : '' ?><?= $recent['body'] ?></a></h3>
                                 <p class="meta"><?=format_date($recent['hdate'], LONGERDATEFORMAT); ?></p>
+<?php if ($recent['desc']) { ?>
                                 <p class="meta excerpt__category"><a href="<?= $recent['more_url'] ?>"><?= $recent['desc'] ?></a></p>
+<?php } ?>
                                 <p class="excerpt__statement">
                                 <?php if (isset($recent['child']['speaker']) && count($recent['child']['speaker'])) { ?>
                                 <a href="<?= $recent['child']['speaker']['url'] ?>"><?= $recent['child']['speaker']['name'] ?></a>

--- a/www/includes/easyparliament/templates/html/homepage/recent-votes.php
+++ b/www/includes/easyparliament/templates/html/homepage/recent-votes.php
@@ -12,6 +12,8 @@
                 </a>
             </h3>
             <p class="meta">
+                <?php if ($debate['major'] == 1) { ?>Commons, <?php } ?>
+                <?php if ($debate['major'] == 101) { ?>Lords, <?php } ?>
                 <?= format_date($debate['date'], LONGERDATEFORMAT) ?>
             </p>
       </li>

--- a/www/includes/easyparliament/templates/html/scotland/index.php
+++ b/www/includes/easyparliament/templates/html/scotland/index.php
@@ -20,14 +20,13 @@
             <div class="panel panel--flushtop clearfix">
                 <div class="row nested-row">
                     <div class="homepage-recently homepage-content-section">
-                        <?php include dirname(__FILE__) . '/../homepage/recent-votes.php'; ?>
-
                         <h2>Recently in Parliament</h2>
                         <ul class="recently__list"><?php
                             foreach ($debates['recent'] as $recent) {
                                 include dirname(__FILE__) . '/../homepage/recent-debates.php';
                             }
 ?></ul>
+                        <?php include dirname(__FILE__) . '/../homepage/recent-votes.php'; ?>
                     </div>
                     <div class="homepage-upcoming homepage-content-section">
                         <h2>What is the Scottish Parliament?</h2>

--- a/www/includes/easyparliament/templates/html/senedd/index.php
+++ b/www/includes/easyparliament/templates/html/senedd/index.php
@@ -27,6 +27,7 @@
                                 include dirname(__FILE__) . '/../homepage/recent-debates.php';
                             }
 ?></ul>
+                        <?php include dirname(__FILE__) . '/../homepage/recent-votes.php'; ?>
                     </div>
                     <div class="homepage-upcoming homepage-content-section">
                         <h2><?= gettext('What is the Senedd?') ?></h2>


### PR DESCRIPTION
Don't know who should review something like this currently :) The only actual change should be displaying Welsh votes at all, moving Scottish votes underneath Scottish debates, and including Commons/Lords on UK (fixes #1832) on their homepages. The rest is just trying to tidy all these homepages to use the same homepage base class, which seemed sensible whilst I was there, they're mostly the same now (more could probably be done, combining templates and whatnot, but seemed enough for now).