### PR TITLE
Devolved regmem

### DIFF
--- a/classes/DataClass/BaseCollection.php
+++ b/classes/DataClass/BaseCollection.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass;
+
+use Rutek\Dataclass\Collection;
+
+/**
+ * @template T
+ * @extends Collection<T>
+ */
+class BaseCollection extends Collection {
+    use BaseInterface;
+
+    public function isEmpty(): bool {
+        return empty($this->items);
+    }
+}

--- a/classes/DataClass/BaseInterface.php
+++ b/classes/DataClass/BaseInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace MySociety\TheyWorkForYou\DataClass;
+
+use function Rutek\Dataclass\transform;
+
+trait BaseInterface {
+    public static function fromJson(string $json): self {
+        $data = json_decode($json, true);
+        try {
+            return transform(static::class, $data);
+        } catch (\Exception $transformException) {
+            echo json_encode($transformException, JSON_PRETTY_PRINT);
+            throw $transformException;
+        }
+    }
+
+    public static function fromArray(array $data): self {
+        try {
+            return transform(static::class, $data);
+        } catch (\Exception $transformException) {
+            echo json_encode($transformException, JSON_PRETTY_PRINT);
+            throw $transformException;
+        }
+    }
+}

--- a/classes/DataClass/BaseModel.php
+++ b/classes/DataClass/BaseModel.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass;
+
+class BaseModel {
+    use BaseInterface;
+
+}

--- a/classes/DataClass/Regmem/Annotation.php
+++ b/classes/DataClass/Regmem/Annotation.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Regmem;
+
+use MySociety\TheyWorkForYou\DataClass\BaseModel;
+
+class Annotation extends BaseModel {
+    public string $author;
+    public string $type;
+    public string $content;
+    public string $date_added;
+    public string $content_format;
+}

--- a/classes/DataClass/Regmem/AnnotationList.php
+++ b/classes/DataClass/Regmem/AnnotationList.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Regmem;
+
+use MySociety\TheyWorkForYou\DataClass\BaseCollection;
+
+/**
+ * @extends BaseCollection<Annotation>
+ */
+class AnnotationList extends BaseCollection {
+    public function __construct(Annotation ...$annotations) {
+        $this->items = $annotations;
+    }
+}

--- a/classes/DataClass/Regmem/Category.php
+++ b/classes/DataClass/Regmem/Category.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Regmem;
+
+use MySociety\TheyWorkForYou\DataClass\BaseModel;
+
+class Category extends BaseModel {
+    public string $category_id;
+    public string $category_name;
+    public ?string $category_description;
+    public ?string $legislation_or_rule_name;
+    public ?string $legislation_or_rule_url;
+    public EntryList $summaries;
+    public EntryList $entries;
+
+    public function only_null_entries(): bool {
+        foreach ($this->entries as $entry) {
+            if (!$entry->null_entry) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/classes/DataClass/Regmem/CategoryList.php
+++ b/classes/DataClass/Regmem/CategoryList.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Regmem;
+
+use MySociety\TheyWorkForYou\DataClass\BaseCollection;
+
+/**
+ * @extends BaseCollection<Category>
+ */
+class CategoryList extends BaseCollection {
+    public function __construct(Category ...$categories) {
+        $this->items = $categories;
+    }
+}

--- a/classes/DataClass/Regmem/Detail.php
+++ b/classes/DataClass/Regmem/Detail.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Regmem;
+
+use MySociety\TheyWorkForYou\DataClass\BaseModel;
+
+class Detail extends BaseModel {
+    public string $source;
+    public ?string $slug = null;
+    public ?string $display_as = null;
+    public ?string $common_key = null;
+    public ?string $description = null;
+    public ?string $type = null;
+    public $value = null;
+    public AnnotationList $annotations;
+
+
+    public function has_value(): bool {
+        // if not null or empty string when removing trailing whitespace
+
+        // if string, trim and return false if empty
+        if (is_string($this->value)) {
+            return trim($this->value) !== '';
+        }
+
+        return $this->value !== null;
+    }
+
+    /**
+     * @return \Iterator<Detail>|
+     */
+    public function sub_details(): \Iterator {
+        $items = new \ArrayIterator();
+
+        if (!$this->type === 'container') {
+            return $items;
+        }
+
+
+        foreach ($this->value as $detail_group) {
+            foreach ($detail_group as $detail) {
+                $detail_obj = self::fromArray($detail);
+                $items[] = $detail_obj;
+            }
+        }
+
+        return $items;
+    }
+
+}

--- a/classes/DataClass/Regmem/DetailGroup.php
+++ b/classes/DataClass/Regmem/DetailGroup.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Regmem;
+
+use MySociety\TheyWorkForYou\DataClass\BaseCollection;
+
+/**
+ * @extends BaseCollection<Detail>
+ */
+class DetailGroup extends BaseCollection {
+    public function __construct(Detail ...$names) {
+        $this->items = $names;
+    }
+}

--- a/classes/DataClass/Regmem/DetailGroupList.php
+++ b/classes/DataClass/Regmem/DetailGroupList.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Regmem;
+
+use MySociety\TheyWorkForYou\DataClass\BaseCollection;
+
+/**
+ * @extends BaseCollection<DetailGroup>
+ */
+class DetailGroupList extends BaseCollection {
+    public function __construct(DetailGroup ...$groups) {
+        $this->items = $groups;
+    }
+}

--- a/classes/DataClass/Regmem/EntryList.php
+++ b/classes/DataClass/Regmem/EntryList.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Regmem;
+
+use MySociety\TheyWorkForYou\DataClass\BaseCollection;
+
+/**
+ * @extends BaseCollection<InfoEntry>
+ */
+class EntryList extends BaseCollection {
+    public function __construct(InfoEntry ...$entries) {
+        $this->items = $entries;
+    }
+}

--- a/classes/DataClass/Regmem/InfoEntry.php
+++ b/classes/DataClass/Regmem/InfoEntry.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Regmem;
+
+use MySociety\TheyWorkForYou\DataClass\BaseModel;
+
+class InfoEntry extends BaseModel {
+    public ?string $id = null;
+    public ?string $comparable_id = null;
+    public string $item_hash;
+    public string $content;
+    public string $content_format;
+    public string $info_type;
+    public bool $null_entry;
+    public ?string $date_registered = null;
+    public ?string $date_published = null;
+    public ?string $date_updated = null;
+    public ?string $date_received = null;
+    public AnnotationList $annotations;
+    public DetailGroup $details;
+    public EntryList $sub_entries;
+
+}

--- a/classes/DataClass/Regmem/Person.php
+++ b/classes/DataClass/Regmem/Person.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Mirrors pydantic model for deseralisation in a PHP context.
+ * For adding display related helper functions.
+ * @package TheyWorkForYou
+ */
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Regmem;
+
+use MySociety\TheyWorkForYou\DataClass\BaseModel;
+
+use InvalidArgumentException;
+
+class Person extends BaseModel {
+    public string $chamber;
+    public string $language;
+    public string $person_id;
+    public string $person_name;
+    public string $published_date;
+    public CategoryList $categories;
+
+    public function displayChamber(): string {
+        switch ($this->chamber) {
+            case 'house-of-commons':
+                return 'House of Commons';
+            case 'welsh-parliament':
+                return 'Senedd';
+            case 'scottish-parliament':
+                return 'Scottish Parliament';
+            case 'northern-ireland-assembly':
+                return 'Northern Ireland Assembly';
+            default:
+                return 'Unknown Chamber';
+        }
+    }
+
+    public function getCategoryFromId(string $categoryId): Category {
+        foreach ($this->categories as $category) {
+            if ($category->category_id === $categoryId) {
+                return $category;
+            }
+        }
+        throw new InvalidArgumentException("Category $categoryId not found in register");
+    }
+}

--- a/classes/DataClass/Regmem/PersonList.php
+++ b/classes/DataClass/Regmem/PersonList.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Regmem;
+
+use MySociety\TheyWorkForYou\DataClass\BaseCollection;
+
+/**
+ * @extends BaseCollection<Person>
+ */
+class PersonList extends BaseCollection {
+    public function __construct(Person ...$persons) {
+        $this->items = $persons;
+    }
+}

--- a/classes/DataClass/Regmem/Register.php
+++ b/classes/DataClass/Regmem/Register.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Regmem;
+
+use MySociety\TheyWorkForYou\DataClass\BaseModel;
+
+class Register extends BaseModel {
+    public string $chamber;
+    public string $language;
+    public string $published_date;
+    public AnnotationList $annotations;
+    public EntryList $summaries;
+    public PersonList $persons;
+}

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         }
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=7.4",
         "filp/whoops": "2.*",
         "ircmaxell/password-compat": "1.0.4",
         "facebook/graph-sdk": "^5.6",
@@ -13,14 +13,15 @@
         "predis/predis": "^1.1",
         "volnix/csrf": "^1.2",
         "phpmailer/phpmailer": "^6.5",
-        "erusev/parsedown": "^1.7"
+        "erusev/parsedown": "^1.7",
+        "rutek/dataclass": "^0.1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "9.*"
     },
     "config": {
         "platform": {
-            "php": "7.3"
+            "php": "7.4"
         },
         "allow-plugins": {
             "symfony/flex": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2b6639efe71fb1ca2d5e18c76db5f3b",
+    "content-hash": "e6c2434168db8fa0dd4b0ffd9d27bb67",
     "packages": [
         {
             "name": "erusev/parsedown",
@@ -432,6 +432,54 @@
                 "source": "https://github.com/php-fig/log/tree/1.1.4"
             },
             "time": "2021-05-03T11:20:27+00:00"
+        },
+        {
+            "name": "rutek/dataclass",
+            "version": "v0.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rutek/dataclass.git",
+                "reference": "ab4e3a31eddded1c3edf6df90ceec10c14f580bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rutek/dataclass/zipball/ab4e3a31eddded1c3edf6df90ceec10c14f580bc",
+                "reference": "ab4e3a31eddded1c3edf6df90ceec10c14f580bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.4",
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Rutek\\Dataclass\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Łukasz Rutkowski",
+                    "email": "lukasz.rutkowski@tauceti.email"
+                }
+            ],
+            "description": "Library for validation of type-hinted classes",
+            "support": {
+                "issues": "https://github.com/rutek/dataclass/issues",
+                "source": "https://github.com/rutek/dataclass/tree/v0.1.2"
+            },
+            "time": "2023-06-16T06:24:27+00:00"
         },
         {
             "name": "stripe/stripe-php",
@@ -2277,11 +2325,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3"
+        "php": ">=7.4"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.3"
+        "php": "7.4"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,6 +12,28 @@ files = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.8.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a"},
+    {file = "anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a"},
+]
+
+[package.dependencies]
+exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
+
+[package.extras]
+doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
+test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21)"]
+trio = ["trio (>=0.26.1)"]
+
+[[package]]
 name = "asgiref"
 version = "3.8.1"
 description = "ASGI specs, helper code, and adapters"
