### PR TITLE
use configured smarthost for PHP emails

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -29,6 +29,8 @@ sed -r \
     -e 's!^(.*"PWMEMBERS", *)"[^"]*"!'"\\1'/twfy/data/parlparse/members/'!" \
     -e 's!^(.*"XAPIANDB", *)"[^"]*"!'"\\1'/twfy/searchdb/'!" \
     -e "s!^(.*define\('OPTION_MAPIT_URL', *)'[^']*"!"\\1'https://mapit.mysociety.org/!" \
+    -e "s!^(.*define\('OPTION_SMTP_SMARTHOST', *)'[^']*"!"\\1'email.svc!" \
+    -e "s!^(.*define\('OPTION_SMTP_PORT', *)[0-9]*"!"\\11025!" \
     -e "s/array\('127.0.0.1'\)/array\('sentinel'\)/" \
   conf/general-example > conf/general
 

--- a/conf/general-example
+++ b/conf/general-example
@@ -144,6 +144,7 @@ define('ENTRIES_AFTER_LEFT', '{
 // More Email addresses.
 
 define('OPTION_SMTP_SMARTHOST', 'localhost');
+define('OPTION_SMTP_PORT', 25);
 
 // When a user reports an annotation, notification is sent to this address.
 define ("REPORTLIST", CONTACTEMAIL);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,17 @@ services:
       timeout: 5s
       retries: 5
 
+  mailhog:
+    image: mailhog/mailhog:v1.0.1
+    restart: always
+    ports:
+      - 1025:1025
+      - 8025:8025
+    networks:
+     default:
+       aliases:
+         - email.svc
+
 volumes:
   db:
   testdb:

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -781,6 +781,8 @@ function send_email($to, $subject, $message, $bulk = false, $from = '', $want_bo
     $mail->addAddress($to);
     $mail->Subject = $subject;
     $mail->CharSet = 'utf-8';
+    $mail->Host = OPTION_SMTP_SMARTHOST;
+    $mail->Port = OPTION_SMTP_PORT;
 
     if ($html) {
         $mail->msgHTML($html, INCLUDESPATH . 'easyparliament/templates/emails');


### PR DESCRIPTION
This updates the utility class to use the configured smarthost, plus adds a port configuration, and then updates docker to use mailhog and configure php to use this. Largely to make testing things like alert signups etc easier in docker.