### PR TITLE
Improved accessibility for button--negative

### DIFF
--- a/www/docs/style/sass/_twfy-mixins.scss
+++ b/www/docs/style/sass/_twfy-mixins.scss
@@ -274,19 +274,12 @@ button {
     }
 }
 
-.button--negative {
-  background-color: $colour_pale_red;
-  &:hover {
-      background-color: darken($colour_pale_red, 10%);
-  }
-}
-x
-.button--red {
-    background-color: red;
+.button--red, .button--negative {
+    background-color: $color_red;
     &:hover {
-        background-color: darken($colour_pale_red, 10%);
+        background-color: darken($color_red, 10%);
     }
-  }
+}
 
 .button--disabled,
 .button--disabled:hover {


### PR DESCRIPTION
Fixes: `button--negative` didn't had a low contrast ratio.

<img width="1163" alt="Screenshot 2024-10-15 at 09 51 09" src="https://github.com/user-attachments/assets/b1932e4c-a128-40da-b962-07d6d5e36f70">