@@ -215,6 +237,20 @@ argon2 = ["argon2-cffi (>=19.1.0)"]
 bcrypt = ["bcrypt"]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.2.2"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
+
+[[package]]
 name = "greenlet"
 version = "3.0.3"
 description = "Lightweight in-process concurrent programming"
@@ -286,6 +322,63 @@ docs = ["Sphinx", "furo"]
 test = ["objgraph", "psutil"]
 
 [[package]]
+name = "h11"
+version = "0.14.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
+    {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.7"
+description = "A minimal low-level HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd"},
+    {file = "httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c"},
+]
+
+[package.dependencies]
+certifi = "*"
+h11 = ">=0.13,<0.15"
+
+[package.extras]
+asyncio = ["anyio (>=4.0,<5.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+trio = ["trio (>=0.22.0,<1.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.27.2"
+description = "The next generation HTTP client."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0"},
+    {file = "httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2"},
+]
+
+[package.dependencies]
+anyio = "*"
+certifi = "*"
+httpcore = "==1.*"
+idna = "*"
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotli", "brotlicffi"]
+cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (==1.*)"]
+zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
 name = "idna"
 version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -298,6 +391,180 @@ files = [
 
 [package.extras]
 all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.0.3"
+description = "Links recognition library with FULL unicode support."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048"},
+    {file = "linkify_it_py-2.0.3-py3-none-any.whl", hash = "sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79"},
+]
+
+[package.dependencies]
+uc-micro-py = "*"
+
+[package.extras]
+benchmark = ["pytest", "pytest-benchmark"]
+dev = ["black", "flake8", "isort", "pre-commit", "pyproject-flake8"]
+doc = ["myst-parser", "sphinx", "sphinx-book-theme"]
+test = ["coverage", "pytest", "pytest-cov"]
+
+[[package]]
+name = "lxml"
+version = "5.3.0"
+description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "lxml-5.3.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:dd36439be765e2dde7660212b5275641edbc813e7b24668831a5c8ac91180656"},
+    {file = "lxml-5.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ae5fe5c4b525aa82b8076c1a59d642c17b6e8739ecf852522c6321852178119d"},
+    {file = "lxml-5.3.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:501d0d7e26b4d261fca8132854d845e4988097611ba2531408ec91cf3fd9d20a"},
+    {file = "lxml-5.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb66442c2546446944437df74379e9cf9e9db353e61301d1a0e26482f43f0dd8"},
+    {file = "lxml-5.3.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9e41506fec7a7f9405b14aa2d5c8abbb4dbbd09d88f9496958b6d00cb4d45330"},
+    {file = "lxml-5.3.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f7d4a670107d75dfe5ad080bed6c341d18c4442f9378c9f58e5851e86eb79965"},
+    {file = "lxml-5.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41ce1f1e2c7755abfc7e759dc34d7d05fd221723ff822947132dc934d122fe22"},
+    {file = "lxml-5.3.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:44264ecae91b30e5633013fb66f6ddd05c006d3e0e884f75ce0b4755b3e3847b"},
+    {file = "lxml-5.3.0-cp310-cp310-manylinux_2_28_ppc64le.whl", hash = "sha256:3c174dc350d3ec52deb77f2faf05c439331d6ed5e702fc247ccb4e6b62d884b7"},
+    {file = "lxml-5.3.0-cp310-cp310-manylinux_2_28_s390x.whl", hash = "sha256:2dfab5fa6a28a0b60a20638dc48e6343c02ea9933e3279ccb132f555a62323d8"},
+    {file = "lxml-5.3.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:b1c8c20847b9f34e98080da785bb2336ea982e7f913eed5809e5a3c872900f32"},
+    {file = "lxml-5.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2c86bf781b12ba417f64f3422cfc302523ac9cd1d8ae8c0f92a1c66e56ef2e86"},
+    {file = "lxml-5.3.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:c162b216070f280fa7da844531169be0baf9ccb17263cf5a8bf876fcd3117fa5"},
+    {file = "lxml-5.3.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:36aef61a1678cb778097b4a6eeae96a69875d51d1e8f4d4b491ab3cfb54b5a03"},
+    {file = "lxml-5.3.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f65e5120863c2b266dbcc927b306c5b78e502c71edf3295dfcb9501ec96e5fc7"},
+    {file = "lxml-5.3.0-cp310-cp310-win32.whl", hash = "sha256:ef0c1fe22171dd7c7c27147f2e9c3e86f8bdf473fed75f16b0c2e84a5030ce80"},
+    {file = "lxml-5.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:052d99051e77a4f3e8482c65014cf6372e61b0a6f4fe9edb98503bb5364cfee3"},
+    {file = "lxml-5.3.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:74bcb423462233bc5d6066e4e98b0264e7c1bed7541fff2f4e34fe6b21563c8b"},
+    {file = "lxml-5.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a3d819eb6f9b8677f57f9664265d0a10dd6551d227afb4af2b9cd7bdc2ccbf18"},
+    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b8f5db71b28b8c404956ddf79575ea77aa8b1538e8b2ef9ec877945b3f46442"},
+    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c3406b63232fc7e9b8783ab0b765d7c59e7c59ff96759d8ef9632fca27c7ee4"},
+    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2ecdd78ab768f844c7a1d4a03595038c166b609f6395e25af9b0f3f26ae1230f"},
+    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:168f2dfcfdedf611eb285efac1516c8454c8c99caf271dccda8943576b67552e"},
+    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa617107a410245b8660028a7483b68e7914304a6d4882b5ff3d2d3eb5948d8c"},
+    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:69959bd3167b993e6e710b99051265654133a98f20cec1d9b493b931942e9c16"},
+    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_28_ppc64le.whl", hash = "sha256:bd96517ef76c8654446fc3db9242d019a1bb5fe8b751ba414765d59f99210b79"},
+    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_28_s390x.whl", hash = "sha256:ab6dd83b970dc97c2d10bc71aa925b84788c7c05de30241b9e96f9b6d9ea3080"},
+    {file = "lxml-5.3.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:eec1bb8cdbba2925bedc887bc0609a80e599c75b12d87ae42ac23fd199445654"},
+    {file = "lxml-5.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6a7095eeec6f89111d03dabfe5883a1fd54da319c94e0fb104ee8f23616b572d"},
+    {file = "lxml-5.3.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:6f651ebd0b21ec65dfca93aa629610a0dbc13dbc13554f19b0113da2e61a4763"},
+    {file = "lxml-5.3.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:f422a209d2455c56849442ae42f25dbaaba1c6c3f501d58761c619c7836642ec"},
+    {file = "lxml-5.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:62f7fdb0d1ed2065451f086519865b4c90aa19aed51081979ecd05a21eb4d1be"},
+    {file = "lxml-5.3.0-cp311-cp311-win32.whl", hash = "sha256:c6379f35350b655fd817cd0d6cbeef7f265f3ae5fedb1caae2eb442bbeae9ab9"},
+    {file = "lxml-5.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:9c52100e2c2dbb0649b90467935c4b0de5528833c76a35ea1a2691ec9f1ee7a1"},
+    {file = "lxml-5.3.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:e99f5507401436fdcc85036a2e7dc2e28d962550afe1cbfc07c40e454256a859"},
+    {file = "lxml-5.3.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:384aacddf2e5813a36495233b64cb96b1949da72bef933918ba5c84e06af8f0e"},
+    {file = "lxml-5.3.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:874a216bf6afaf97c263b56371434e47e2c652d215788396f60477540298218f"},
+    {file = "lxml-5.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:65ab5685d56914b9a2a34d67dd5488b83213d680b0c5d10b47f81da5a16b0b0e"},
+    {file = "lxml-5.3.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aac0bbd3e8dd2d9c45ceb82249e8bdd3ac99131a32b4d35c8af3cc9db1657179"},
+    {file = "lxml-5.3.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b369d3db3c22ed14c75ccd5af429086f166a19627e84a8fdade3f8f31426e52a"},
+    {file = "lxml-5.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c24037349665434f375645fa9d1f5304800cec574d0310f618490c871fd902b3"},
+    {file = "lxml-5.3.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:62d172f358f33a26d6b41b28c170c63886742f5b6772a42b59b4f0fa10526cb1"},
+    {file = "lxml-5.3.0-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:c1f794c02903c2824fccce5b20c339a1a14b114e83b306ff11b597c5f71a1c8d"},
+    {file = "lxml-5.3.0-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:5d6a6972b93c426ace71e0be9a6f4b2cfae9b1baed2eed2006076a746692288c"},
+    {file = "lxml-5.3.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:3879cc6ce938ff4eb4900d901ed63555c778731a96365e53fadb36437a131a99"},
+    {file = "lxml-5.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:74068c601baff6ff021c70f0935b0c7bc528baa8ea210c202e03757c68c5a4ff"},
+    {file = "lxml-5.3.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ecd4ad8453ac17bc7ba3868371bffb46f628161ad0eefbd0a855d2c8c32dd81a"},
+    {file = "lxml-5.3.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:7e2f58095acc211eb9d8b5771bf04df9ff37d6b87618d1cbf85f92399c98dae8"},
+    {file = "lxml-5.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e63601ad5cd8f860aa99d109889b5ac34de571c7ee902d6812d5d9ddcc77fa7d"},
+    {file = "lxml-5.3.0-cp312-cp312-win32.whl", hash = "sha256:17e8d968d04a37c50ad9c456a286b525d78c4a1c15dd53aa46c1d8e06bf6fa30"},
+    {file = "lxml-5.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:c1a69e58a6bb2de65902051d57fde951febad631a20a64572677a1052690482f"},
+    {file = "lxml-5.3.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c72e9563347c7395910de6a3100a4840a75a6f60e05af5e58566868d5eb2d6a"},
+    {file = "lxml-5.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e92ce66cd919d18d14b3856906a61d3f6b6a8500e0794142338da644260595cd"},
+    {file = "lxml-5.3.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d04f064bebdfef9240478f7a779e8c5dc32b8b7b0b2fc6a62e39b928d428e51"},
+    {file = "lxml-5.3.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c2fb570d7823c2bbaf8b419ba6e5662137f8166e364a8b2b91051a1fb40ab8b"},
+    {file = "lxml-5.3.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0c120f43553ec759f8de1fee2f4794452b0946773299d44c36bfe18e83caf002"},
+    {file = "lxml-5.3.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:562e7494778a69086f0312ec9689f6b6ac1c6b65670ed7d0267e49f57ffa08c4"},
+    {file = "lxml-5.3.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:423b121f7e6fa514ba0c7918e56955a1d4470ed35faa03e3d9f0e3baa4c7e492"},
+    {file = "lxml-5.3.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c00f323cc00576df6165cc9d21a4c21285fa6b9989c5c39830c3903dc4303ef3"},
+    {file = "lxml-5.3.0-cp313-cp313-manylinux_2_28_ppc64le.whl", hash = "sha256:1fdc9fae8dd4c763e8a31e7630afef517eab9f5d5d31a278df087f307bf601f4"},
+    {file = "lxml-5.3.0-cp313-cp313-manylinux_2_28_s390x.whl", hash = "sha256:658f2aa69d31e09699705949b5fc4719cbecbd4a97f9656a232e7d6c7be1a367"},
+    {file = "lxml-5.3.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:1473427aff3d66a3fa2199004c3e601e6c4500ab86696edffdbc84954c72d832"},
+    {file = "lxml-5.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a87de7dd873bf9a792bf1e58b1c3887b9264036629a5bf2d2e6579fe8e73edff"},
+    {file = "lxml-5.3.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0d7b36afa46c97875303a94e8f3ad932bf78bace9e18e603f2085b652422edcd"},
+    {file = "lxml-5.3.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:cf120cce539453ae086eacc0130a324e7026113510efa83ab42ef3fcfccac7fb"},
+    {file = "lxml-5.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:df5c7333167b9674aa8ae1d4008fa4bc17a313cc490b2cca27838bbdcc6bb15b"},
+    {file = "lxml-5.3.0-cp313-cp313-win32.whl", hash = "sha256:c802e1c2ed9f0c06a65bc4ed0189d000ada8049312cfeab6ca635e39c9608957"},
+    {file = "lxml-5.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:406246b96d552e0503e17a1006fd27edac678b3fcc9f1be71a2f94b4ff61528d"},
+    {file = "lxml-5.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8f0de2d390af441fe8b2c12626d103540b5d850d585b18fcada58d972b74a74e"},
+    {file = "lxml-5.3.0-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1afe0a8c353746e610bd9031a630a95bcfb1a720684c3f2b36c4710a0a96528f"},
+    {file = "lxml-5.3.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56b9861a71575f5795bde89256e7467ece3d339c9b43141dbdd54544566b3b94"},
+    {file = "lxml-5.3.0-cp36-cp36m-manylinux_2_28_x86_64.whl", hash = "sha256:9fb81d2824dff4f2e297a276297e9031f46d2682cafc484f49de182aa5e5df99"},
+    {file = "lxml-5.3.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:2c226a06ecb8cdef28845ae976da407917542c5e6e75dcac7cc33eb04aaeb237"},
+    {file = "lxml-5.3.0-cp36-cp36m-musllinux_1_2_x86_64.whl", hash = "sha256:7d3d1ca42870cdb6d0d29939630dbe48fa511c203724820fc0fd507b2fb46577"},
+    {file = "lxml-5.3.0-cp36-cp36m-win32.whl", hash = "sha256:094cb601ba9f55296774c2d57ad68730daa0b13dc260e1f941b4d13678239e70"},
+    {file = "lxml-5.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:eafa2c8658f4e560b098fe9fc54539f86528651f61849b22111a9b107d18910c"},
+    {file = "lxml-5.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cb83f8a875b3d9b458cada4f880fa498646874ba4011dc974e071a0a84a1b033"},
+    {file = "lxml-5.3.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:25f1b69d41656b05885aa185f5fdf822cb01a586d1b32739633679699f220391"},
+    {file = "lxml-5.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:23e0553b8055600b3bf4a00b255ec5c92e1e4aebf8c2c09334f8368e8bd174d6"},
+    {file = "lxml-5.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ada35dd21dc6c039259596b358caab6b13f4db4d4a7f8665764d616daf9cc1d"},
+    {file = "lxml-5.3.0-cp37-cp37m-manylinux_2_28_aarch64.whl", hash = "sha256:81b4e48da4c69313192d8c8d4311e5d818b8be1afe68ee20f6385d0e96fc9512"},
+    {file = "lxml-5.3.0-cp37-cp37m-manylinux_2_28_x86_64.whl", hash = "sha256:2bc9fd5ca4729af796f9f59cd8ff160fe06a474da40aca03fcc79655ddee1a8b"},
+    {file = "lxml-5.3.0-cp37-cp37m-musllinux_1_2_aarch64.whl", hash = "sha256:07da23d7ee08577760f0a71d67a861019103e4812c87e2fab26b039054594cc5"},
+    {file = "lxml-5.3.0-cp37-cp37m-musllinux_1_2_x86_64.whl", hash = "sha256:ea2e2f6f801696ad7de8aec061044d6c8c0dd4037608c7cab38a9a4d316bfb11"},
+    {file = "lxml-5.3.0-cp37-cp37m-win32.whl", hash = "sha256:5c54afdcbb0182d06836cc3d1be921e540be3ebdf8b8a51ee3ef987537455f84"},
+    {file = "lxml-5.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:f2901429da1e645ce548bf9171784c0f74f0718c3f6150ce166be39e4dd66c3e"},
+    {file = "lxml-5.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c56a1d43b2f9ee4786e4658c7903f05da35b923fb53c11025712562d5cc02753"},
+    {file = "lxml-5.3.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ee8c39582d2652dcd516d1b879451500f8db3fe3607ce45d7c5957ab2596040"},
+    {file = "lxml-5.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0fdf3a3059611f7585a78ee10399a15566356116a4288380921a4b598d807a22"},
+    {file = "lxml-5.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:146173654d79eb1fc97498b4280c1d3e1e5d58c398fa530905c9ea50ea849b22"},
+    {file = "lxml-5.3.0-cp38-cp38-manylinux_2_28_aarch64.whl", hash = "sha256:0a7056921edbdd7560746f4221dca89bb7a3fe457d3d74267995253f46343f15"},
+    {file = "lxml-5.3.0-cp38-cp38-manylinux_2_28_x86_64.whl", hash = "sha256:9e4b47ac0f5e749cfc618efdf4726269441014ae1d5583e047b452a32e221920"},
+    {file = "lxml-5.3.0-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:f914c03e6a31deb632e2daa881fe198461f4d06e57ac3d0e05bbcab8eae01945"},
+    {file = "lxml-5.3.0-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:213261f168c5e1d9b7535a67e68b1f59f92398dd17a56d934550837143f79c42"},
+    {file = "lxml-5.3.0-cp38-cp38-win32.whl", hash = "sha256:218c1b2e17a710e363855594230f44060e2025b05c80d1f0661258142b2add2e"},
+    {file = "lxml-5.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:315f9542011b2c4e1d280e4a20ddcca1761993dda3afc7a73b01235f8641e903"},
+    {file = "lxml-5.3.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:1ffc23010330c2ab67fac02781df60998ca8fe759e8efde6f8b756a20599c5de"},
+    {file = "lxml-5.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2b3778cb38212f52fac9fe913017deea2fdf4eb1a4f8e4cfc6b009a13a6d3fcc"},
+    {file = "lxml-5.3.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b0c7a688944891086ba192e21c5229dea54382f4836a209ff8d0a660fac06be"},
+    {file = "lxml-5.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:747a3d3e98e24597981ca0be0fd922aebd471fa99d0043a3842d00cdcad7ad6a"},
+    {file = "lxml-5.3.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86a6b24b19eaebc448dc56b87c4865527855145d851f9fc3891673ff97950540"},
+    {file = "lxml-5.3.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b11a5d918a6216e521c715b02749240fb07ae5a1fefd4b7bf12f833bc8b4fe70"},
+    {file = "lxml-5.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:68b87753c784d6acb8a25b05cb526c3406913c9d988d51f80adecc2b0775d6aa"},
+    {file = "lxml-5.3.0-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:109fa6fede314cc50eed29e6e56c540075e63d922455346f11e4d7a036d2b8cf"},
+    {file = "lxml-5.3.0-cp39-cp39-manylinux_2_28_ppc64le.whl", hash = "sha256:02ced472497b8362c8e902ade23e3300479f4f43e45f4105c85ef43b8db85229"},
+    {file = "lxml-5.3.0-cp39-cp39-manylinux_2_28_s390x.whl", hash = "sha256:6b038cc86b285e4f9fea2ba5ee76e89f21ed1ea898e287dc277a25884f3a7dfe"},
+    {file = "lxml-5.3.0-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:7437237c6a66b7ca341e868cda48be24b8701862757426852c9b3186de1da8a2"},
+    {file = "lxml-5.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:7f41026c1d64043a36fda21d64c5026762d53a77043e73e94b71f0521939cc71"},
+    {file = "lxml-5.3.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:482c2f67761868f0108b1743098640fbb2a28a8e15bf3f47ada9fa59d9fe08c3"},
+    {file = "lxml-5.3.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:1483fd3358963cc5c1c9b122c80606a3a79ee0875bcac0204149fa09d6ff2727"},
+    {file = "lxml-5.3.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2dec2d1130a9cda5b904696cec33b2cfb451304ba9081eeda7f90f724097300a"},
+    {file = "lxml-5.3.0-cp39-cp39-win32.whl", hash = "sha256:a0eabd0a81625049c5df745209dc7fcef6e2aea7793e5f003ba363610aa0a3ff"},
+    {file = "lxml-5.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:89e043f1d9d341c52bf2af6d02e6adde62e0a46e6755d5eb60dc6e4f0b8aeca2"},
+    {file = "lxml-5.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7b1cd427cb0d5f7393c31b7496419da594fe600e6fdc4b105a54f82405e6626c"},
+    {file = "lxml-5.3.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51806cfe0279e06ed8500ce19479d757db42a30fd509940b1701be9c86a5ff9a"},
+    {file = "lxml-5.3.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee70d08fd60c9565ba8190f41a46a54096afa0eeb8f76bd66f2c25d3b1b83005"},
+    {file = "lxml-5.3.0-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:8dc2c0395bea8254d8daebc76dcf8eb3a95ec2a46fa6fae5eaccee366bfe02ce"},
+    {file = "lxml-5.3.0-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:6ba0d3dcac281aad8a0e5b14c7ed6f9fa89c8612b47939fc94f80b16e2e9bc83"},
+    {file = "lxml-5.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:6e91cf736959057f7aac7adfc83481e03615a8e8dd5758aa1d95ea69e8931dba"},
+    {file = "lxml-5.3.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:94d6c3782907b5e40e21cadf94b13b0842ac421192f26b84c45f13f3c9d5dc27"},
+    {file = "lxml-5.3.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c300306673aa0f3ed5ed9372b21867690a17dba38c68c44b287437c362ce486b"},
+    {file = "lxml-5.3.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d9b952e07aed35fe2e1a7ad26e929595412db48535921c5013edc8aa4a35ce"},
+    {file = "lxml-5.3.0-pp37-pypy37_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:01220dca0d066d1349bd6a1726856a78f7929f3878f7e2ee83c296c69495309e"},
+    {file = "lxml-5.3.0-pp37-pypy37_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2d9b8d9177afaef80c53c0a9e30fa252ff3036fb1c6494d427c066a4ce6a282f"},
+    {file = "lxml-5.3.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:20094fc3f21ea0a8669dc4c61ed7fa8263bd37d97d93b90f28fc613371e7a875"},
+    {file = "lxml-5.3.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ace2c2326a319a0bb8a8b0e5b570c764962e95818de9f259ce814ee666603f19"},
+    {file = "lxml-5.3.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92e67a0be1639c251d21e35fe74df6bcc40cba445c2cda7c4a967656733249e2"},
+    {file = "lxml-5.3.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd5350b55f9fecddc51385463a4f67a5da829bc741e38cf689f38ec9023f54ab"},
+    {file = "lxml-5.3.0-pp38-pypy38_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:4c1fefd7e3d00921c44dc9ca80a775af49698bbfd92ea84498e56acffd4c5469"},
+    {file = "lxml-5.3.0-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:71a8dd38fbd2f2319136d4ae855a7078c69c9a38ae06e0c17c73fd70fc6caad8"},
+    {file = "lxml-5.3.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:97acf1e1fd66ab53dacd2c35b319d7e548380c2e9e8c54525c6e76d21b1ae3b1"},
+    {file = "lxml-5.3.0-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:68934b242c51eb02907c5b81d138cb977b2129a0a75a8f8b60b01cb8586c7b21"},
+    {file = "lxml-5.3.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b710bc2b8292966b23a6a0121f7a6c51d45d2347edcc75f016ac123b8054d3f2"},
+    {file = "lxml-5.3.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18feb4b93302091b1541221196a2155aa296c363fd233814fa11e181adebc52f"},
+    {file = "lxml-5.3.0-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:3eb44520c4724c2e1a57c0af33a379eee41792595023f367ba3952a2d96c2aab"},
+    {file = "lxml-5.3.0-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:609251a0ca4770e5a8768ff902aa02bf636339c5a93f9349b48eb1f606f7f3e9"},
+    {file = "lxml-5.3.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:516f491c834eb320d6c843156440fe7fc0d50b33e44387fcec5b02f0bc118a4c"},
+    {file = "lxml-5.3.0.tar.gz", hash = "sha256:4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f"},
+]
+
+[package.extras]
+cssselect = ["cssselect (>=0.7)"]
+html-clean = ["lxml-html-clean"]
+html5 = ["html5lib"]
+htmlsoup = ["BeautifulSoup4"]
+source = ["Cython (>=3.0.11)"]
 
 [[package]]
 name = "mailchimp-marketing"
