### PR TITLE
Add basic formatting to new regmem data

### DIFF
--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -481,7 +481,6 @@
 
     .register {
         .regmemcategory {
-            border-top: 1px solid $borders;
             font-weight: $weight_semibold;
             margin-top: em-calc(16);
             margin-bottom: em-calc(8);
@@ -790,4 +789,26 @@ a[href^="https://www.publicwhip.org"] {
 .postcode-mp-image-wrapper {
     display: block;
     margin-top: 5px;
+}
+
+.interest-summary {
+    font-weight: bold;
+    margin-top: 1em;
+    margin-bottom: 1em;
+}
+
+.interest-child-items > div.interest-item > p.interest-summary {
+    font-weight: normal;
+    text-decoration: none;
+}
+
+.interest-details-list {
+    font-size: 0.8em;
+}
+
+.child-item-header {
+    text-decoration: underline;
+}
+.regmemitem > .interest-item {
+    border-top: 1px solid $borders;
 }

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -791,15 +791,18 @@ a[href^="https://www.publicwhip.org"] {
     margin-top: 5px;
 }
 
-.interest-summary {
+h4.interest-summary {
     font-weight: bold;
+    font-size: 1.3em;
     margin-top: 1em;
     margin-bottom: 1em;
 }
 
-.interest-child-items > div.interest-item > p.interest-summary {
-    font-weight: normal;
-    text-decoration: none;
+h6.interest-summary {
+    font-weight: bold;
+    font-size: 1em;
+    margin-top: 1em;
+    margin-bottom: 1em;
 }
 
 .interest-details-list {
@@ -807,7 +810,10 @@ a[href^="https://www.publicwhip.org"] {
 }
 
 .child-item-header {
-    text-decoration: underline;
+    font-weight: bold;
+    font-size: 1.2em;   
+    margin-top: 1em;
+    margin-bottom: 1em;
 }
 .regmemitem > .interest-item {
     border-top: 1px solid $borders;


### PR DESCRIPTION
The new regmem data has more markup for formatting, which is good because we're also dumping a lot more data into the display now.

This is a first pass at styling that data to make the structure (especially of parent/child items - which are new)- clearer. 

![image](https://github.com/user-attachments/assets/094bc628-ea6e-4c85-a5e2-716c9d980209)
