### PR TITLE
enable using announcements to add content to alerts

### DIFF
--- a/www/includes/easyparliament/templates/emails/alert_mailout.html
+++ b/www/includes/easyparliament/templates/emails/alert_mailout.html
@@ -103,6 +103,7 @@
             <a href="https://www.theyworkforyou.com">
                 <img src="images/theyworkforyou-logo.png" alt="" width="170">
             </a>
+            {_BANNER_}
             <h1 style="color: #333333; font-size: 21px; font-weight: 400; line-height: 21px; font-family: 'Source Sans Pro'; margin-top: 30px;">Email alerts</h1>
         </header>
 


### PR DESCRIPTION
If an announcement has a location of 'alerts' then include that at the top of all alerts. The HTML version either uses "Read more" or the `button_text` property for the link.

Announcements are added at the top of the alerts.

Part of #1825