@@ -333,6 +600,8 @@ files = [
 ]
 
 [package.dependencies]
+linkify-it-py = {version = ">=1,<3", optional = true, markers = "extra == \"linkify\""}
+mdit-py-plugins = {version = "*", optional = true, markers = "extra == \"plugins\""}
 mdurl = ">=0.1,<1.0"
 
 [package.extras]
@@ -346,6 +615,25 @@ rtd = ["jupyter_sphinx", "mdit-py-plugins", "myst-parser", "pyyaml", "sphinx", "
 testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
+name = "mdit-py-plugins"
+version = "0.4.2"
+description = "Collection of plugins for markdown-it-py"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mdit_py_plugins-0.4.2-py3-none-any.whl", hash = "sha256:0c673c3f889399a33b95e88d2f0d111b4447bdfea7f237dab2d488f459835636"},
+    {file = "mdit_py_plugins-0.4.2.tar.gz", hash = "sha256:5f2cd1fdb606ddf152d37ec30e46101a60512bc0e5fa1a7002c36647b09e26b5"},
+]
+
+[package.dependencies]
+markdown-it-py = ">=1.0.0,<4.0.0"
+
+[package.extras]
+code-style = ["pre-commit"]
+rtd = ["myst-parser", "sphinx-book-theme"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 description = "Markdown URL utilities"
@@ -355,6 +643,30 @@ files = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
 ]
