### PR TITLE
Improve design of alerts page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get -qq update && apt-get -qq install \
       php-xdebug \
       gettext \
       rsync \
+      mariadb-client \
     --no-install-recommends && \
     rm -r /var/lib/apt/lists/*
 

--- a/classes/AlertView/Standard.php
+++ b/classes/AlertView/Standard.php
@@ -320,13 +320,13 @@ class Standard extends \MySociety\TheyWorkForYou\AlertView {
             }
             $this->data['alerts'] = \MySociety\TheyWorkForYou\Utility\Alert::forUser($this->data['email']);
             foreach ($this->data['alerts'] as $alert) {
-                if (array_key_exists('words', $alert)) {
+                if (array_key_exists('spokenby', $alert) and sizeof($alert['spokenby']) == 1 and $alert['spokenby'][0] == $own_mp_criteria) {
+                    $this->data['own_member_alerts'][] = $alert;
+                } elseif (array_key_exists('spokenby', $alert)) {
+                    $this->data['spoken_alerts'][] = $alert;
+                } else {
                     $this->data['all_keywords'][] = implode(' ', $alert['words']);
                     $this->data['keyword_alerts'][] = $alert;
-                } elseif (array_key_exists('spokenby', $alert) and sizeof($alert['spokenby']) == 1 and $alert['spokenby'][0] == $own_mp_criteria) {
-                    $this->data['own_member_alerts'][] = $alert;
-                } else {
-                    $this->data['spoken_alerts'][] = $alert;
                 }
             }
         }

--- a/classes/Utility/Alert.php
+++ b/classes/Utility/Alert.php
@@ -61,6 +61,7 @@ class Alert {
                 'raw' => $row['criteria'],
                 'keywords' => [],
                 'exclusions' => [],
+                'sections' => [],
             ];
 
             $alert = array_merge($alert, $parts);

--- a/classes/Utility/Alert.php
+++ b/classes/Utility/Alert.php
@@ -34,6 +34,7 @@ class Alert {
         $alerts = [];
         foreach ($q as $row) {
             $criteria = self::prettifyCriteria($row['criteria']);
+            $parts = self::prettifyCriteria($row['criteria'], true);
             $token = $row['alert_id'] . '-' . $row['registrationtoken'];
 
             $status = 'confirmed';
@@ -43,21 +44,28 @@ class Alert {
                 $status = 'suspended';
             }
 
-            $alerts[] = [
+            $alert = [
                 'token' => $token,
                 'status' => $status,
                 'criteria' => $criteria,
                 'raw' => $row['criteria'],
+                'keywords' => [],
+                'exclusions' => [],
             ];
+
+            $alert = array_merge($alert, $parts);
+
+            $alerts[] = $alert;
         }
 
         return $alerts;
     }
 
-    public static function prettifyCriteria($alert_criteria) {
+    public static function prettifyCriteria($alert_criteria, $as_parts = false) {
         $text = '';
         if ($alert_criteria) {
             $criteria = explode(' ', $alert_criteria);
+            $parts = [];
             $words = [];
             $spokenby = array_values(\MySociety\TheyWorkForYou\Utility\Search::speakerNamesForIDs($alert_criteria));
 
@@ -68,11 +76,18 @@ class Alert {
             }
             if ($spokenby && count($words)) {
                 $text = implode(' or ', $spokenby) . ' mentions [' . implode(' ', $words) . ']';
+                $parts['spokenby'] = $spokenby;
+                $parts['words'] = $words;
             } elseif (count($words)) {
                 $text = '[' . implode(' ', $words) . ']' . ' is mentioned';
+                $parts['words'] = $words;
             } elseif ($spokenby) {
                 $text = implode(' or ', $spokenby) . " speaks";
+                $parts['spokenby'] = $spokenby;
             }
+        }
+        if ($as_parts) {
+            return $parts;
         }
         return $text;
     }

--- a/www/docs/js/main.js
+++ b/www/docs/js/main.js
@@ -423,6 +423,77 @@ function wrap_error($message){
   return '<div class="donate-form__error-wrapper"><p class="donate-form__error">' + $message + '</p></div>';
 }
 
+function createAccordion(triggerSelector, contentSelector) {
+  var triggers = document.querySelectorAll(triggerSelector);
+  
+  triggers.forEach(function(trigger) {
+    var content = document.querySelector(trigger.getAttribute('href'));
+
+    var openAccordion = function() {
+      content.style.maxHeight = content.scrollHeight + "px"; // Dynamically calculate height
+      content.setAttribute('aria-hidden', 'false');
+      trigger.setAttribute('aria-expanded', 'true');
+    };
+
+    var closeAccordion = function() {
+      content.style.maxHeight = null; // Collapse
+      content.setAttribute('aria-hidden', 'true');
+      trigger.setAttribute('aria-expanded', 'false');
+    };
+
+    trigger.addEventListener('click', function(e) {
+      e.preventDefault();
+      
+      if (content.style.maxHeight) {
+        closeAccordion();
+      } else {
+        openAccordion();
+      }
+    });
+    
+    // Accessibility
+    trigger.setAttribute('aria-controls', content.getAttribute('id'));
+    trigger.setAttribute('aria-expanded', 'false');
+    content.setAttribute('aria-hidden', 'true');
+    content.style.maxHeight = null;
+  });
+}
+
+// Initialize accordion when DOM is loaded
+document.addEventListener('DOMContentLoaded', function() {
+  createAccordion('.accordion-button', '.accordion-content');
+});
+
+// Create alert form
+$(document).ready(function() {
+  let currentStep = 0;
+  let steps = $(".alert-step");
+
+  // Show the first step
+  $(steps[currentStep]).show();
+
+  // Focus management: Set focus to the first input on each step change
+  function focusFirstInput(stepIndex) {
+    $(steps[stepIndex]).find('input, button').first().focus();
+  }
+
+  // Next button click
+  $(".next").click(function() {
+    $(steps[currentStep]).hide();
+    currentStep++;
+    $(steps[currentStep]).show();
+    focusFirstInput(currentStep); // Set focus to the first input of the new step
+  });
+
+  // Previous button click
+  $(".prev").click(function() {
+    $(steps[currentStep]).hide();
+    currentStep--;
+    $(steps[currentStep]).show();
+    focusFirstInput(currentStep); // Set focus to the first input of the new step
+  });
+});
+
 $(function() {
 
   $('#how-often-annually').click(function() {

--- a/www/docs/style/sass/app.scss
+++ b/www/docs/style/sass/app.scss
@@ -62,10 +62,10 @@
 @import url(https://fonts.googleapis.com/css2?family=Manrope:wght@700&family=Merriweather:wght@400;700&display=swap);
 /* Foundation Icons v 3.0 MIT License */
 @font-face {
-  font-family: "foundation-icons";
-  src: url("/style/foundation-icons/foundation-icons.woff") format("woff");
-  font-weight: normal;
-  font-style: normal;
+    font-family: "foundation-icons";
+    src: url("/style/foundation-icons/foundation-icons.woff") format("woff");
+    font-weight: normal;
+    font-style: normal;
 }
 
 .fi-social-facebook:before,