+
+[[package]]
+name = "mysoc-validator"
+version = "1.0.0"
+description = "Pydantic validators for mySociety democracy types"
+optional = false
+python-versions = "<4.0,>=3.9"
+files = [
+    {file = "mysoc_validator-1.0.0-py3-none-any.whl", hash = "sha256:80bc84675c3390040940f29d4443bc7820233a9eaa91b6565aa6a866ab541810"},
+    {file = "mysoc_validator-1.0.0.tar.gz", hash = "sha256:4ef7c10d37eb8ecc722a357b089964ce4c8d757c72ae1de2533f56370cfc2816"},
+]
+
+[package.dependencies]
+click = ">=8.1.0,<9.0.0"
+httpx = ">=0.27.2,<0.28.0"
+lxml = ">=4.0.0,<6.0.0"
+nest-asyncio = ">=1.6.0,<2.0.0"
+pydantic = ">=2.7.1,<3.0.0"
+requests = ">=2.32.3,<3.0.0"
+rich = ">=10.0.0,<14.0.0"
+tqdm = ">=4.67.1,<5.0.0"
+trogon = ">=0.6.0,<0.7.0"
+typer = ">=0.12.3,<0.13.0"
+typing-extensions = ">=4.11.0,<5.0.0"
 
 [[package]]
 name = "mysqlclient"
@@ -372,6 +684,17 @@ files = [
     {file = "mysqlclient-2.2.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:4e80dcad884dd6e14949ac6daf769123223a52a6805345608bf49cdaf7bc8b3a"},
     {file = "mysqlclient-2.2.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:9d3310295cb682232cadc28abd172f406c718b9ada41d2371259098ae37779d3"},
     {file = "mysqlclient-2.2.4.tar.gz", hash = "sha256:33bc9fb3464e7d7c10b1eaf7336c5ff8f2a3d3b88bab432116ad2490beb3bf41"},
+]
+
+[[package]]
+name = "nest-asyncio"
+version = "1.6.0"
+description = "Patch asyncio to allow nested event loops"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c"},
+    {file = "nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe"},
 ]
 
 [[package]]
@@ -491,6 +814,22 @@ spss = ["pyreadstat (>=1.2.0)"]
 sql-other = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)"]
 test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.9.2)"]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.6"
+description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
+    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
+]
+
+[package.extras]
+docs = ["furo (>=2024.8.6)", "proselint (>=0.14)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-cov (>=5)", "pytest-mock (>=3.14)"]
+type = ["mypy (>=1.11.2)"]
 
 [[package]]
 name = "pyarrow"
@@ -870,6 +1209,17 @@ files = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.32"
 description = "Database Abstraction Library"
@@ -972,14 +1322,73 @@ dev = ["build", "hatch"]
 doc = ["sphinx"]
 
 [[package]]
+name = "textual"
+version = "1.0.0"
+description = "Modern Text User Interface framework"
+optional = false
+python-versions = "<4.0.0,>=3.8.1"
+files = [
+    {file = "textual-1.0.0-py3-none-any.whl", hash = "sha256:2d4a701781c05104925e463ae370c630567c70c2880e92ab838052e3e23c986f"},
+    {file = "textual-1.0.0.tar.gz", hash = "sha256:bec9fe63547c1c552569d1b75d309038b7d456c03f86dfa3706ddb099b151399"},
+]
+
+[package.dependencies]
+markdown-it-py = {version = ">=2.1.0", extras = ["linkify", "plugins"]}
+platformdirs = ">=3.6.0,<5"
+rich = ">=13.3.3"
+typing-extensions = ">=4.4.0,<5.0.0"
+
+[package.extras]
+syntax = ["tree-sitter (>=0.23.0)", "tree-sitter-bash (>=0.23.0)", "tree-sitter-css (>=0.23.0)", "tree-sitter-go (>=0.23.0)", "tree-sitter-html (>=0.23.0)", "tree-sitter-java (>=0.23.0)", "tree-sitter-javascript (>=0.23.0)", "tree-sitter-json (>=0.24.0)", "tree-sitter-markdown (>=0.3.0)", "tree-sitter-python (>=0.23.0)", "tree-sitter-regex (>=0.24.0)", "tree-sitter-rust (>=0.23.0)", "tree-sitter-sql (>=0.3.0)", "tree-sitter-toml (>=0.6.0)", "tree-sitter-xml (>=0.7.0)", "tree-sitter-yaml (>=0.6.0)"]
+
+[[package]]
+name = "tqdm"
+version = "4.67.1"
+description = "Fast, Extensible Progress Meter"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
+    {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["nbval", "pytest (>=6)", "pytest-asyncio (>=0.24)", "pytest-cov", "pytest-timeout"]
+discord = ["requests"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
+
+[[package]]
+name = "trogon"
+version = "0.6.0"
+description = "Automatically generate a Textual TUI for your Click CLI"
+optional = false
+python-versions = "<4.0.0,>=3.8.1"
+files = [
+    {file = "trogon-0.6.0-py3-none-any.whl", hash = "sha256:fb5b6c25acd7a0eaba8d2cd32a57f1d80c26413cea737dad7a4eebcda56060e0"},
+    {file = "trogon-0.6.0.tar.gz", hash = "sha256:fd1abfeb7b15d79d6e6cfc9e724aad2a2728812e4713a744d975f133e7ec73a4"},
+]
+
+[package.dependencies]
+click = ">=8.0.0"
+textual = ">=0.61.0"
+
+[package.extras]
+typer = ["typer (>=0.9.0)"]
+
+[[package]]
 name = "typer"
-version = "0.15.1"
+version = "0.12.5"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typer-0.15.1-py3-none-any.whl", hash = "sha256:7994fb7b8155b64d3402518560648446072864beefd44aa2dc36972a5972e847"},
-    {file = "typer-0.15.1.tar.gz", hash = "sha256:a0588c0a7fa68a1978a069818657778f86abe6ff5ea6abf472f940a08bfe4f0a"},
+    {file = "typer-0.12.5-py3-none-any.whl", hash = "sha256:62fe4e471711b147e3365034133904df3e235698399bc4de2b36c8579298d52b"},
+    {file = "typer-0.12.5.tar.gz", hash = "sha256:f592f089bedcc8ec1b974125d64851029c3b1af145f04aca64d69410f0c9b722"},
 ]
 
 [package.dependencies]
@@ -1011,6 +1420,20 @@ files = [
 ]
 
 [[package]]
+name = "uc-micro-py"
+version = "1.0.3"
+description = "Micro subset of unicode data files for linkify-it-py projects."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "uc-micro-py-1.0.3.tar.gz", hash = "sha256:d321b92cff673ec58027c04015fcaa8bb1e005478643ff4a500882eaab88c48a"},
+    {file = "uc_micro_py-1.0.3-py3-none-any.whl", hash = "sha256:db1dffff340817673d7b466ec86114a9dc0e9d4d9b5ba229d9d60e5c12600cd5"},
+]
+
+[package.extras]
+test = ["coverage", "pytest", "pytest-cov"]
+
+[[package]]
 name = "urllib3"
 version = "2.2.3"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1030,4 +1453,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "e60700446c474d5e984f160564b1e43f41d6056c6eb269fbf6cb166813c0fa73"