@@ -75,17 +75,24 @@
 .fi-megaphone:before,
 .fi-pound:before,
 .fi-magnifying-glass:before,
-.fi-heart:before
+.fi-heart:before,
+.fi-plus:before,
+.fi-play:before,
+.fi-pause:before,
+.fi-trash:before,
+.fi-page-edit:before,
+.fi-x:before,
+.fi-save:before
 {
-  font-family: "foundation-icons";
-  font-style: normal;
-  font-weight: normal;
-  font-variant: normal;
-  text-transform: none;
-  line-height: 1;
-  -webkit-font-smoothing: antialiased;
-  display: inline-block;
-  text-decoration: inherit;
+    font-family: "foundation-icons";
+    font-style: normal;
+    font-weight: normal;
+    font-variant: normal;
+    text-transform: none;
+    line-height: 1;
+    -webkit-font-smoothing: antialiased;
+    display: inline-block;
+    text-decoration: inherit;
 }
 
 // https://github.com/zurb/foundation-icon-fonts/blob/master/_foundation-icons.scss
@@ -97,6 +104,13 @@
 .fi-pound:before {content: "\f19a"}
 .fi-magnifying-glass:before {content: "\f16c"}
 .fi-heart:before { content: "\f159"; }
+.fi-plus:before { content: "\f199"; }
+.fi-play:before { content: "\f198"; }
+.fi-pause:before { content: "\f191"; }
+.fi-trash:before { content: "\f204"; }
+.fi-page-edit:before { content: "\f184"; }
+.fi-x:before { content: "\f217"; }
+.fi-save:before { content: "\f1ac"; }
 
 html,
 body {
@@ -129,13 +143,13 @@ h3 {
 }
 
 .pull-right {
-     @media (min-width: $medium-screen) {
+    @media (min-width: $medium-screen) {
         float: right;
         margin-left: 1em;
     }
 }
 .pull-left {
-     @media (min-width: $medium-screen) {
+    @media (min-width: $medium-screen) {
         float: left;
         margin-left: 1em;
     }
@@ -166,12 +180,12 @@ ul {
 a {
     overflow-wrap: break-word;
     word-wrap: break-word;
-
+    
     -webkit-hyphens: auto;
-       -moz-hyphens: auto;
-        -ms-hyphens: auto;
-            hyphens: auto;
-
+    -moz-hyphens: auto;
+    -ms-hyphens: auto;
+    hyphens: auto;
+    
     color: $links;
 }
 
@@ -198,7 +212,7 @@ a:focus {
         // for .button elements!!
         vertical-align: -0.4em;
     }
-
+    
     &.tertiary {
         @include button-style($bg: $links);
     }
@@ -231,6 +245,7 @@ form {
 
 @import "parts/panels";
 @import "parts/promo-banner";
+@import "parts/accordion";
 
 @import "pages/mp";
 @import "pages/topics";

--- a/www/docs/style/sass/parts/_accordion.scss
+++ b/www/docs/style/sass/parts/_accordion.scss
@@ -1,0 +1,236 @@
+.label {
+    background-color: #fff;
+    color: $primary-color;
+    padding: 0.25rem 0.5rem;
+    border-radius: 1rem;
+    font-size: 0.75rem;
+
+    &--primary-light {
+        background-color: $primary-color-200;
+        color: $body-font-color;
+    }
+
+    &--red {
+        background-color: lighten($color-red, 40%);
+        color: $body-font-color;
+    }
+}
+
+.alert-page-header {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: end;
+
+    h2 {
+        margin-bottom: 0.5rem;
+    }
+}
+
+.accordion {
+    margin-top: 2rem;
+}
+
+.accordion-button {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    text-align: left;
+    padding: 10px;
+    font-size: 1.2em;
+    cursor: pointer;
+    border: none;
+
+    &[aria-expanded="true"] {
+        background-color: $primary-color-200;
+        color: $body-font-color;
+        & + .accordion-content{
+            max-height: 1000px;
+            transition: max-height 0.3s ease;
+        }
+
+        i {
+            transform: rotate(45deg);
+        }
+    }
+
+}
+
+.accordion-button--content {
+    display: flex;
+    flex-direction: row;
+    align-content: center;
+    align-items: center;
+    gap: 0.75rem;
+
+    .content-subtitle {
+        @extend .label;
+    }
+}
+
+.accordion-content {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.3s ease;
+
+    .alert-controller-wrapper {
+        margin-bottom: 2rem;
+        button {
+            margin-bottom: 0;
+            span {
+                margin-right: 0.2rem;
+            }
+        }
+
+        button.alert {
+            background-color: $color-red;
+            color: #fff;
+        }
+    }
+
+    .add-remove-tool {
+        display: flex;
+        flex-direction: row;
+
+        input {
+            margin: 0;
+            height: 40px;
+        }
+
+        button {
+            max-width: 100px;
+            height: 40px;
+        }
+    }
+
+    label {
+        font-size: inherit;
+        color: inherit;
+    }
+
+    select {
+        max-width: 350px;
+    }
+}
+
+.keyword-list {
+    ul {
+        list-style: none;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-left: 0;
+
+        li {
+            font-weight: bold;
+            i {
+                margin-left: 0.25rem;
+            }
+        }
+
+    }
+}
+
+.heading-with-bold-word {
+    font-weight: 400;
+
+    span {
+        font-weight: bold;
+    }
+}
+
+.alert-meta-info {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    column-gap: 4rem;
+    row-gap: 1rem;
+    align-items: center;
+
+    dt { 
+        color: $light-text;
+        font-size: 0.9rem;
+    }
+}
+
+button {
+    i {
+        margin-left: 0.25rem;
+    }
+}
+
+.alert-page-section {
+    margin-bottom: 3rem;
+}
+
+.alert-page-subsection {
+    margin-bottom: 2rem;
+
+    .alert-page-subsection--subtitle {
+        margin-bottom: 0.5rem;
+    }
+
+}
+
+.button.red {
+    background-color: $color-red;
+    color: #fff;
+
+    &:hover {
+        background-color: darken($color-red, 15%);
+    }
+}
+
+// FORM
+.alert-step {
+    display: none;
+}
+
+.alert-step.active {
+    display: block;
+}
+
+#create-alert-form {
+    label {
+        color: $body-font-color;
+        font-size: 1rem;
+        margin-bottom: 1rem;
+    }
+    input[type="text"], select {
+        max-width: 400px;
+        height: 40px;
+        border-color: $body-font-color;
+    }
+
+    fieldset {
+        column-count: 2;
+    }
+}
+  
+
+.mockup-internal-comment {
+    font-family: 'Trebuchet MS', 'Lucida Sans Unicode', 'Lucida Grande', 'Lucida Sans', Arial, sans-serif;
+    font-size: 0.8rem;
+    color: rgb(114, 8, 8);
+    background-color: rgb(230, 170, 170);
+    padding: 1rem;
+    border-radius: 1rem;
+    h4 {
+        color: inherit;
+    }
+    margin-bottom: 3rem;
+}
+
+.mockup-divider {
+    margin-top: 30rem;
+}
+
+.fi-x {
+    display: none;
+}
+
+.display-none {
+    display:none !important;
+}

--- a/www/includes/easyparliament/templates/html/alert/index.php
+++ b/www/includes/easyparliament/templates/html/alert/index.php
@@ -342,7 +342,9 @@
                         </dl>
                     </div>
 
+                    <?php if ($alert["keywords"] or $alert["exclusions"] or $alert["sections"] or array_key_exists('spokenby', $alert)) { ?>
                     <hr>
+                    <?php } ?>
 
                     <?php if ($alert["keywords"]) { ?>
                     <div class="keyword-list alert-page-subsection">
@@ -376,6 +378,7 @@
                     </div>
                     <?php } ?>
 
+                    <?php if ($alert['sections']) { ?>
                     <div class="keyword-list alert-page-subsection">
                       <h3 class="display-none"><label for="sections">Which section should this alert apply to?</label></h3>
                       <select name="sections" id="sections" class="display-none">
@@ -385,10 +388,13 @@
                       </select>
                       <h3 class="heading-with-bold-word">Which <span class="bold">section</span> should this alert apply to:</h3>
                       <ul>
-                        <li class="label label--red">All sections
+                        <?php foreach ($alert["sections_verbose"] as $section) { ?>
+                        <li class="label label--red"><?= _htmlspecialchars($section) ?>
                           <i aria-hidden="true" role="img" class="fi-x"></i></li>
+                        <?php } ?>
                       </ul>
                     </div>
+                    <?php } ?>
 
                     <!-- Only to be displayed if there is a person in this query -->
 

--- a/www/includes/easyparliament/templates/html/alert/index.php
+++ b/www/includes/easyparliament/templates/html/alert/index.php
@@ -250,38 +250,286 @@
       <?php } ?>
 
         <div class="alert-section">
-            <div class="alert-section__secondary">
-              <?php if ($email_verified) { ?>
-
-                  <?php if ($alerts) { ?>
-                    <?php include('_list.php'); ?>
-                  <?php } ?>
-
-                  <?php if ($current_mp) { ?>
-                    <h3><?= gettext('Your MP alert') ?></h3>
-                    <ul class="alerts-manage__list">
-                        <li>
-                            <?= sprintf(gettext('You are not subscribed to an alert for your current MP, %s'), $current_mp->full_name()) ?>.
-                            <form action="<?= $actionurl ?>" method="post">
-                                <input type="hidden" name="t" value="<?=_htmlspecialchars($token)?>">
-                                <input type="hidden" name="pid" value="<?= $current_mp->person_id() ?>">
-                                <input type="submit" class="button small" value="<?= gettext('Subscribe') ?>">
-                            </form>
-                        </li>
-                    </ul>
-                  <?php } ?>
-
-              <?php } else { ?>
+            <div class="alert-section__primary">
+              <?php if (!$email_verified) { ?>
                 <p>
                     <?= sprintf(gettext('If you <a href="%s">join</a> or <a href="%s">sign in</a>, you can suspend, resume and delete your email alerts from your profile page.'), '/user/?pg=join', '/user/login/?ret=%2Falert%2F') ?>
                 </p>
                 <p>
                     <?= gettext('Plus, you won’t need to confirm your email address for every alert you set.') ?>
                 </p>
-              <?php } ?>
-            </div>
+              <?php } else { ?>
+              <div class="clearfix">
+                  <form action="<?= $actionurl ?>" method="POST" class="pull-right">
+                      <input type="hidden" name="t" value="< ?= _htmlspecialchars($alert['token']) ?>">
+                      <input type="submit" class="button button--negative small" name="action" value="<?= gettext('Delete All') ?>">
+                  </form>
+              </div>
 
-            <div class="alert-section__primary">
+              <div class="alert-page-header">
+                <div>
+                <h2><?= gettext('Keywords alerts') ?></h2>
+                <!-- Go to Create alert page -->
+                <?php if (!$alerts) { ?>
+                  <p><?= gettext('You haven´t created any keyword alerts.') ?></p>
+                <?php } ?>
+                </div>
+                <a class="button" href="#new_alert">
+                  <?= gettext('Create new alert') ?>
+                  <i aria-hidden="true" role="img" class="fi-megaphone"></i>
+                </a>
+              </div>
+
+              <!-- The groups alerts should be sorted by default from most recent mention to oldest one -->
+              <!-- Future functionality: The groups alerts can be sorted alphabetically-->
+
+              <div class="accordion">
+                <?php foreach ($keyword_alerts as $index => $alert) { ?>
+                <div class="accordion-item">
+                <button class="accordion-button" href="#accordion-content-<?= $index ?>" aria-expanded="false">
+                    <div class="accordion-button--content">
+                      <span class="content-title"><?= _htmlspecialchars($alert['criteria']) ?></span>
+                      <?php if (array_key_exists("mentions", $alert)) { ?>
+                      <span class="content-subtitle"><?= sprintf(gettext('%d mentions this week'), $alert['mentions']) ?></span>
+                      <?php } ?>
+                    </div>
+                    <i aria-hidden="true" role="img" class="fi-plus"></i>
+                  </button>
+                  <div id="accordion-content-<?= $index ?>" class="accordion-content" aria-hidden="true" role="img">
+                    <div class="accordion-content-header">
+                      <form action="<?= $actionurl ?>" method="POST">
+                        <input type="hidden" name="t" value="<?= _htmlspecialchars($alert['token']) ?>">
+                        <div class="alert-controller-wrapper">
+                          <button class="button small display-none">Discard changes</button>
+                          <?php if ($alert['status'] == 'unconfirmed') { ?>
+                            <button type="submit" class="button small" name="action" value="Confirm">
+                              <span><?= gettext('Confirm alert') ?></span>
+                              <i aria-hidden="true" class="fi-save"></i>
+                            </button>
+                          <?php } elseif ($alert['status'] == 'suspended') { ?>
+                            <button type="submit" class="button small" name="action" value="Resume">
+                            <span><?= gettext('Resume alert') ?></span>
+                              <i aria-hidden="true" class="fi-play"></i>
+                            </button>
+                          <?php } else { ?>
+                            <button type="submit" class="button small" name="action" value="Suspend">
+                              <span><?= gettext('Suspend alert') ?></span>
+                              <i aria-hidden="true" class="fi-pause"></i>
+                            </button>
+                            <button type="submit" class="button small red" name="action" value="Delete">
+                              <span><?= gettext('Delete alert') ?></span>
+                              <i aria-hidden="true" class="fi-trash"></i>
+                            </button>
+                          <?php } ?>
+                        </div>
+                      </form>
+                      <dl class="alert-meta-info">
+                          <?php if (array_key_exists("mentions", $alert)) { ?>
+                           <div class="content-header-item">
+                             <dt><?= gettext('This week') ?></dt>
+                             <dd><?= sprintf(gettext('%d mentions'), $alert['mentions']) ?></dd>
+                           </div>
+                          <?php } ?>
+
+                          <?php if (array_key_exists("last_mention", $alert)) { ?>
+                          <div class="content-header-item">
+                          <dt><?= gettext('Date of last mention') ?></dt>
+                          <dd><?= $alert['last_mention'] ?></dd>
+                          </div>
+                          <?php } ?>
+
+                          <a href="/search/?q=<?= $alert['raw'] ?>" class="button small"><?= gettext('See results for this alert') ?></a>
+                        </dl>
+                    </div>
+
+                    <hr>
+
+                    <?php if ($alert["keywords"]) { ?>
+                    <div class="keyword-list alert-page-subsection">
+                      <h3 class="heading-with-bold-word">Keywords <span class="bold">included</span> in this alert:</h3>
+                      <ul>
+                        <?php foreach ($alert["keywords"] as $keyword) { ?>
+                        <li class="label label--primary-light"><?= _htmlspecialchars($keyword) ?>
+                          <i aria-hidden="true" role="img" class="fi-x"></i></li>
+                        <?php } ?>
+                      </ul>
+                      <div class="add-remove-tool display-none">
+                        <input type="text" placeholder="e.g.'freedom of information'">
+                        <button type="submit" class="prefix">add</button>
+                      </div>
+                    </div>
+                    <?php } ?>
+
+                    <?php if ($alert["exclusions"]) { ?>
+                    <div class="keyword-list excluded-keywords alert-page-subsection">
+                      <h3 class="heading-with-bold-word">Keywords <span class="bold">excluded</span> in this alert:</h3>
+                      <ul>
+                        <?php foreach ($alert["exclusions"] as $exclusion) { ?>
+                        <li class="label label--red"><?= _htmlspecialchars($exclusion) ?>
+                          <i aria-hidden="true" role="img" class="fi-x"></i></li>
+                        <?php } ?>
+                      </ul>
+                      <div class="add-remove-tool display-none">
+                        <input type="text" placeholder="e.g.'freedom of information'">
+                        <button type="submit" class="prefix">add</button>
+                      </div>
+                    </div>
+                    <?php } ?>
+
+                    <div class="keyword-list alert-page-subsection">
+                      <h3 class="display-none"><label for="sections">Which section should this alert apply to?</label></h3>
+                      <select name="sections" id="sections" class="display-none">
+                        <option value="uk-parliament">All sections</option>
+                        <option value="uk-parliament">UK Parliament</option>
+                        <option value="scottish-parliament">Scottish Parliament</option>
+                      </select>
+                      <h3 class="heading-with-bold-word">Which <span class="bold">section</span> should this alert apply to:</h3>
+                      <ul>
+                        <li class="label label--red">All sections
+                          <i aria-hidden="true" role="img" class="fi-x"></i></li>
+                      </ul>
+                    </div>
+
+                    <!-- Only to be displayed if there is a person in this query -->
+
+                    <?php if (array_key_exists('spokenby', $alert)) { ?>
+                      <div class="keyword-list alert-page-subsection">
+                        <h3 class="heading-with-bold-word"><?= gettext('This alert applies to the following <span class="bold">representative</span>') ?></h3>
+                        <ul>
+                        <?php foreach ($alert['spokenby'] as $speaker) { ?>
+                        <li class="label label--primary-light"><?= $speaker ?>
+                            <i aria-hidden="true" role="img" class="fi-x"></i></li>
+                        <?php } ?>
+                        </ul>
+                        <div class="add-remove-tool display-none">
+                          <input type="text" placeholder="e.g.'freedom of information'">
+                          <button type="submit" class="prefix">add</button>
+                        </div>
+                      </div>
+                    <?php } ?>
+
+                    <button class="display-none" style="margin: -1rem 0rem 3rem;">Save changes</button>
+                    <button class="display-none" style="margin: -1rem 0rem 3rem;">Discard changes</button>
+
+                  </div>
+                </div>
+                <?php } ?>
+
+                <hr>
+
+                <div class="alert-page-header alert-page-section">
+                  <div>
+                    <h2>Representative alerts</h2>
+                    <?php if ($current_mp) { ?>
+                      <ul class="alerts-manage__list">
+                          <li>
+                              <?= sprintf(gettext('You are not subscribed to an alert for your current MP, %s'), $current_mp->full_name()) ?>.
+                              <form action="<?= $actionurl ?>" method="post">
+                                  <input type="hidden" name="t" value="<?=_htmlspecialchars($token)?>">
+                                  <input type="hidden" name="pid" value="<?= $current_mp->person_id() ?>">
+                                  <input type="submit" class="button" value="<?= gettext('Subscribe') ?>">
+                              </form>
+                          </li>
+                      </ul>
+                    <?php } else { ?>
+                      <?php foreach ($own_member_alerts as $alert) { ?>
+                        <div class="alert-page-subsection">
+                          <h3 class="alert-page-subsection--heading"><?= gettext('Your MP') ?> ﹒ XXX</h3>
+
+                          <p class="alert-page-subsection--subtitle"><?= _htmlspecialchars($alert['criteria']) ?></p>
+                          <form action="<?= $actionurl ?>" method="POST">
+                            <input type="hidden" name="t" value="<?= _htmlspecialchars($alert['token']) ?>">
+                            <div>
+                              <?php if ($alert['status'] == 'unconfirmed') { ?>
+                                <button type="submit" class="button small" name="action" value="Confirm">
+                                  <span><?= gettext('Confirm alert') ?></span>
+                                  <i aria-hidden="true" class="fi-save"></i>
+                                </button>
+                              <?php } elseif ($alert['status'] == 'suspended') { ?>
+                              <button type="submit" class="button small" name="action" value="Resume">
+                                <span><?= gettext('Resume alert') ?></span>
+                                <i aria-hidden="true" class="fi-play"></i>
+                              </button>
+                              <?php } else { ?>
+                              <button typ="submit" class="button small" value="Suspend">
+                                <span><?= gettext('Suspend alert') ?></span>
+                                <i aria-hidden="true" class="fi-pause"></i>
+                              </button>
+                              <button typ="submit" class="button small" value="Delete">
+                                <span><?= gettext('Delete alert') ?></span>
+                                <i aria-hidden="true" class="fi-trash"></i>
+                              </button>
+                              <?php } ?>
+                            </div>
+                          </form>
+
+                          <?php if (!in_array(implode('', $alert['spokenby']), $all_keywords)) { ?>
+                          <p class="alert-page-subsection--subtitle">Alert when <?= _htmlspecialchars(implode(', ', $alert['spokenby'])) ?> is <strong>mentioned</strong></p>
+                          <form action="<?= $actionurl ?>" method="post">
+                            <input type="hidden" name="t" value="<?= _htmlspecialchars($token) ?>">
+                            <input type="hidden" name="speaker" value="<?= _htmlentities(implode('', $alert['spokenby'])) ?>">
+                            <button type="submit" class="button small" name="action" value="Subscribe">
+                              <?= gettext('Create new alert') ?>
+                              <i aria-hidden="true" role="img" class="fi-megaphone"></i>
+                            </button>
+                          </form>
+                        </div>
+                        <?php } ?>
+                      <?php } ?>
+                    <?php } ?>
+
+                    <?php foreach ($spoken_alerts as $alert) { ?>
+                        <div class="alert-page-subsection">
+                        <h3 class="alert-page-subsection--heading"><?= _htmlspecialchars(implode(', ', $alert['spokenby'])) ?></h3>
+
+                          <p class="alert-page-subsection--subtitle"><?= _htmlspecialchars($alert['criteria']) ?>
+                          <form action="<?= $actionurl ?>" method="POST">
+                            <input type="hidden" name="t" value="<?= _htmlspecialchars($alert['token']) ?>">
+                            <div>
+                              <?php if ($alert['status'] == 'unconfirmed') { ?>
+                                <button type="submit" class="button small" name="action" value="Confirm">
+                                  <span><?= gettext('Confirm alert') ?></span>
+                                  <i aria-hidden="true" class="fi-save"></i>
+                                </button>
+                              <?php } elseif ($alert['status'] == 'suspended') { ?>
+                              <button type="submit" class="button small" name="action" value="Resume">
+                                <span><?= gettext('Resume alert') ?></span>
+                                <i aria-hidden="true" class="fi-play"></i>
+                              </button>
+                              <?php } else { ?>
+                              <button type="submit" class="button small" name="action" value="Suspend">
+                                <span><?= gettext('Suspend alert') ?></span>
+                                <i aria-hidden="true" class="fi-pause"></i>
+                              </button>
+                              <button type="submit" class="button small" name="action" value="Delete">
+                                <span><?= gettext('Delete alert') ?></span>
+                                <i aria-hidden="true" class="fi-trash"></i>
+                              </button>
+                              <?php } ?>
+                            </div>
+                          </form>
+
+                          <?php if (!in_array(implode('', $alert['spokenby']), $all_keywords)) { ?>
+                          <p class="alert-page-subsection--subtitle">Alert when <?= _htmlspecialchars(implode(', ', $alert['spokenby'])) ?> is <strong>mentioned</strong></p>
+                          <form action="<?= $actionurl ?>" method="post">
+                            <input type="hidden" name="t" value="<?= _htmlspecialchars($token) ?>">
+                            <input type="hidden" name="speaker" value="<?= _htmlentities(implode('', $alert['spokenby'])) ?>">
+                            <button type="submit" class="button small" name="action" value="Subscribe">
+                              <?= gettext('Create new alert') ?>
+                              <i aria-hidden="true" role="img" class="fi-megaphone"></i>
+                            </button>
+                          </form>
+                        </div>
+                        <?php } ?>
+                    <?php } ?>
+                  </div>
+                  <a class="button">
+                    <?= gettext('Create new MP alert') ?>
+                    <i aria-hidden="true" role="img" class="fi-megaphone"></i>
+                  </a>
+              </div>
+              </div>
+              <?php } ?>
 
               <?php if ($pid) { ?>
                 <h3>
@@ -302,6 +550,7 @@
                 <h3><?= gettext('Request a new TheyWorkForYou email alert') ?></h3>
               <?php } ?>
 
+              <a name="new_alert"></a>
                 <form action="<?= $actionurl ?>" method="post" class="alert-page-main-inputs">
                   <?php if (!$email_verified) { ?>
                     <p>


### PR DESCRIPTION
This is the first PR in a series to update the look of the alerts page. It only updates the display of existing alerts and not the creation etc. It splits alerts into keyword alerts and representative alerts, although _x is mentioned_ alerts still count as keyword alerts for now.

It doesn't really touch any of the back end other to add some extra properties to alert objects.

It's also missing any translations for the new text.

I'm not proposing this is merged, but is used as the first part of several which will include changes to the alert creation UX.

Part of #1824 