+content-hash = "e7ea8a489ce54c871fe82574a5f6651da90776dae494ba8c9b5cc1ccf06cef52"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ pydantic = "^2.8.2"
 sqlalchemy = "^2.0.32"
 django = ">=4.2,<5.0"
 mailchimp-marketing = {git = "https://github.com/mailchimp/mailchimp-marketing-python.git"}
-typer = "^0.15.1"
+typer = "^0.12.0"
+mysoc-validator = "^1.0.0"
 
 
 [tool.poetry.group.dev.dependencies]
@@ -26,6 +27,7 @@ ruff = "^0.6.1"
 
 [tool.poetry.scripts]
 contact-io = "twfy_tools.utils.contact_io:app"
+personinfo = "twfy_tools.utils.personinfo:app"
 
 [build-system]
 requires = ["poetry-core"]

--- a/scripts/dailyupdate
+++ b/scripts/dailyupdate
@@ -28,6 +28,9 @@ unless ($staging) {
 chdir $FindBin::Bin;
 system './mpinfoin.pl';
 
+# Update register of interests
+system "scripts/personinfo upload-all-regmem >> $cron_log";
+
 # update individual division votes
 system "./json2db.pl >> $cron_log";
 

--- a/scripts/personinfo
+++ b/scripts/personinfo
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+poetry run python -m twfy_tools.utils.personinfo "$@"

--- a/src/twfy_tools/db/models.py
+++ b/src/twfy_tools/db/models.py
@@ -90,3 +90,25 @@ class User(UnmanagedDataclassModel, db_table="users"):
         Remove an optin value from the user.
         """
         self.optin &= ~optin_value
+
+
+class PersonInfo(
+    UnmanagedDataclassModel,
+    db_table="personinfo",
+    unique_together=(("person_id", "data_key"),),
+):
+    person_id: int = field(models.IntegerField, primary_key=True)
+    data_key: str = field(models.CharField, max_length=100, primary_key=True)
+    data_value: str = field(models.TextField, default="")
+    lastupdate: datetime.datetime = field(models.DateTimeField, auto_now=True)
+
+    def __str__(self):
+        return f"{self.person_id}: {self.data_key}"
+
+    def str_data_value(self):
+        if isinstance(self.data_value, str):
+            return self.data_value
+        elif isinstance(self.data_value, (int, float)):
+            return str(self.data_value)
+        else:
+            raise ValueError(f"type: {type(self.data_value)} not supported")

--- a/src/twfy_tools/db/utils.py
+++ b/src/twfy_tools/db/utils.py
@@ -1,0 +1,162 @@
+import json
+from itertools import groupby
+from typing import Any, Mapping, Union
+
+from django.utils import timezone
+
+import rich
+from mysoc_validator.models.interests import RegmemPerson
+from pydantic import BaseModel
+
+from .models import PersonInfo
+
+# specify the validation model to be applied to a common key prefix
+validation_lookup: dict[str, type[BaseModel]] = {
+    "person_regmem_": RegmemPerson,
+}
+
+
+def upload_person_info_values(
+    values: list[PersonInfo],
+    *,
+    remove_absent: bool = False,
+    quiet: bool = False,
+    batch_size: int = 500,
+):
+    """
+    Upload a list of PersonInfo values to the database.
+    Checks which values are already present to do efficient bulk updates and creates.
+    The remove_absent bool will remove any entries for person-id/key pairs not present in this upload.
+    e.g. if you always reupload the same file, and you've remove an entry from the file.
+    This being true will remove the entry from the database.
+    """
+
+    values = sorted(values, key=lambda x: x.data_key)
+
+    now = timezone.now()
+
+    for key, group in groupby(values, key=lambda x: x.data_key):
+        # get all person_ids for this key
+        group = list(group)
+        for g in group:
+            g.data_value = g.str_data_value()
+        rich.print(f"Uploading [blue]{len(group)}[/blue] values for {key}")
+        value_lookup = {x.person_id: x for x in group}
+        person_ids = [x.person_id for x in group]
+
+        existing_entries = list(
+            PersonInfo.objects.filter(data_key=key, person_id__in=person_ids)
+        )
+        existing_person_ids = [x.person_id for x in existing_entries]
+        to_update = []
+        same_value_count = 0
+        for e in existing_entries:
+            new_value = value_lookup[e.person_id].data_value
+            old_value = e.data_value
+            if new_value != old_value:
+                e.data_value = new_value
+                e.lastupdate = now
+                to_update.append(e)
+            else:
+                same_value_count += 1
+
+        new_entries = [x for x in group if x.person_id not in existing_person_ids]
+
+        for n in new_entries:
+            n.lastupdate = now
+
+        if not quiet:
+            rich.print(
+                f"Found [blue]{len(existing_person_ids)}[/blue] existing entries for people"
+            )
+
+        # update existing entries
+        if not quiet:
+            rich.print(f"Updating [blue]{len(to_update)}[/blue] entries")
+        PersonInfo.objects.filter(data_key=key).bulk_update(
+            to_update, ["data_value", "lastupdate"], batch_size=batch_size
+        )
+
+        # create new entries
+        if not quiet:
+            rich.print(f"Creating [green]{len(new_entries)}[/green] entries")
+        PersonInfo.objects.bulk_create(new_entries, batch_size=batch_size)
+
+        if remove_absent:
+            deleted_count, _ = (
+                PersonInfo.objects.filter(data_key=key)
+                .exclude(person_id__in=person_ids)
+                .delete()
+            )
+            if deleted_count and not quiet:
+                rich.print(f"Deleted [red]{deleted_count}[/red] entries")
+
+
+def upload_person_info(
+    key_name: str,
+    person_id_to_value: Mapping[int, Union[str, dict[Any, Any], list[Any], BaseModel]],
+    *,
+    validate: bool = True,
+    remove_absent: bool = False,
+    quiet: bool = False,
+    batch_size: int = 500,
+):
+    """
+    Prepare a set of data (via dicts or pydantic models) to be uploaded to personinfo table.
+    """
+    validation_model = None
+
+    if validate:
+        for key_prefix, value in validation_lookup.items():
+            if key_name.startswith(key_prefix):
+                validation_model = value
+                break
+
+        if not quiet:
+            if validation_model:
+                rich.print(f"Validating with {validation_model.__name__}")
+            else:
+                rich.print(f"No validation model specified for {key_name}")
+
+    items = []
+    now = timezone.now()
+    for person_id, value in person_id_to_value.items():
+        if validation_model:
+            # enforce validation check if validated
+            if isinstance(value, BaseModel):
+                if not isinstance(value, validation_model):
+                    raise ValueError(
+                        f"Value for {key_name} is not a {validation_model.__name__}"
+                    )
+            elif isinstance(value, dict):
+                validation_model.model_validate(value)
+            else:
+                # if validation is on, don't want to process non-dicts
+                raise ValueError(f"Value for {key_name} is not a dict or a valid model")
+
+        if isinstance(value, BaseModel):
+            str_value = value.model_dump_json()
+        elif isinstance(value, (dict, list)):
+            str_value = json.dumps(value)
+        elif isinstance(value, (int, float)):
+            str_value = str(value)
+        elif isinstance(value, str):
+            str_value = value
+        else:
+            raise ValueError(f"type: {type(value)} not supported")
+
+        items.append(
+            PersonInfo(
+                person_id=person_id,
+                data_key=key_name,
+                data_value=str_value,
+                lastupdate=now,
+            )
+        )
+
+    if not quiet:
+        rich.print(f"Uploading [blue]{len(items)}[/blue] items for {key_name}")
+
+    upload_person_info_values(
+        items, remove_absent=remove_absent, quiet=quiet, batch_size=batch_size
+    )

--- a/src/twfy_tools/utils/personinfo.py
+++ b/src/twfy_tools/utils/personinfo.py
@@ -1,0 +1,115 @@
+#!.venv/bin/python
+
+from typing import Literal, Optional
+
+import rich
+from mysoc_validator.models.interests import RegmemPerson, RegmemRegister
+from tqdm import tqdm
+from typer import Typer
+from typing_extensions import TypeGuard
+
+from twfy_tools.common.config import config
+from twfy_tools.db.utils import upload_person_info
+
+app = Typer(pretty_exceptions_enable=False)
+
+
+def is_valid_language(lang: str) -> TypeGuard[Literal["en", "cy"]]:
+    """
+    Typeguard to convert confirm string in Literal["en", "cy"]
+    """
+    return lang in {"en", "cy"}
+
+
+def prepare_chamber_regmem(
+    chamber: str = "house-of-commons",
+    *,
+    language: Literal["en", "cy"] = "en",
+    quiet: bool = False,
+):
+    """
+    Extract the most recent register of interest for a person in this chamber and send for upload
+    to the database.
+    """
+    if not quiet:
+        rich.print(f"Processing {chamber} register of members' interests")
+
+    source_path = config.RAWDATA / "scrapedjson" / "universal_format_regmem" / chamber
+
+    if chamber == "senedd":
+        source_path = source_path / language
+
+    id_to_person: dict[int, RegmemPerson] = {}
+
+    for file in tqdm(
+        list(source_path.glob("*.json")), disable=quiet, desc="Processing sources"
+    ):
+        register = RegmemRegister.from_path(file)
+        for person in register.persons:
+            int_id = int(person.person_id.split("/")[-1])
+            if int_id not in id_to_person:
+                id_to_person[int_id] = person
+            else:
+                # check if we have a more modern version
+                existing = id_to_person[int_id]
+                if person.published_date > existing.published_date:
+                    id_to_person[int_id] = person
+
+    if not quiet:
+        rich.print(f"Found [blue]{len(id_to_person)}[/blue] person items to upload")
+
+    upload_person_info(
+        f"person_regmem_{chamber}_{language}",
+        id_to_person,
+        remove_absent=True,
+        quiet=quiet,
+    )
+
+
+@app.command()
+def upload_all_regmem(quiet: bool = False):
+    """
+    Upload regmems for all known chambers
+    """
+
+    # english chambers
+    chambers = [
+        "house-of-commons",
+        "scottish-parliament",
+        "northern-ireland-assembly",
+        "senedd",
+    ]
+    for chamber in chambers:
+        prepare_chamber_regmem(chamber, quiet=quiet, language="en")
+
+    # welsh chambers
+    prepare_chamber_regmem("senedd", quiet=quiet, language="cy")
+
+
+@app.command()
+def upload_regmem(
+    quiet: bool = False,
+    all: bool = False,
+    chamber: Optional[str] = None,
+    language: str = "en",
+):
+    """
+    Upload register of members' interests to the database for one chamber
+    """
+
+    if all:
+        upload_all_regmem(quiet=quiet)
+    else:
+        if chamber is None:
+            raise ValueError("You must specify a chamber if not uploading all")
+        if is_valid_language(language):
+            prepare_chamber_regmem(chamber, quiet=quiet, language=language)
+
+
+@app.callback()
+def callback():
+    pass
+
+
+if __name__ == "__main__":
+    app()

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -995,18 +995,35 @@ function person_pbc_membership($member) {
     return $out;
 }
 
+function person_register_interests_from_key($key, $extra_info): ?MySociety\TheyWorkForYou\DataClass\Regmem\Person {
+    $lang = LANGUAGE;
+    $reg = null;
+    if (isset($extra_info[$key])) {
+        $reg = MySociety\TheyWorkForYou\DataClass\Regmem\Person::fromJson($extra_info[$key]);
+    }
+    return $reg;
+}
+
 function person_register_interests($member, $extra_info) {
-    if (!isset($extra_info['register_member_interests_html'])) {
+
+    $valid_chambers = ['house-of-commons', 'scottish-parliament', 'northern-ireland-assembly', 'senedd'];
+
+    $lang = LANGUAGE;
+
+    $reg = [ 'date' => '', 'chamber_registers' => [] ];
+
+    foreach ($valid_chambers as $chamber) {
+        $key = 'person_regmem_' . $chamber . '_' . $lang;
+        $chamber_register = person_register_interests_from_key($key, $extra_info);
+        if ($chamber_register) {
+            $reg['chamber_registers'][$chamber] = $chamber_register;
+        }
+    }
+    // if chamber_registers is empty, we don't have any data
+    if (empty($reg['chamber_registers'])) {
         return;
     }
 
-    $reg = [ 'date' => '', 'data' => '<p>Nil</p>' ];
-    if (isset($extra_info['register_member_interests_date'])) {
-        $reg['date'] = format_date($extra_info['register_member_interests_date'], SHORTDATEFORMAT);
-    }
-    if ($extra_info['register_member_interests_html'] != '') {
-        $reg['data'] = $extra_info['register_member_interests_html'];
-    }
     return $reg;
 }
 

--- a/www/docs/regmem/index.php
+++ b/www/docs/regmem/index.php
@@ -2,7 +2,22 @@
 
 include_once '../../includes/easyparliament/init.php';
 
+$chamber = get_http_var('chamber');
+
 $dir = RAWDATA . 'scrapedxml/regmem';
+
+// Set the directory based on the chamber
+if ($chamber == "northern-ireland-assembly") {
+    $dir = RAWDATA . 'scrapedxml/regmem-ni';
+} elseif ($chamber == "scottish-parliament") {
+    $dir = RAWDATA . 'scrapedxml/regmem-scotparl';
+} elseif ($chamber == "senedd") {
+    if (LANGUAGE == "en") {
+        $dir = RAWDATA . 'scrapedxml/regmem-senedd-en';
+    } elseif (LANGUAGE == "cy") {
+        $dir = RAWDATA . 'scrapedxml/regmem-senedd-cy';
+    }
+}
 $dh = opendir($dir);
 $files = [];
 while ($file = readdir($dh)) {

--- a/www/includes/easyparliament/templates/html/mp/_person_navigation.php
+++ b/www/includes/easyparliament/templates/html/mp/_person_navigation.php
@@ -1,14 +1,15 @@
 <div class="person-navigation">
+
     <ul>
         <li <?php if ($pagetype == ""): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>"><?= gettext('Overview') ?></a></li>
           <?php if ($this_page == "mp"): ?>
             <li <?php if ($pagetype == "votes"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/votes"><?= gettext('Voting Summary') ?></a></li>
           <?php endif; ?>
           <?php if (in_array($this_page, ["mp", "msp", "ms"])): ?>
-          <li <?php if ($pagetype == "recent"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/recent"><?= gettext('Recent Votes') ?></a></li>
-            <?php if ($register_interests): ?>
-                <li <?php if ($pagetype == "register"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/register"><?= gettext('Register of Interests') ?></a></li>
-            <?php endif; ?>
+            <li <?php if ($pagetype == "recent"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/recent"><?= gettext('Recent Votes') ?></a></li>
           <?php endif; ?>
-          </ul>
+          <?php if ($register_interests): ?>
+            <li <?php if ($pagetype == "register"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/register"><?= gettext('Register of Interests') ?></a></li>
+          <?php endif; ?>
+    </ul>
 </div>

--- a/www/includes/easyparliament/templates/html/mp/_register_entry.php
+++ b/www/includes/easyparliament/templates/html/mp/_register_entry.php
@@ -1,0 +1,53 @@
+<?php /** @var MySociety\TheyWorkForYou\DataClass\Regmem\InfoEntry $entry */ ?>
+
+<div class="interest-item" id="<?= $entry->comparable_id ?>">
+
+<?php if (!$entry->details->isEmpty()) { ?>
+
+    <?php if ($entry->content) { ?>
+        <?php if ($entry->info_type == "subentry") { ?>
+            <h6 class="interest-summary"><?= htmlspecialchars($entry->content) ?></h6>
+        <?php } else { ?>
+            <h4 class="interest-summary"><?= htmlspecialchars($entry->content) ?></h4>
+        <?php }; ?>
+    <?php }; ?>
+        <ul class="interest-details-list">
+            <?php foreach ($entry->details as $detail) { ?>
+                <?php include '_register_field.php'; ?>
+            <?php }; ?>
+
+            <?php if ($entry->date_registered) { ?>
+                <li class="registration-date">Registration Date: <?= htmlspecialchars($entry->date_registered) ?></li>
+            <?php }; ?>
+            <?php if ($entry->date_published) { ?>
+                <li class="published-date">Published Date: <?= htmlspecialchars($entry->date_published) ?></li>
+            <?php }; ?>
+            <?php if ($entry->date_updated) { ?>
+                <li class="last-updated-date">Last Updated Date: <?= htmlspecialchars($entry->date_updated) ?></li>
+            <?php }; ?>
+        </ul>
+
+    <?php } else { ?>
+    <?php if ($entry->content) { ?>
+        <?php // This is a more mininal style of entry, don't use the header structure, just print the xml content?>
+        <?php if ($entry->content_format == "xml") { ?>
+            <?= $entry->content ?>
+        <?php } else { ?>
+            <p class="interest-content"><?= htmlspecialchars($entry->content) ?></p>
+        <?php }; ?>
+    <?php }; ?>
+<?php }; ?>
+
+    <?php if (!$entry->sub_entries->isEmpty()) { ?>
+        <h5 class="child-item-header">Specific work or payments</h5>
+        <div class="interest-child-items" id="parent-<?= $entry->comparable_id ?>">
+            <?php foreach ($entry->sub_entries as $subentry) {
+                $parent_entry = $entry;
+                $entry = $subentry;
+                include '_register_entry.php';
+                $entry = $parent_entry;
+            } ?>
+        </div>
+    <?php }; ?>
+
+</div>

--- a/www/includes/easyparliament/templates/html/mp/_register_field.php
+++ b/www/includes/easyparliament/templates/html/mp/_register_field.php
@@ -1,0 +1,23 @@
+<?php /** @var MySociety\TheyWorkForYou\DataClass\Regmem\Detail $detail */ ?>
+
+
+    <?php if ($detail->type == "container"): ?>
+        <li class="interest-detail">
+        <span class="interest-detail-name"><?= $detail->display_as ?>: </span>
+
+        <ul class="interest-detail-values-groups">
+            <?php $upper_detail = $detail; ?>
+            <?php foreach ($detail->sub_details() as $detail): ?>
+                <?php include '_register_field.php'; ?>
+            <?php endforeach; ?>
+            <?php $detail = $upper_detail; ?>
+        </ul>
+        </li>
+    <?php else : ?>
+        <li class="interest-detail">
+        <?php if ($detail->has_value()): ?>
+            <span class="interest-detail-name"><?= $detail->display_as ?>: </span>
+            <span class="interest-detail-value"><?= htmlspecialchars($detail->value) ?></span>
+        <?php endif; ?>
+        </li>
+    <?php endif; ?>

--- a/www/includes/easyparliament/templates/html/mp/register.php
+++ b/www/includes/easyparliament/templates/html/mp/register.php
@@ -10,40 +10,72 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
         <div class="person-panels">
             <div class="sidebar__unit in-page-nav">
                 <div>
-                    <h3 class="browse-content"><?= gettext('Browse content') ?></h3>
-                    <ul>
-                      <li><a href="https://pages.mysociety.org/parl_register_interests/datasets/parliament_2024/latest">Download a spreadsheet</a></li>
-                      <li><a href="https://www.mysociety.org/2024/01/17/improving-the-register-of-mps-interests/">Read more about the data</a></li>
 
+                <h3 class="browse-content"><?= gettext('Browse content') ?></h3>
+                    <ul>
+                        <li><a href="https://pages.mysociety.org/parl_register_interests/datasets/parliament_2024/latest">Download a spreadsheet</a></li>
+                        <li><a href="https://www.mysociety.org/2024/01/17/improving-the-register-of-mps-interests/">Read more about the data</a></li>
                     </ul>
-                      <?php include '_featured_content.php'; ?>
-                      <?php include '_donation.php'; ?>
+
+                    <?php foreach ($register_interests['chamber_registers'] as $register): ?>
+                    <?php /** @var MySociety\TheyWorkForYou\DataClass\Regmem\Person $register */ ?>
+
+                    <h3 class="browse-content"><?= $register->displayChamber() ?></h3>
+                    <ul>
+                            <?php foreach ($register->categories as $category): ?>
+                                <?php if ($category->only_null_entries()): ?>
+                                    <?php continue; ?>
+                                <?php endif; ?>
+                                <li><a href="#category-<?= $register->chamber . $category->category_id ?>"><?= $category->category_name ?></a></li>
+                            <?php endforeach; ?>
+                    </ul>
+                    <?php endforeach; ?>
+
+                    <?php include '_featured_content.php'; ?>
+                    <?php include '_donation.php'; ?>
                 </div>
             </div>
 
             <div class="primary-content__unit">
 
-                <?php if ($register_interests): ?>
-                <div class="panel register">
+                <?php if ($register_interests) { ?>
+
+                    <?php /** @var MySociety\TheyWorkForYou\DataClass\Regmem\Person $register */ ?>
+                    <?php foreach ($register_interests['chamber_registers'] as $chamber => $register) { ?>
+                        
+                    <div class="panel register">
                     <a name="register"></a>
-                    <h2>Register of Members&rsquo; Interests</h2>
-                    <p><b>New</b>: <a href="https://pages.mysociety.org/parl_register_interests/datasets/parliament_2024/latest">Download a spreadsheet of all Members Interests.</a></p>
+                    <h2>Register of Members&rsquo; Interests - <?= $register->displayChamber() ?></h2>
 
                     <p>
-                        <a href="<?= WEBPATH ?>regmem/?p=<?= $person_id ?>">View the history of this MP&rsquo;s entries in the Register</a>
+                        <a href="<?= WEBPATH ?>regmem/?p=<?= $person_id ?>&chamber=<?= $chamber ?>">View the history of this person’s entries in the Register</a>
                     </p>
-                    <?php if ($register_interests['date']): ?>
-                        <p>Last updated: <?= $register_interests['date'] ?>.</p>
-                    <?php endif; ?>
 
-                    <?= $register_interests['data'] ?>
+                        <p>This register last updated on: <?= $register->published_date ?></p>
 
+                        <?php foreach ($register->categories as $category) { ?>
+                            <?php if ($category->only_null_entries()) {
+                                continue;
+                            }; ?>
+                            <h3 id="category-<?= $register->chamber . $category->category_id ?>"><?= $category->category_name ?></h3>
+                        
+                            <?php foreach ($category->entries as $entry) {
+                                if ($entry->null_entry == false) {
+                                    include('_register_entry.php');
+                                }
+                            } ?>
+                        
+                        <?php }; ?>
+                    
+                        </div>
+                    <?php }; ?>
 
+                <div class="panel">
                     <p>
                          <a class="moreinfo-link" href="https://www.parliament.uk/mps-lords-and-offices/standards-and-financial-interests/parliamentary-commissioner-for-standards/registers-of-interests/register-of-members-financial-interests/">More about the register</a>
                     </p>
                 </div>
-                <?php endif; ?>
+                <?php }; ?>
 
                 <?php include('_profile_footer.php'); ?>
 


### PR DESCRIPTION
This adds devolved registers of interest to TheyWorkForYou (using data from https://github.com/mysociety/parlparse/pull/201)

For this PR, the important bit is getting the data structure and loaders merged - because that's also used for the election summaries. When this is approved I'll comment out the non-commons chambers until we're ready to launch.  This will also need some changes to the text to link to right spreadsheets.

The end goal of this PR is getting the template logic into TWFY rather than being stored in parlparse and the importer, but there's a few steps needed to get there.

- This adds a new personinfo importer - as a way of loading validated data in via python. This dumps json in the personinfo table.
- Inside PHP, this is expanded into dataclasses using the same schema (adding some extra helper methods to the data).
- This is then expanded in the template, with a new side menu structure and support for the rare duel mandates (Douglas Ross is a good current example).
- The change over time comparison still uses the XML, but there's a small tweak to make the folder it looks in configurable.

To load the new data use `scripts/personinfo upload-all-regmem`.

# Live MP

![image](https://github.com/user-attachments/assets/e7559568-572a-4c79-a090-672fa7da0e17)


# Old MP (pre 2024 data)

(not as nicely formatted, but still works for preserving the history we already had)

![image](https://github.com/user-attachments/assets/bcbb9872-24c2-4a43-9d52-887379d91d08)

# Scottish Parliament

![image](https://github.com/user-attachments/assets/4c05b745-5761-4939-87eb-b9bc1a093e9e)

# Senedd

![image](https://github.com/user-attachments/assets/86756bfa-033b-4abb-bef6-47aa04991406)

# NI Assembly

![image](https://github.com/user-attachments/assets/0c61e447-063b-47eb-83d3-68a50bc32b94)

