### PR TITLE
Format alternative syntax

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,6 +11,7 @@ return (new PhpCsFixer\Config())
     ->setRules([
         '@PER-CS' => true,
         '@PHP74Migration' => true,
+        'no_alternative_syntax' => ['fix_non_monolithic_code' => true],
         'braces_position' => ['functions_opening_brace' => 'same_line', 'classes_opening_brace' => 'same_line'],
     ])
     ->setFinder($finder)

--- a/www/includes/easyparliament/templates/html/alert/postcode.php
+++ b/www/includes/easyparliament/templates/html/alert/postcode.php
@@ -2,9 +2,9 @@
     <div class="full-page__row">
         <div class="full-page__unit">
 
-            <h1>Track your <?php if ($data['recent_election']): ?>new<?php endif ?> MP&rsquo;s parliamentary activity</h1>
+            <h1>Track your <?php if ($data['recent_election']) { ?>new<?php } ?> MP&rsquo;s parliamentary activity</h1>
 
-          <?php if (isset($data['confirmation_sent'])): ?>
+          <?php if (isset($data['confirmation_sent'])) { ?>
 
             <div class="alerts-message alerts-message--confirmation-sent">
                 <h2>Almost there!</h2>
@@ -12,72 +12,72 @@
                 <p>Please click the link in the email we just sent you.</p>
             </div>
 
-          <?php elseif (isset($data['signedup_no_confirm']) || isset($data['confirmation_received'])): ?>
+          <?php } elseif (isset($data['signedup_no_confirm']) || isset($data['confirmation_received'])) { ?>
 
             <div class="alerts-message alerts-message--confirmation-received">
                 <h2>Thanks for subscribing!</h2>
                 <p>You will now receive alerts when your MP speaks or votes in Parliament, or receives an answer to a written question.</p>
-                <?php if (isset($data['user_signed_in'])): ?>
+                <?php if (isset($data['user_signed_in'])) { ?>
                 <p><a href="/alert/" class="button radius">Show my email settings</a></p>
-                <?php endif ?>
+                <?php } ?>
             </div>
 
-          <?php elseif (isset($data['error'])): ?>
+          <?php } elseif (isset($data['error'])) { ?>
             <div class="alerts-message alerts-message--error">
                 <h2>Something went wrong</h2>
                 <p>Sorry, we were unable to create this alert. Please <a href="mailto:<?= str_replace('@', '&#64;', CONTACTEMAIL) ?>">let us know</a>. Thanks.</p>
             </div>
 
-          <?php else: ?>
+          <?php } else { ?>
 
             <p class="lead">Enter your postcode, and we&rsquo;ll email you every time your MP speaks, votes, or receives a written answer.</p>
 
-          <?php if (isset($data['invalid-postcode-or-email'])): ?>
+          <?php if (isset($data['invalid-postcode-or-email'])) { ?>
             <div class="alerts-message alerts-message--error">
                 <h2>Oops!</h2>
                 <p>Either we didn't recognize that postcode or your email address wasn't valid.</p>
             </div>
-          <?php endif ?>
+          <?php } ?>
 
-          <?php if (isset($data['bad-constituency'])): ?>
+          <?php if (isset($data['bad-constituency'])) { ?>
             <div class="alerts-message alerts-message--error">
                 <h2>Oops!</h2>
                 <p>We can't find an MP for that postcode.</p>
             </div>
-          <?php endif ?>
+          <?php } ?>
 
-          <?php if (isset($data['user_signed_in']) && isset($data['already_signed_up'])): ?>
+          <?php if (isset($data['user_signed_in']) && isset($data['already_signed_up'])) { ?>
             <div class="alerts-message alerts-message--reminder">
                 <h2>You are already signed up</h2>
                 <p>You are already receiving alerts when your MP<?= isset($data['mp_name']) ? ', ' . $data['mp_name'] . ',' : '' ?> speaks or votes in Parliament, or receives an answer to a written question.</p>
                 <p><a href="/alert/" class="button radius">Show my email settings</a></p>
             </div>
-           <?php endif ?>
+           <?php } ?>
 
             <form class="alerts-form" method="post">
                 <input type="hidden" name="add-alert" value="1">
                 <p>
                     <label for="id_postcode">Your postcode</label>
-                  <?php if (isset($data['postcode'])): ?>
+                  <?php if (isset($data['postcode'])) { ?>
                     <input type="text" name="postcode" id="id_postcode" value="<?= _htmlentities($data['postcode']) ?>">
-                  <?php else: ?>
+                  <?php } else { ?>
                     <input type="text" name="postcode" id="id_postcode">
-                  <?php endif ?>
+                  <?php } ?>
                 </p>
                 <p>
                     <label for="id_email">Your email address</label>
-                  <?php if (isset($data['email'])): ?>
+                  <?php if (isset($data['email'])) { ?>
                     <input type="text" name="email" id="id_email" value="<?= _htmlentities($data['email']) ?>">
-                  <?php else: ?>
+                  <?php } else { ?>
                     <input type="text" name="email" id="id_email">
-                  <?php endif ?>
+                  <?php } ?>
                 </p>
                 <p>
                     <button type="submit" class="button radius">Set up alerts</button>
                 </p>
             </form>
 
-          <?php endif ?>
+          <?php } ?>
 
         </div>
     </div>

--- a/www/includes/easyparliament/templates/html/alert/update-mp.php
+++ b/www/includes/easyparliament/templates/html/alert/update-mp.php
@@ -4,15 +4,15 @@
 
             <h1>Update your MP</h1>
 
-          <?php if (isset($data['already_signed_up'])): ?>
+          <?php if (isset($data['already_signed_up'])) { ?>
             <div class="alerts-message alerts-message--reminder">
                 <h2>You are already signed up</h2>
                 <p>You are already receiving alerts when your new MP, <?= $data['mp_name'] ?>, speaks in Parliament or receives an answer to a written question.</p>
-                <?php if (isset($data['user_signed_in'])): ?>
+                <?php if (isset($data['user_signed_in'])) { ?>
                 <p><a href="/alert/" class="button radius">Show my email settings</a></p>
-                <?php endif ?>
+                <?php } ?>
             </div>
-          <?php elseif (isset($data['update'])): ?>
+          <?php } elseif (isset($data['update'])) { ?>
 
             <div class="alerts-message alerts-message--confirmation-sent">
                 <h2>Confirm your update!</h2>
@@ -24,23 +24,23 @@
                 </form>
             </div>
 
-          <?php elseif (isset($data['signedup_no_confirm']) || isset($data['confirmation_received'])): ?>
+          <?php } elseif (isset($data['signedup_no_confirm']) || isset($data['confirmation_received'])) { ?>
 
             <div class="alerts-message alerts-message--confirmation-received">
                 <h2>Thanks for subscribing!</h2>
                 <p>You will now receive alerts when your MP speaks in Parliament or receives an answer to a written question.</p>
-                <?php if (isset($data['user_signed_in'])): ?>
+                <?php if (isset($data['user_signed_in'])) { ?>
                 <p><a href="/alert/" class="button radius">Show my email settings</a></p>
-                <?php endif ?>
+                <?php } ?>
             </div>
 
-          <?php elseif (isset($data['error'])): ?>
+          <?php } elseif (isset($data['error'])) { ?>
             <div class="alerts-message alerts-message--error">
                 <h2>Something went wrong</h2>
                 <p>Sorry, we were unable to create this alert. Please try again <a href="/alert/by-postcode/">using your postcode</a>. Thanks.</p>
             </div>
 
-          <?php else: ?>
+          <?php } else { ?>
 
             <p class="lead">Enter your postcode, and we&rsquo;ll email you every time your MP speaks or receives a written answer.</p>
 
@@ -48,26 +48,26 @@
                 <input type="hidden" name="add-alert" value="1">
                 <p>
                     <label for="id_postcode">Your postcode</label>
-                  <?php if (isset($data['postcode'])): ?>
+                  <?php if (isset($data['postcode'])) { ?>
                     <input type="text" name="postcode" id="id_postcode" value="<?= _htmlentities($data['postcode']) ?>">
-                  <?php else: ?>
+                  <?php } else { ?>
                     <input type="text" name="postcode" id="id_postcode">
-                  <?php endif ?>
+                  <?php } ?>
                 </p>
                 <p>
                     <label for="id_email">Your email address</label>
-                  <?php if (isset($data['email'])): ?>
+                  <?php if (isset($data['email'])) { ?>
                     <input type="text" name="email" id="id_email" value="<?= _htmlentities($data['email']) ?>">
-                  <?php else: ?>
+                  <?php } else { ?>
                     <input type="text" name="email" id="id_email">
-                  <?php endif ?>
+                  <?php } ?>
                 </p>
                 <p>
                     <button type="submit" class="button radius">Set up alerts</button>
                 </p>
             </form>
 
-          <?php endif ?>
+          <?php } ?>
 
         </div>
     </div>

--- a/www/includes/easyparliament/templates/html/footer.php
+++ b/www/includes/easyparliament/templates/html/footer.php
@@ -27,14 +27,14 @@
         <div class="medium-4 columns">
             <nav class="mysoc-footer__links">
                 <ul>
-                  <?php foreach ($footer_links['about'] as $footer_link): ?>
+                  <?php foreach ($footer_links['about'] as $footer_link) { ?>
                     <li role="presentation"><a href="<?= $footer_link['href'] ?>" title="<?= $footer_link['title'] ?>" class="<?= $footer_link['classes'] ?>"><?= $footer_link['text'] ?></a></li>
-                  <?php endforeach; ?>
+                  <?php } ?>
                 </ul>
                 <ul>
-                  <?php foreach ($footer_links['tech'] as $footer_link): ?>
+                  <?php foreach ($footer_links['tech'] as $footer_link) { ?>
                     <li role="presentation"><a href="<?= $footer_link['href'] ?>" title="<?= $footer_link['title'] ?>" class="<?= $footer_link['classes'] ?>"><?= $footer_link['text'] ?></a></li>
-                  <?php endforeach; ?>
+                  <?php } ?>
                 </ul>
             </nav>
         </div>

--- a/www/includes/easyparliament/templates/html/footer.php
+++ b/www/includes/easyparliament/templates/html/footer.php
@@ -24,13 +24,13 @@
                   <div class="small-12 columns">
                       <?php
                       // For the API page we add users to the "Data, coding and development" segment
-                      if (strpos($_SERVER['REQUEST_URI'], '/api') === 0):
+                      if (strpos($_SERVER['REQUEST_URI'], '/api') === 0) {
                           ?>
                       <label>
                           <input type="checkbox" name="group[11745][256]" value="1" checked>
                           <?= gettext('I’m also interested in data, coding and development emails.') ?>
                       </label>
-                      <?php endif; ?>
+                      <?php } ?>
                   </div>
                 </div>
                 <p><a href="https://www.mysociety.org/privacy#newsletter"><?= gettext('Your data') ?></a></p>
@@ -40,14 +40,14 @@
         <div class="medium-4 columns">
             <nav class="mysoc-footer__links">
                 <ul>
-                  <?php foreach ($footer_links['about'] as $footer_link): ?>
+                  <?php foreach ($footer_links['about'] as $footer_link) { ?>
                     <li role="presentation"><a href="<?= $footer_link['href'] ?>" title="<?= $footer_link['title'] ?>" class="<?= $footer_link['classes'] ?>"><?= $footer_link['text'] ?></a></li>
-                  <?php endforeach; ?>
+                  <?php } ?>
                 </ul>
                 <ul>
-                  <?php foreach ($footer_links['tech'] as $footer_link): ?>
+                  <?php foreach ($footer_links['tech'] as $footer_link) { ?>
                     <li role="presentation"><a href="<?= $footer_link['href'] ?>" title="<?= $footer_link['title'] ?>" class="<?= $footer_link['classes'] ?>"><?= $footer_link['text'] ?></a></li>
-                  <?php endforeach; ?>
+                  <?php } ?>
                 </ul>
             </nav>
         </div>

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -4,9 +4,9 @@
     <meta charset="utf-8">
     <title><?= strip_tags($page_title) ?></title>
     <meta name="viewport" content="initial-scale=1">
-    <?php if (isset($meta_description)): ?>
+    <?php if (isset($meta_description)) { ?>
     <meta name="description" content="<?= _htmlentities($meta_description) ?>">
-    <?php endif; ?>
+    <?php } ?>
     <meta name="keywords" content="<?= _htmlentities($meta_keywords); ?>">
     <?php
         if (!empty($robots)) {
@@ -43,15 +43,15 @@
 
     <script>document.documentElement.className = 'js';</script>
 
-    <?php foreach ($header_links as $link): ?>
+    <?php foreach ($header_links as $link) { ?>
     <link rel="<?= $link['rel'] ?>" title="<?= $link['title'] ?>" href="<?= $link['href'] ?>">
-    <?php endforeach; ?>
+    <?php } ?>
 
     <link rel="stylesheet" href="<?= cache_version("style/stylesheets/app.css") ?>" type="text/css">
 
-    <?php if (isset($page_rss_url)): ?>
+    <?php if (isset($page_rss_url)) { ?>
     <link rel="alternate" type="application/rss+xml" title="TheyWorkForYou RSS" href="<?= $page_rss_url ?>">
-    <?php endif; ?>
+    <?php } ?>
 
     <link rel="apple-touch-icon" href="/images/apple-touch-60.png" />
     <link rel="apple-touch-icon" sizes="76x76" href="/images/apple-touch-76.png" />
@@ -60,7 +60,7 @@
 
     <script async src="<?= cache_version("js/loading-attribute-polyfill.min.js") ?>"></script>
 
-  <?php if (!DEVSITE): ?>
+  <?php if (!DEVSITE) { ?>
 
     <!-- Google tag (gtag.js) -->
     <script defer>Object.defineProperty(document,"cookie",{get:function(){var t=Object.getOwnPropertyDescriptor(Document.prototype,"cookie").get.call(document);return t.trim().length>0&&(t+="; "),t+="_ga=GA1.1."+Math.floor(1e9*Math.random())+"."+Math.floor(1e9*Math.random())},set:function(t){t.trim().startsWith("_ga")||Object.getOwnPropertyDescriptor(Document.prototype,"cookie").set.call(document,t)}});</script>
@@ -84,7 +84,7 @@
         ga('set', 'anonymizeIp', true);
         ga('send', 'pageview');
     </script>
-  <?php endif; ?>
+  <?php } ?>
 
 </head>
 

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -4,9 +4,9 @@
     <meta charset="utf-8">
     <title><?= strip_tags($page_title) ?></title>
     <meta name="viewport" content="initial-scale=1">
-    <?php if (isset($meta_description)): ?>
+    <?php if (isset($meta_description)) { ?>
     <meta name="description" content="<?= _htmlentities($meta_description) ?>">
-    <?php endif; ?>
+    <?php } ?>
     <meta name="keywords" content="<?= _htmlentities($meta_keywords); ?>">
     <?php
         if (!empty($robots)) {
@@ -52,15 +52,15 @@
 
     <script>document.documentElement.className = 'js';</script>
 
-    <?php foreach ($header_links as $link): ?>
+    <?php foreach ($header_links as $link) { ?>
     <link rel="<?= $link['rel'] ?>" title="<?= $link['title'] ?>" href="<?= $link['href'] ?>">
-    <?php endforeach; ?>
+    <?php } ?>
 
     <link rel="stylesheet" href="<?= cache_version("style/stylesheets/app.css") ?>" type="text/css">
 
-    <?php if (isset($page_rss_url)): ?>
+    <?php if (isset($page_rss_url)) { ?>
     <link rel="alternate" type="application/rss+xml" title="TheyWorkForYou RSS" href="<?= $page_rss_url ?>">
-    <?php endif; ?>
+    <?php } ?>
 
     <link rel="apple-touch-icon" href="/images/apple-touch-60.png" />
     <link rel="apple-touch-icon" sizes="76x76" href="/images/apple-touch-76.png" />
@@ -69,7 +69,7 @@
 
     <script async src="<?= cache_version("js/loading-attribute-polyfill.min.js") ?>"></script>
 
-  <?php if (!DEVSITE): ?>
+  <?php if (!DEVSITE) { ?>
 
     <!-- Google tag (gtag.js) -->
     <script defer>Object.defineProperty(document,"cookie",{get:function(){var t=Object.getOwnPropertyDescriptor(Document.prototype,"cookie").get.call(document);return t.trim().length>0&&(t+="; "),t+="_ga=GA1.1."+Math.floor(1e9*Math.random())+"."+Math.floor(1e9*Math.random())},set:function(t){t.trim().startsWith("_ga")||Object.getOwnPropertyDescriptor(Document.prototype,"cookie").set.call(document,t)}});</script>
@@ -83,7 +83,7 @@
         gtag('config','<?= GOOGLE_ANALYTICS_ID ?>', {'client_id': client_id, 'cookie_expires': 1 });
     </script>
 
-  <?php endif; ?>
+  <?php } ?>
 
 </head>
 

--- a/www/includes/easyparliament/templates/html/mp/_chamber_info_panel.php
+++ b/www/includes/easyparliament/templates/html/mp/_chamber_info_panel.php
@@ -33,7 +33,7 @@
         <li>Find out <a href="#profile">more about this MP</a>, including:
             <ul class="rep-actions">
                 <?php if ($memberships) { ?>
-                    <li <?php if ($pagetype == "memberships"): ?>class="active"<?php endif; ?>>
+                    <li <?php if ($pagetype == "memberships") { ?>class="active"<?php } ?>>
                         <a href="<?= $member_url ?>/memberships"><?= gettext('Committees and groups') ?></a> they are part of.
                     </li>
                 <?php } ?>
@@ -43,7 +43,7 @@
                 <?php } ?>
                 <li><a href="<?= $member_url ?>/speeches">Recent speeches and questions</a></li>
                 <?php if ($memberships) { ?>
-                    <li <?php if ($pagetype == "memberships"): ?>class="active"<?php endif; ?>>
+                    <li <?php if ($pagetype == "memberships") { ?>class="active"<?php } ?>>
                         <a href="<?= $member_url ?>/signatures"><?= gettext('Signatures') ?></a> (open letters and EDMs)
                     </li>
                 <?php } ?>

--- a/www/includes/easyparliament/templates/html/mp/_covid19_panel.php
+++ b/www/includes/easyparliament/templates/html/mp/_covid19_panel.php
@@ -1,4 +1,4 @@
-<?php if (in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+<?php if (in_array(HOUSE_TYPE_COMMONS, $houses)) { ?>
 <a name="covid-19"></a>
 <div class="panel panel--highlight panel--covid19">
     <h2>As a result of COVID-19, some MPs were less able to vote in Parliament in certain periods, and this will be reflected by absences in their voting record.</h2>
@@ -21,4 +21,4 @@
     </dl>
     <p> <a href="https://www.mysociety.org/2020/07/06/parliamentary-votes-during-covid-19/">See more detail on votes during the COVID-19 period here.</a></p>
 </div>
-<?php endif; ?>
+<?php } ?>

--- a/www/includes/easyparliament/templates/html/mp/_division_description.php
+++ b/www/includes/easyparliament/templates/html/mp/_division_description.php
@@ -7,33 +7,33 @@
     
     <div class="vote-actions vote-actions--inline">
         <a class="vote-action-btn" href="<?= $division['debate_url'] ?? '/divisions/' . $division['division_id'] . '/mp/' . $person_id ?>">Show vote in context</a>
-        <?php if (isset($division['analysis_url'])): ?>
+        <?php if (isset($division['analysis_url'])) { ?>
             <a class="vote-action-btn" href="<?= $division['analysis_url'] ?>">Vote analysis</a>
-        <?php endif; ?>
-        <?php if (isset($division['annotation']) && !empty($division['annotation'])): ?>
+        <?php } ?>
+        <?php if (isset($division['annotation']) && !empty($division['annotation'])) { ?>
             <a class="vote-action-btn" href="<?= $division['annotation'] ?>" title="External link to <?= $division['annotation'] ?>">Public Statement</a>
-        <?php endif; ?>
-        <?php if (isset($division['speeches']) && count($division['speeches']) > 0): ?>
+        <?php } ?>
+        <?php if (isset($division['speeches']) && count($division['speeches']) > 0) { ?>
             <input type="checkbox" id="speeches-toggle-<?= $division['division_id'] ?>" class="vote-speeches-checkbox" hidden>
             <label for="speeches-toggle-<?= $division['division_id'] ?>" class="vote-action-btn vote-speeches-toggle">
                 Related speeches (<?= count($division['speeches']) ?>)
             </label>
-        <?php endif; ?>
+        <?php } ?>
     </div>
     
-    <?php if (isset($division['speeches']) && count($division['speeches']) > 0): ?>
+    <?php if (isset($division['speeches']) && count($division['speeches']) > 0) { ?>
         <div class="vote-speeches-content">
             <ul class="vote-speeches__list">
-                <?php foreach ($division['speeches'] as $speech): ?>
+                <?php foreach ($division['speeches'] as $speech) { ?>
                     <li>
                         <a href="<?= $speech['url'] ?>" class="vote-speech__link">
                             <?= $speech['time'] ? $speech['time'] . ': ' : '' ?><?= $speech['preview'] ?>
                         </a>
                     </li>
-                <?php endforeach; ?>
+                <?php } ?>
             </ul>
         </div>
-    <?php endif; ?>
+    <?php } ?>
 
     <?php
     # remove the current policy from the list of related policies

--- a/www/includes/easyparliament/templates/html/mp/_donation_banner.php
+++ b/www/includes/easyparliament/templates/html/mp/_donation_banner.php
@@ -22,7 +22,7 @@ if (isset($_GET['show_donation_banner'])) {
 }
 ?>
 
-<?php if ($show_banner): ?>
+<?php if ($show_banner) { ?>
 <div class="panel panel--donation-banner" id="donation-banner">
     <div class="donation-banner__content">
         <div class="donation-banner__header">
@@ -95,4 +95,4 @@ if (isset($_GET['show_donation_banner'])) {
     }
 })();
 </script>
-<?php endif; ?>
+<?php } ?>

--- a/www/includes/easyparliament/templates/html/mp/_person_navigation.php
+++ b/www/includes/easyparliament/templates/html/mp/_person_navigation.php
@@ -1,14 +1,14 @@
 <div class="person-navigation">
     <ul>
-        <li <?php if ($pagetype == ""): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>"><?= gettext('Overview') ?></a></li>
-          <?php if ($this_page == "mp"): ?>
-            <li <?php if ($pagetype == "votes"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/votes"><?= gettext('Voting Summary') ?></a></li>
-          <?php endif; ?>
-          <?php if (in_array($this_page, ["mp", "msp", "ms"])): ?>
-          <li <?php if ($pagetype == "recent"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/recent"><?= gettext('Recent Votes') ?></a></li>
-            <?php if ($register_interests): ?>
-                <li <?php if ($pagetype == "register"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/register"><?= gettext('Register of Interests') ?></a></li>
-            <?php endif; ?>
-          <?php endif; ?>
+        <li <?php if ($pagetype == "") { ?>class="active"<?php } ?>><a href="<?= $member_url ?>"><?= gettext('Overview') ?></a></li>
+          <?php if ($this_page == "mp") { ?>
+            <li <?php if ($pagetype == "votes") { ?>class="active"<?php } ?>><a href="<?= $member_url ?>/votes"><?= gettext('Voting Summary') ?></a></li>
+          <?php } ?>
+          <?php if (in_array($this_page, ["mp", "msp", "ms"])) { ?>
+          <li <?php if ($pagetype == "recent") { ?>class="active"<?php } ?>><a href="<?= $member_url ?>/recent"><?= gettext('Recent Votes') ?></a></li>
+            <?php if ($register_interests) { ?>
+                <li <?php if ($pagetype == "register") { ?>class="active"<?php } ?>><a href="<?= $member_url ?>/register"><?= gettext('Register of Interests') ?></a></li>
+            <?php } ?>
+          <?php } ?>
           </ul>
 </div>

--- a/www/includes/easyparliament/templates/html/mp/_person_navigation.php
+++ b/www/includes/easyparliament/templates/html/mp/_person_navigation.php
@@ -7,7 +7,7 @@
 <div class="table-of-content js-table-of-content">
     <h2 class="browse-content"><?= ucfirst($full_name) ?></h2>
     <ul>
-        <li <?php if ($pagetype == ""): ?>class="active"<?php endif; ?>>
+        <li <?php if ($pagetype == "") { ?>class="active"<?php } ?>>
             <a href="<?= $member_url ?>" class="table-of-content--subpage-heading">
                 <h3>📌 <?= gettext('Overview') ?></h3>
             </a>
@@ -16,142 +16,142 @@
             </ul>
         </li>
 
-        <?php if (count($recent_appearances['appearances'])): ?>
-            <li <?php if ($pagetype == "speeches"): ?>class="active"<?php endif; ?>>
+        <?php if (count($recent_appearances['appearances'])) { ?>
+            <li <?php if ($pagetype == "speeches") { ?>class="active"<?php } ?>>
                 <a href="<?= $member_url ?>/speeches" class="table-of-content--subpage-heading">
                     <h3>💬 <?= gettext('Speeches and Questions') ?></h3>
                 </a>
                 
-                <?php if ($pagetype == "speeches"): ?>
+                <?php if ($pagetype == "speeches") { ?>
                     <nav class="subpage-content-list js-accordion" aria-label="Appearances list">
                         <ul class="subpage-content-list">
-                            <?php if (count($recent_appearances['speeches']) > 0): ?>
+                            <?php if (count($recent_appearances['speeches']) > 0) { ?>
                             <li><a href="#speeches"><?= gettext('Speeches & Debates') ?></a></li>
-                            <?php endif; ?>
-                            <?php if (count($recent_appearances['written_questions']) > 0): ?>
+                            <?php } ?>
+                            <?php if (count($recent_appearances['written_questions']) > 0) { ?>
                             <li><a href="#written-questions"><?= gettext('Written Questions') ?></a></li>
-                            <?php endif; ?>
+                            <?php } ?>
                         </ul>
                     </nav>
-                <?php endif; ?>
+                <?php } ?>
             </li>
-        <?php endif; ?>
+        <?php } ?>
         
-        <?php if (!empty($memberships) && (array_key_exists('posts', $memberships) || array_key_exists('previous_posts', $memberships) || array_key_exists('appg_membership', $memberships))): ?>
-            <li <?php if ($pagetype == "memberships"): ?>class="active"<?php endif; ?>>
+        <?php if (!empty($memberships) && (array_key_exists('posts', $memberships) || array_key_exists('previous_posts', $memberships) || array_key_exists('appg_membership', $memberships))) { ?>
+            <li <?php if ($pagetype == "memberships") { ?>class="active"<?php } ?>>
                 <a href="<?= $member_url ?>/memberships" class="table-of-content--subpage-heading">
                     <h3>👥 <?= gettext('Committees / APPGs') ?></h3>
                 </a>
 
-                <?php if (!empty($memberships)): ?>
+                <?php if (!empty($memberships)) { ?>
                     <nav class="subpage-content-list js-accordion" aria-label="Memberships list">
                         <ul class="subpage-content-list">
-                            <?php if (array_key_exists('posts', $memberships)): ?>
+                            <?php if (array_key_exists('posts', $memberships)) { ?>
                             <li><a href="#posts"><?= gettext('Memberships') ?></a></li>
-                            <?php endif; ?>
-                            <?php if (array_key_exists('previous_posts', $memberships)): ?>
+                            <?php } ?>
+                            <?php if (array_key_exists('previous_posts', $memberships)) { ?>
                             <li><a href="#previous_posts"><?= gettext('Previous Memberships') ?></a></li>
-                            <?php endif; ?>
-                            <?php if (array_key_exists('appg_membership', $memberships)): ?>
-                                <?php if ($memberships['appg_membership']->is_an_officer()): ?>
+                            <?php } ?>
+                            <?php if (array_key_exists('appg_membership', $memberships)) { ?>
+                                <?php if ($memberships['appg_membership']->is_an_officer()) { ?>
                                 <li><a href="#appg_is_officer_of"><?= gettext('APPG Offices held') ?></a></li>
-                                <?php endif; ?>
-                                <?php if ($memberships['appg_membership']->is_a_member()): ?>
+                                <?php } ?>
+                                <?php if ($memberships['appg_membership']->is_a_member()) { ?>
                                 <li><a href="#appg_is_ordinary_member_of"><?= gettext('APPG memberships') ?></a></li>
-                                <?php endif; ?>
-                            <?php endif; ?>
+                                <?php } ?>
+                            <?php } ?>
                         </ul>
                     </nav>
-                <?php endif; ?>
+                <?php } ?>
             </li>
-        <?php endif; ?>
+        <?php } ?>
 
-        <?php if (array_key_exists('letters_signed', $memberships) || array_key_exists('edms_signed', $memberships) || array_key_exists('topics_of_interest', $memberships) || array_key_exists('eu_stance', $memberships)): ?>
-            <li <?php if ($pagetype == "signatures"): ?>class="active"<?php endif; ?>>
+        <?php if (array_key_exists('letters_signed', $memberships) || array_key_exists('edms_signed', $memberships) || array_key_exists('topics_of_interest', $memberships) || array_key_exists('eu_stance', $memberships)) { ?>
+            <li <?php if ($pagetype == "signatures") { ?>class="active"<?php } ?>>
                 <a href="<?= $member_url ?>/signatures" class="table-of-content--subpage-heading">
                     <h3>✍️ <?= gettext('Signatures') ?></h3>
                 </a>
 
                 <nav class="subpage-content-list js-accordion" aria-label="Signatures list">
                     <ul class="subpage-content-list">
-                            <?php if (array_key_exists('annul_motions_signed', $memberships)): ?>
+                            <?php if (array_key_exists('annul_motions_signed', $memberships)) { ?>
                             <li><a href="#annul_motions_signed"><?= gettext('Recent motions to annul') ?></a></li>
-                            <?php endif; ?>
-                            <?php if (array_key_exists('letters_signed', $memberships)): ?>
+                            <?php } ?>
+                            <?php if (array_key_exists('letters_signed', $memberships)) { ?>
                             <li><a href="#letters_signed"><?= gettext('Recent open letters') ?></a></li>
-                            <?php endif; ?>
-                            <?php if (array_key_exists('edms_signed', $memberships)): ?>
+                            <?php } ?>
+                            <?php if (array_key_exists('edms_signed', $memberships)) { ?>
                             <li><a href="#edms_signed"><?= gettext('Recent EDMs') ?></a></li>
-                            <?php endif; ?>
-                            <?php if (array_key_exists('topics_of_interest', $memberships) || array_key_exists('eu_stance', $memberships)): ?>
+                            <?php } ?>
+                            <?php if (array_key_exists('topics_of_interest', $memberships) || array_key_exists('eu_stance', $memberships)) { ?>
                             <li><a href="#topics"><?= gettext('Topics of interest') ?></a></li>
-                            <?php endif; ?>
+                            <?php } ?>
                         </ul>
                     </nav>
             </li>
-        <?php endif; ?>
+        <?php } ?>
 
-        <?php if ($this_page == "mp"): ?>
-            <li <?php if ($pagetype == "votes"): ?>class="active"<?php endif; ?>>
+        <?php if ($this_page == "mp") { ?>
+            <li <?php if ($pagetype == "votes") { ?>class="active"<?php } ?>>
                 <a href="<?= $member_url ?>/votes" class="table-of-content--subpage-heading">
                     <h3>🗳️ <?= gettext('Voting Summary') ?></h3>
                 </a>
 
-                <?php if (!empty($has_voting_record) && !empty($key_votes_segments)): ?>
+                <?php if (!empty($has_voting_record) && !empty($key_votes_segments)) { ?>
                     <nav class="subpage-content-list js-accordion" aria-label="Policy groups">
                         <h4 class="js-accordion-button">Policy areas</h4>
                         <ul class="js-accordion-content">
-                            <?php if ($has_voting_record): ?>
-                                <?php foreach ($key_votes_segments as $segment): ?>
-                                    <?php if (count($segment->policy_pairs) > 0): ?>
+                            <?php if ($has_voting_record) { ?>
+                                <?php foreach ($key_votes_segments as $segment) { ?>
+                                    <?php if (count($segment->policy_pairs) > 0) { ?>
                                     <li><a href="#<?= $segment->group_slug ?>"><?= $segment->group_name ?></a></li>
-                                    <?php endif; ?>
-                                <?php endforeach; ?>
-                            <?php endif; ?>
+                                    <?php } ?>
+                                <?php } ?>
+                            <?php } ?>
                         </ul>
                     </nav>
-                <?php endif; ?>
+                <?php } ?>
             </li>
-        <?php endif; ?>
+        <?php } ?>
 
-        <?php if (in_array($this_page, ["mp", "msp", "ms"])): ?>
-            <li <?php if ($pagetype == "recent"): ?>class="active"<?php endif; ?>>
+        <?php if (in_array($this_page, ["mp", "msp", "ms"])) { ?>
+            <li <?php if ($pagetype == "recent") { ?>class="active"<?php } ?>>
                 <a href="<?= $member_url ?>/recent" class="table-of-content--subpage-heading">
                     <h3>📜 <?= gettext('Recent Votes') ?></h3>
                 </a>
             </li>
-        <?php endif; ?>
+        <?php } ?>
 
 
 
-        <?php if ($register_interests): ?>
-            <li <?php if ($pagetype == "register"): ?>class="active"<?php endif; ?>>
+        <?php if ($register_interests) { ?>
+            <li <?php if ($pagetype == "register") { ?>class="active"<?php } ?>>
                 <a href="<?= $member_url ?>/register" class="table-of-content--subpage-heading">
                     <h3>📖 <?= gettext('Register of Interests') ?></h3>
                 </a>
 
-                <?php if (!empty($register_interests)): ?>
+                <?php if (!empty($register_interests)) { ?>
                     <?php foreach ($register_interests['chamber_registers'] as $register) { ?>
                         <?php /** @var MySociety\TheyWorkForYou\DataClass\Regmem\Person $register */ ?>
 
                         <nav class="subpage-content-list js-accordion" aria-label="<?= $register->displayChamber() ?> list">
                             <h4 class="js-accordion-button"><?= $register->displayChamber() ?></h4>
                             <ul class="js-accordion-content">
-                                <?php foreach ($register->getCategories() as $category): ?>
-                                    <?php if ($category->only_null_entries()): ?>
+                                <?php foreach ($register->getCategories() as $category) { ?>
+                                    <?php if ($category->only_null_entries()) { ?>
                                         <?php continue; ?>
-                                    <?php endif; ?>
+                                    <?php } ?>
                                     <li><a href="#category-<?= $register->chamber . $category->category_id ?>"><?= $category->category_name ?></a></li>
-                                <?php endforeach; ?>
+                                <?php } ?>
                             </ul>
                         </nav>
                     <?php } ?>
-                <?php endif; ?>
+                <?php } ?>
             </li>
-        <?php endif; ?>
+        <?php } ?>
 
-        <?php if ($register_2024_enriched): ?>
-            <li <?php if ($pagetype == "election_register"): ?>class="active"<?php endif; ?>>
+        <?php if ($register_2024_enriched) { ?>
+            <li <?php if ($pagetype == "election_register") { ?>class="active"<?php } ?>>
                 <a href="<?= $member_url ?>/election_register" class="table-of-content--subpage-heading">
                     <h3>🏛️ <?= gettext('2024 Election Donations') ?></h3>
                 </a>
@@ -159,7 +159,7 @@
                 <ul class="subpage-content-list">
                     <li><a href="https://www.whofundsthem.com">About WhoFundsThem</a></li> 
                 <?php $election_registers = [$register_2024_enriched]; ?>
-                <?php if (!empty($election_registers)): ?>
+                <?php if (!empty($election_registers)) { ?>
                      <?php foreach ($election_registers as $register) { ?>
                                 <?php foreach ($register->getCategories() as $category) { ?>
                                     <?php if ($category->only_null_entries()) { ?>
@@ -168,17 +168,17 @@
                                     <li><a href="#category-<?= $register->chamber . $category->category_id ?>"><?= $category->category_name ?></a></li>
                                 <?php }; ?>
                             <?php }; ?>
-                <?php endif; ?>
+                <?php } ?>
                 </ul>
             </li>
-        <?php endif; ?>
+        <?php } ?>
 
-        <?php if (in_array($this_page, ["mp"])): ?>
-            <li <?php if ($pagetype == "constituency"): ?>class="active"<?php endif; ?>>
+        <?php if (in_array($this_page, ["mp"])) { ?>
+            <li <?php if ($pagetype == "constituency") { ?>class="active"<?php } ?>>
                 <a href="<?= $member_url ?>/constituency" class="table-of-content--subpage-heading">
                     <h3>🌍 <?= gettext('Constituency information') ?></h3>
                 </a>
             </li>
-        <?php endif; ?>
+        <?php } ?>
     </ul>
 </div>

--- a/www/includes/easyparliament/templates/html/mp/_stale_data_panel.php
+++ b/www/includes/easyparliament/templates/html/mp/_stale_data_panel.php
@@ -1,4 +1,4 @@
-<?php if (in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+<?php if (in_array(HOUSE_TYPE_COMMONS, $houses)) { ?>
 <a name="stale-data-warning"></a>
 <div class="panel panel--highlight">
 
@@ -8,4 +8,4 @@
     </p>
 
 </div>
-<?php endif; ?>
+<?php } ?>

--- a/www/includes/easyparliament/templates/html/mp/_stale_data_panel.php
+++ b/www/includes/easyparliament/templates/html/mp/_stale_data_panel.php
@@ -1,4 +1,4 @@
-<?php if (in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+<?php if (in_array(HOUSE_TYPE_COMMONS, $houses)) { ?>
 <a name="stale-data-warning"></a>
 <div class="panel panel--highlight">
 
@@ -7,4 +7,4 @@
     </p>
 
 </div>
-<?php endif; ?>
+<?php } ?>

--- a/www/includes/easyparliament/templates/html/mp/_whip_removal_panel.php
+++ b/www/includes/easyparliament/templates/html/mp/_whip_removal_panel.php
@@ -1,4 +1,4 @@
-<?php if ($whip_removal_info && $whip_removal_info['has_whip_removed']): ?>
+<?php if ($whip_removal_info && $whip_removal_info['has_whip_removed']) { ?>
 <div class="panel panel--highlight">
     <h3><?php printf(gettext('Why is %s listed as an independent %s?'), _htmlentities($full_name), $latest_membership['rep_name']); ?></h3>
     <p>
@@ -7,10 +7,10 @@
     <p>
         <?= gettext('The whip can be removed for various reasons, including voting against the party on key issues, breaches of party rules, or other disciplinary matters.') ?>
     </p>
-    <?php if (!empty($whip_removal_info['source'])): ?>
+    <?php if (!empty($whip_removal_info['source'])) { ?>
     <p>
         <a href="<?= _htmlentities($whip_removal_info['source']) ?>"><?php printf(gettext('Read more about the circumstances %s had the whip removed.'), _htmlentities($full_name)); ?></a>
     </p>
-    <?php endif; ?>
+    <?php } ?>
 </div>
-<?php endif; ?>
+<?php } ?>

--- a/www/includes/easyparliament/templates/html/mp/divisions.php
+++ b/www/includes/easyparliament/templates/html/mp/divisions.php
@@ -75,11 +75,11 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
             <div class="primary-content__unit">
 
-                <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+                <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)) { ?>
                 <div class="panel">
                     <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
                 </div>
-                <?php endif; ?>
+                <?php } ?>
 
                 <?php $displayed_votes = false; ?>
 
@@ -236,11 +236,11 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
                 <?php } ?>
 
-              <?php if ($profile_message): ?>
+              <?php if ($profile_message) { ?>
                 <div class="panel panel--profile-message">
                     <p><?= $profile_message ?></p>
                 </div>
-              <?php endif; ?>
+              <?php } ?>
 
                 <?php if (!$displayed_votes) { ?>
 

--- a/www/includes/easyparliament/templates/html/mp/list.php
+++ b/www/includes/easyparliament/templates/html/mp/list.php
@@ -6,9 +6,9 @@
 
             <ul>
 
-                <?php foreach ($mps as $mp): ?>
+                <?php foreach ($mps as $mp) { ?>
                 <li><a href="<?= $mp['url'] ?>"><?= $mp['name'] ?></a></li>
-                <?php endforeach; ?>
+                <?php } ?>
 
             </ul>
 

--- a/www/includes/easyparliament/templates/html/mp/memberships.php
+++ b/www/includes/easyparliament/templates/html/mp/memberships.php
@@ -26,38 +26,38 @@ $display_wtt_stats_banner = '2015';
                     <p>
                     In the UK Parliament, committees are groups of MPs or Peers who examine specific issues in more detail than can be done in debates.</p>
                     <p>Some committees focus on checking the government’s decisions and spending, while others investigate specific topics and proposed legislation.</p>
-                    <?php if (array_key_exists('posts', $memberships)): ?>
+                    <?php if (array_key_exists('posts', $memberships)) { ?>
                     <p><?= $full_name ?> is currently a member of the following committees:</p>
-                    <?php foreach ($memberships['posts'] as $office): ?>
+                    <?php foreach ($memberships['posts'] as $office) { ?>
                     <h4><?= $office ?></h4>
                     <div class="committee-more-info">
                     <?= $office->htmlDesc() ?>
 
-                    <?php if (!empty($office->external_url)): ?>
+                    <?php if (!empty($office->external_url)) { ?>
                         <p><a href="<?= $office->external_url ?>">Learn more about this committee</a></p>
-                    <?php endif; ?>
+                    <?php } ?>
                     </div>
                     <hr/>
-                    <?php endforeach; ?>
+                    <?php } ?>
 
 
-                    <?php endif; ?>
-                    <?php if (array_key_exists('previous_posts', $memberships)): ?>
+                    <?php } ?>
+                    <?php if (array_key_exists('previous_posts', $memberships)) { ?>
 
                     <a ></a>
                     <h3 id="previous_posts"><?=gettext('Committee memberships held in the past') ?></h3>
 
                     <ul class='list-dates'>
 
-                        <?php foreach ($memberships['previous_posts'] as $office): ?>
+                        <?php foreach ($memberships['previous_posts'] as $office) { ?>
                         <li><?= $office ?> <small>(<?= $office->pretty_dates() ?>)</small></li>
-                        <?php endforeach; ?>
+                        <?php } ?>
 
                     </ul>
-                    <?php endif; ?>
+                    <?php } ?>
                 </div>
 
-                    <?php if (array_key_exists('appg_membership', $memberships)): ?>
+                    <?php if (array_key_exists('appg_membership', $memberships)) { ?>
                         <div class="panel">
                         <h2><?=gettext('All-Party Parliamentary Groups (APPGs)') ?></h2>
                         <p>All-Party Parliamentary Groups (APPGs) are informal cross-party groups made up of MPs and Peers who share an interest in a particular country or subject.</p>
@@ -70,13 +70,13 @@ $display_wtt_stats_banner = '2015';
                         ];
                         ?>
 
-                        <?php foreach ($appg_roles as $role_key => $role_title): ?>
+                        <?php foreach ($appg_roles as $role_key => $role_title) { ?>
 
-                            <?php if (!$memberships['appg_membership']->$role_key->isEmpty()): ?>
+                            <?php if (!$memberships['appg_membership']->$role_key->isEmpty()) { ?>
                                 <h3 id="appg_<?= $role_key ?>"><?= $role_title ?></h3>
                                 <?php /** @var MySociety\TheyWorkForYou\DataClass\APPGs\APPGMembership $membership */ ?>
 
-                                <?php foreach ($memberships['appg_membership']->$role_key as $membership): ?>
+                                <?php foreach ($memberships['appg_membership']->$role_key as $membership) { ?>
                                     <hr>
                                     <p>
                                         <span><?= $membership->appg->title ?> <?= $membership->role ? '(' . $membership->role . ')' : '' ?></span>
@@ -92,17 +92,17 @@ $display_wtt_stats_banner = '2015';
                                                             E-mail correspondence with APPG
                                                         <?php } ?>
                                                     </li>
-                                                    <li><span class="appg-property-label">APPG Website:</span> <?php if ($membership->appg->website): ?><a href="<?= $membership->appg->website ?>"><?= $membership->appg->website ?></a><?php else: ?>N/A<?php endif; ?></li>
+                                                    <li><span class="appg-property-label">APPG Website:</span> <?php if ($membership->appg->website) { ?><a href="<?= $membership->appg->website ?>"><?= $membership->appg->website ?></a><?php } else { ?>N/A<?php } ?></li>
                                                     <li><span class="appg-property-label">APPG register:</span> <a href="<?= $membership->appg->source_url ?>">Parliament website</a></li>
                                                 </ul>
                                             </div>
                                         </details>
                                     </p>
-                                <?php endforeach; ?>
-                            <?php endif; ?>
-                        <?php endforeach; ?>
+                                <?php } ?>
+                            <?php } ?>
+                        <?php } ?>
                         </div>
-                    <?php endif; ?>
+                    <?php } ?>
 
                 <?php include('_profile_footer.php'); ?>
 

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -18,9 +18,9 @@ $display_wtt_stats_banner = '2015';
                     <h3 class="browse-content"><?= gettext('Browse content') ?></h3>
                     <ul>
                         <li><a href="#profile"><?= gettext('Profile') ?></a></li>
-                        <?php if (count($recent_appearances['appearances'])): ?>
+                        <?php if (count($recent_appearances['appearances'])) { ?>
                           <li><a href="#appearances"><?= gettext('Appearances') ?></a></li>
-                        <?php endif; ?>
+                        <?php } ?>
                       </ul>
                       <?php include '_featured_content.php'; ?>
                       <?php include '_donation.php'; ?>
@@ -29,17 +29,17 @@ $display_wtt_stats_banner = '2015';
 
             <div class="primary-content__unit">
 
-              <?php if ($profile_message): ?>
+              <?php if ($profile_message) { ?>
                 <div id="profile-message" class="panel panel--profile-message">
                     <p><?= $profile_message ?></p>
                 </div>
-              <?php endif; ?>
+              <?php } ?>
 
-              <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+              <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)) { ?>
                 <div class="panel">
                     <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
                 </div>
-              <?php elseif (isset($is_new_mp) && $is_new_mp && count($recent_appearances['appearances']) == 0): ?>
+              <?php } elseif (isset($is_new_mp) && $is_new_mp && count($recent_appearances['appearances']) == 0) { ?>
                 <div class="panel panel--secondary">
                     <h3><?= $full_name ?> is a recently elected MP &ndash; elected on <?= format_date($entry_date, LONGDATEFORMAT) ?></h3>
 
@@ -49,7 +49,7 @@ $display_wtt_stats_banner = '2015';
                     <a href="<?= WEBPATH ?>alert/?pid=<?= $person_id ?>#" onclick="trackLinkClick(this, 'alert_click', 'Search', 'Person'); return false;">Sign up for email alerts to be the first to know when that happens.</a>
                   <?php } ?>
                 </div>
-              <?php endif; ?>
+              <?php } ?>
 
                 <?php include "_chamber_info_panel.php"; ?>
 
@@ -59,21 +59,21 @@ $display_wtt_stats_banner = '2015';
 
                     <p><?= $member_summary ?></p>
 
-                    <?php if (count($enter_leave) > 0): ?>
-                        <?php foreach ($enter_leave as $string): ?>
+                    <?php if (count($enter_leave) > 0) { ?>
+                        <?php foreach ($enter_leave as $string) { ?>
                             <p><?= $string ?></p>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
+                        <?php } ?>
+                    <?php } ?>
 
-                    <?php if ($other_parties): ?>
+                    <?php if ($other_parties) { ?>
                     <p><?= $other_parties ?></p>
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if ($other_constituencies): ?>
+                    <?php if ($other_constituencies) { ?>
                     <p><?= $other_constituencies ?></p>
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($useful_links) > 0): ?>
+                    <?php if (count($useful_links) > 0) { ?>
 
                     <ul class="comma-list">
 
@@ -86,36 +86,36 @@ $display_wtt_stats_banner = '2015';
 
                     </ul>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($social_links) > 0): ?>
+                    <?php if (count($social_links) > 0) { ?>
                     <h3><?=gettext('Social Media') ?></h3>
                     <ul>
-                        <?php foreach ($social_links as $link): ?>
+                        <?php foreach ($social_links as $link) { ?>
                         <li><a class="fi-social-<?= $link['type'] ?>" href="<?= $link['href'] ?>" onclick="trackLinkClick(this, 'social_link', '<?= $link['type'] ?>', '<?= $link['text'] ?>'); return false;"><?= $link['text'] ?></a></li>
-                        <?php endforeach; ?>
+                        <?php } ?>
                     </ul>
-                    <?php endif; ?>
+                    <?php } ?>
 
 
-                    <?php if ($has_expenses): ?>
+                    <?php if ($has_expenses) { ?>
                     <h3>Expenses</h3>
 
                     <ul>
-                        <?php if ($pre_2010_expenses): ?>
+                        <?php if ($pre_2010_expenses) { ?>
                         <li><a href="<?= $expenses_url_2004 ?>">Expenses from 2004 to 2009</a></li>
-                        <?php endif; ?>
-                        <?php if ($post_2010_expenses): ?>
+                        <?php } ?>
+                        <?php if ($post_2010_expenses) { ?>
                         <li><a href="https://www.theipsa.org.uk/mp-staffing-business-costs/your-mp/<?=slugify($full_name)?>/<?=$post_2010_expenses?>">Expenses from 2010 onwards</a></li>
-                        <?php endif; ?>
+                        <?php } ?>
                     </ul>
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($topics_of_interest) > 0 || $eu_stance): ?>
+                    <?php if (count($topics_of_interest) > 0 || $eu_stance) { ?>
 
                     <h3><?= gettext('Topics of interest') ?></h3>
 
-                    <?php if ($eu_stance): ?>
+                    <?php if ($eu_stance) { ?>
                         <p>
                             <?php if ($eu_stance == 'Leave' || $eu_stance == 'Remain') { ?>
                                 <strong><?= $full_name ?></strong> campaigned to <?= $eu_stance == 'Leave' ? 'leave' : 'remain in' ?> the European Union
@@ -124,129 +124,129 @@ $display_wtt_stats_banner = '2015';
                             <?php } ?>
                             <small>Source: <a href="https://www.bbc.co.uk/news/uk-politics-eu-referendum-35616946">BBC</a></small>
                         </p>
-                    <?php endif; ?>
+                    <?php } ?>
 
                     <ul class="comma-list">
 
-                        <?php foreach ($topics_of_interest as $topic): ?>
+                        <?php foreach ($topics_of_interest as $topic) { ?>
                         <li><?= $topic ?></li>
-                        <?php endforeach; ?>
+                        <?php } ?>
 
                     </ul>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($current_offices) > 0): ?>
+                    <?php if (count($current_offices) > 0) { ?>
 
                     <h3><?=gettext('Currently held offices') ?></h3>
 
                     <ul class='list-dates'>
 
-                        <?php foreach ($current_offices as $office): ?>
+                        <?php foreach ($current_offices as $office) { ?>
                         <li><?= $office ?> <small>(<?= $office->pretty_dates() ?>)</small></li>
-                        <?php endforeach; ?>
+                        <?php } ?>
 
                     </ul>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($previous_offices) > 0): ?>
+                    <?php if (count($previous_offices) > 0) { ?>
 
                     <h3><?=gettext('Other offices held in the past') ?></h3>
 
                     <ul class='list-dates'>
 
-                        <?php foreach ($previous_offices as $office): ?>
+                        <?php foreach ($previous_offices as $office) { ?>
                         <li><?= $office ?> <small>(<?= $office->pretty_dates() ?>)</small></li>
-                        <?php endforeach; ?>
+                        <?php } ?>
 
                     </ul>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($constituency_previous_mps) > 0): ?>
+                    <?php if (count($constituency_previous_mps) > 0) { ?>
 
                     <h3>Previous MPs in this constituency</h3>
 
                     <ul class="comma-list">
 
-                        <?php foreach ($constituency_previous_mps as $constituency_previous_mp): ?>
+                        <?php foreach ($constituency_previous_mps as $constituency_previous_mp) { ?>
                         <li><a href="<?= $constituency_previous_mp['href'] ?>"><?= $constituency_previous_mp['text'] ?></a></li>
-                        <?php endforeach; ?>
+                        <?php } ?>
 
                     </ul>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($constituency_future_mps) > 0): ?>
+                    <?php if (count($constituency_future_mps) > 0) { ?>
 
                     <h3>Future MPs in this constituency</h3>
 
                     <ul class="comma-list">
 
-                        <?php foreach ($constituency_future_mps as $constituency_future_mp): ?>
+                        <?php foreach ($constituency_future_mps as $constituency_future_mp) { ?>
                         <li><a href="<?= $constituency_future_mp['href'] ?>"><?= $constituency_future_mp['text'] ?></a></li>
-                        <?php endforeach; ?>
+                        <?php } ?>
 
                     </ul>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($public_bill_committees['data']) > 0): ?>
+                    <?php if (count($public_bill_committees['data']) > 0) { ?>
 
                     <h3>Public bill committees <small>(Sittings attended)</small></h3>
 
-                    <?php if ($public_bill_committees['info']): ?>
+                    <?php if ($public_bill_committees['info']) { ?>
                         <p><em><?= $public_bill_committees['info'] ?></em></p>
-                    <?php endif; ?>
+                    <?php } ?>
 
                     <ul>
 
-                        <?php foreach ($public_bill_committees['data'] as $committee): ?>
+                        <?php foreach ($public_bill_committees['data'] as $committee) { ?>
                         <li><a href="<?= $committee['href'] ?>"><?= $committee['text'] ?></a> (<?= $committee['attending'] ?>)</li>
-                        <?php endforeach; ?>
+                        <?php } ?>
 
                     </ul>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
                 </div>
 
 
-                <?php if (count($recent_appearances['appearances'])): ?>
+                <?php if (count($recent_appearances['appearances'])) { ?>
                 <div class="panel">
                     <a name="appearances"></a>
                     <h2><?=gettext('Recent appearances') ?></h2>
 
-                    <?php if (count($recent_appearances['appearances']) > 0): ?>
+                    <?php if (count($recent_appearances['appearances']) > 0) { ?>
 
                         <ul class="appearances">
 
-                        <?php foreach ($recent_appearances['appearances'] as $recent_appearance): ?>
+                        <?php foreach ($recent_appearances['appearances'] as $recent_appearance) { ?>
 
                             <li>
                                 <h4><a href="<?= $recent_appearance['listurl'] ?>"><?= $recent_appearance['parent']['body'] ?></a> <span class="date"><?= date('j M Y', strtotime($recent_appearance['hdate'])) ?></span></h4>
                                 <blockquote><?= $recent_appearance['extract'] ?></blockquote>
                             </li>
 
-                        <?php endforeach; ?>
+                        <?php } ?>
 
                         </ul>
 
                         <p><a href="<?= $recent_appearances['more_href'] ?>"><?= $recent_appearances['more_text'] ?></a></p>
 
-                        <?php if (isset($recent_appearances['additional_links'])): ?>
+                        <?php if (isset($recent_appearances['additional_links'])) { ?>
                         <?= $recent_appearances['additional_links'] ?>
-                        <?php endif; ?>
+                        <?php } ?>
 
-                    <?php else: ?>
+                    <?php } else { ?>
 
                         <p><?=gettext('No recent appearances to display.') ?></p>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
                 </div>
-                <?php endif; ?>
+                <?php } ?>
 
                 <?php include('_profile_footer.php'); ?>
 

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -18,19 +18,19 @@ $display_wtt_stats_banner = '2015';
 
             <div class="primary-content__unit">
 
-              <?php if ($profile_message): ?>
+              <?php if ($profile_message) { ?>
                 <div id="profile-message" class="panel panel--profile-message">
                     <p><?= $profile_message ?></p>
                 </div>
-              <?php else: ?>
+              <?php } else { ?>
                 <?php include '_donation_banner.php'; ?>
-              <?php endif; ?>
+              <?php } ?>
 
-              <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+              <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)) { ?>
                 <div class="panel">
                     <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
                 </div>
-              <?php elseif (isset($is_new_mp) && $is_new_mp && count($recent_appearances['appearances']) == 0): ?>
+              <?php } elseif (isset($is_new_mp) && $is_new_mp && count($recent_appearances['appearances']) == 0) { ?>
                 <div class="panel panel--secondary">
                     <h3><?= $full_name ?> is a recently elected MP &ndash; elected on <?= format_date($entry_date, LONGDATEFORMAT) ?></h3>
 
@@ -40,7 +40,7 @@ $display_wtt_stats_banner = '2015';
                     <a href="<?= WEBPATH ?>alert/?pid=<?= $person_id ?>#" onclick="trackLinkClick(this, 'alert_click', 'Search', 'Person'); return false;">Sign up for email alerts to be the first to know when that happens.</a>
                   <?php } ?>
                 </div>
-              <?php endif; ?>
+              <?php } ?>
 
                 <?php include "_whip_removal_panel.php"; ?>
 
@@ -52,21 +52,21 @@ $display_wtt_stats_banner = '2015';
 
                     <p><?= $member_summary ?></p>
 
-                    <?php if (count($enter_leave) > 0): ?>
-                        <?php foreach ($enter_leave as $string): ?>
+                    <?php if (count($enter_leave) > 0) { ?>
+                        <?php foreach ($enter_leave as $string) { ?>
                             <p><?= $string ?></p>
-                        <?php endforeach; ?>
-                    <?php endif; ?>
+                        <?php } ?>
+                    <?php } ?>
 
-                    <?php if ($other_parties): ?>
+                    <?php if ($other_parties) { ?>
                     <p><?= $other_parties ?></p>
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if ($other_constituencies): ?>
+                    <?php if ($other_constituencies) { ?>
                     <p><?= $other_constituencies ?></p>
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($useful_links) > 0): ?>
+                    <?php if (count($useful_links) > 0) { ?>
 
                     <ul class="comma-list">
 
@@ -79,104 +79,104 @@ $display_wtt_stats_banner = '2015';
 
                     </ul>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($social_links) > 0): ?>
+                    <?php if (count($social_links) > 0) { ?>
                     <h3><?=gettext('Social Media') ?></h3>
                     <ul>
-                        <?php foreach ($social_links as $link): ?>
+                        <?php foreach ($social_links as $link) { ?>
                         <li><a class="fi-social-<?= $link['type'] ?>" href="<?= $link['href'] ?>" onclick="trackLinkClick(this, 'social_link', '<?= $link['type'] ?>', '<?= $link['text'] ?>'); return false;"><?= $link['text'] ?></a></li>
-                        <?php endforeach; ?>
+                        <?php } ?>
                     </ul>
-                    <?php endif; ?>
+                    <?php } ?>
 
 
-                    <?php if ($has_expenses): ?>
+                    <?php if ($has_expenses) { ?>
                     <h3>Expenses</h3>
 
                     <ul>
-                        <?php if ($pre_2010_expenses): ?>
+                        <?php if ($pre_2010_expenses) { ?>
                         <li><a href="<?= $expenses_url_2004 ?>">Expenses from 2004 to 2009</a></li>
-                        <?php endif; ?>
-                        <?php if ($post_2010_expenses): ?>
+                        <?php } ?>
+                        <?php if ($post_2010_expenses) { ?>
                         <li><a href="https://www.theipsa.org.uk/mp-staffing-business-costs/your-mp/<?=slugify($full_name)?>/<?=$post_2010_expenses?>">Expenses from 2010 onwards</a></li>
-                        <?php endif; ?>
+                        <?php } ?>
                     </ul>
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($current_offices) > 0): ?>
+                    <?php if (count($current_offices) > 0) { ?>
 
                     <h3><?=gettext('Currently held offices') ?></h3>
 
                     <ul class='list-dates'>
 
-                        <?php foreach ($current_offices as $office): ?>
+                        <?php foreach ($current_offices as $office) { ?>
                         <li><?= $office ?> <small>(<?= $office->pretty_dates() ?>)</small></li>
-                        <?php endforeach; ?>
+                        <?php } ?>
 
                     </ul>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($previous_offices) > 0): ?>
+                    <?php if (count($previous_offices) > 0) { ?>
 
                     <h3><?=gettext('Other offices held in the past') ?></h3>
 
                     <ul class='list-dates'>
 
-                        <?php foreach ($previous_offices as $office): ?>
+                        <?php foreach ($previous_offices as $office) { ?>
                         <li><?= $office ?> <small>(<?= $office->pretty_dates() ?>)</small></li>
-                        <?php endforeach; ?>
+                        <?php } ?>
 
                     </ul>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($constituency_previous_mps) > 0): ?>
+                    <?php if (count($constituency_previous_mps) > 0) { ?>
 
                     <h3>Previous MPs in this constituency</h3>
 
                     <ul class="comma-list">
 
-                        <?php foreach ($constituency_previous_mps as $constituency_previous_mp): ?>
+                        <?php foreach ($constituency_previous_mps as $constituency_previous_mp) { ?>
                         <li><a href="<?= $constituency_previous_mp['href'] ?>"><?= $constituency_previous_mp['text'] ?></a></li>
-                        <?php endforeach; ?>
+                        <?php } ?>
 
                     </ul>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($constituency_future_mps) > 0): ?>
+                    <?php if (count($constituency_future_mps) > 0) { ?>
 
                     <h3>Future MPs in this constituency</h3>
 
                     <ul class="comma-list">
 
-                        <?php foreach ($constituency_future_mps as $constituency_future_mp): ?>
+                        <?php foreach ($constituency_future_mps as $constituency_future_mp) { ?>
                         <li><a href="<?= $constituency_future_mp['href'] ?>"><?= $constituency_future_mp['text'] ?></a></li>
-                        <?php endforeach; ?>
+                        <?php } ?>
 
                     </ul>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
-                    <?php if (count($public_bill_committees['data']) > 0): ?>
+                    <?php if (count($public_bill_committees['data']) > 0) { ?>
 
                     <h3>Public bill committees <small>(Sittings attended)</small></h3>
 
-                    <?php if ($public_bill_committees['info']): ?>
+                    <?php if ($public_bill_committees['info']) { ?>
                         <p><em><?= $public_bill_committees['info'] ?></em></p>
-                    <?php endif; ?>
+                    <?php } ?>
 
                     <ul>
 
-                        <?php foreach ($public_bill_committees['data'] as $committee): ?>
+                        <?php foreach ($public_bill_committees['data'] as $committee) { ?>
                         <li><a href="<?= $committee['href'] ?>"><?= $committee['text'] ?></a> (<?= $committee['attending'] ?>)</li>
-                        <?php endforeach; ?>
+                        <?php } ?>
 
                     </ul>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
                 </div>
 

--- a/www/includes/easyparliament/templates/html/mp/recent.php
+++ b/www/includes/easyparliament/templates/html/mp/recent.php
@@ -11,11 +11,11 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
             <div class="primary-content__unit">
 
 
-                <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+                <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)) { ?>
                 <div class="panel">
                     <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
                 </div>
-                <?php endif; ?>
+                <?php } ?>
 
                 <?php
 

--- a/www/includes/easyparliament/templates/html/mp/recent.php
+++ b/www/includes/easyparliament/templates/html/mp/recent.php
@@ -9,11 +9,11 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
                 <?php include '_donation_banner.php'; ?>
 
-                <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+                <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)) { ?>
                 <div class="panel">
                     <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
                 </div>
-                <?php endif; ?>
+                <?php } ?>
 
                 <?php $vote_count = isset($divisions) ? count($divisions) : 0;?>
 

--- a/www/includes/easyparliament/templates/html/mp/regional_list.php
+++ b/www/includes/easyparliament/templates/html/mp/regional_list.php
@@ -6,9 +6,9 @@
 
             <ul>
 
-                <?php foreach ($members as $member): ?>
+                <?php foreach ($members as $member) { ?>
                 <li><a href="<?= $member['url'] ?>"><?= $member['name'] ?></a></li>
-                <?php endforeach; ?>
+                <?php } ?>
 
             </ul>
 

--- a/www/includes/easyparliament/templates/html/mp/register.php
+++ b/www/includes/easyparliament/templates/html/mp/register.php
@@ -23,7 +23,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
             <div class="primary-content__unit">
 
-                <?php if ($register_interests): ?>
+                <?php if ($register_interests) { ?>
                 <div class="panel register">
                     <a name="register"></a>
                     <h2>Register of Members&rsquo; Interests</h2>
@@ -32,9 +32,9 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                     <p>
                         <a href="<?= WEBPATH ?>regmem/?p=<?= $person_id ?>">View the history of this MP&rsquo;s entries in the Register</a>
                     </p>
-                    <?php if ($register_interests['date']): ?>
+                    <?php if ($register_interests['date']) { ?>
                         <p>Last updated: <?= $register_interests['date'] ?>.</p>
-                    <?php endif; ?>
+                    <?php } ?>
 
                     <?= $register_interests['data'] ?>
 
@@ -43,7 +43,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                          <a class="moreinfo-link" href="https://www.parliament.uk/mps-lords-and-offices/standards-and-financial-interests/parliamentary-commissioner-for-standards/registers-of-interests/register-of-members-financial-interests/">More about the register</a>
                     </p>
                 </div>
-                <?php endif; ?>
+                <?php } ?>
 
                 <?php include('_profile_footer.php'); ?>
 

--- a/www/includes/easyparliament/templates/html/mp/signatures.php
+++ b/www/includes/easyparliament/templates/html/mp/signatures.php
@@ -20,58 +20,58 @@ $display_wtt_stats_banner = '2015';
 
                 <?php include '_donation_banner.php'; ?>
 
-                <?php if (array_key_exists('letters_signed', $memberships) || array_key_exists('edms_signed', $memberships) || array_key_exists('annul_motions_signed', $memberships)): ?>
+                <?php if (array_key_exists('letters_signed', $memberships) || array_key_exists('edms_signed', $memberships) || array_key_exists('annul_motions_signed', $memberships)) { ?>
                     <div class="panel">
                     <h2 id="signatures"><?= gettext('Signatures') ?></h2>
-                <?php endif; ?>
-                <?php if (array_key_exists('annul_motions_signed', $memberships)): ?>
+                <?php } ?>
+                <?php if (array_key_exists('annul_motions_signed', $memberships)) { ?>
                     <h3 id="annul_motions_signed"><?=gettext('Recent motions to annul signed') ?></h3>
                     <p>Some kinds of government regulations automatically become law if Parliament does not object (negative statutory instrument). A motion to annul/prayer is a request to hold a vote to object. </p>
                     <p><em>Showing motions to annul signed in the last year.</em></p>
                     <ul class='list-dates'>
-                        <?php foreach ($memberships['annul_motions_signed'] as $signature): ?>
+                        <?php foreach ($memberships['annul_motions_signed'] as $signature) { ?>
                         <li><?= $signature->date ?>: <a href="<?= $signature->statement->link() ?>"><?= $signature->statement->title ?></a> (+<?= $signature->statement->total_signatures - 1 ?> others)</li>
-                        <?php endforeach; ?>
+                        <?php } ?>
                     </ul>
-                <?php endif; ?>
+                <?php } ?>
 
-                <?php if (array_key_exists('letters_signed', $memberships)): ?>
+                <?php if (array_key_exists('letters_signed', $memberships)) { ?>
                     <h3 id="letters_signed"><?=gettext('Recent open letters signed') ?></h3>
                     <p>We're starting to collect and display when representatives sign open letters - if there are examples we're missing, <a href="https://survey.alchemer.com/s3/8440376/TheyWorkForYou-Open-Letter">please let us know</a>.</p>
                     <p><em>Showing open letters signed in the last year.</em></p>
                     <ul class='list-dates'>
-                        <?php foreach ($memberships['letters_signed'] as $signature): ?>
+                        <?php foreach ($memberships['letters_signed'] as $signature) { ?>
                         <li><?= $signature->date ?>: <a href="<?= $signature->statement->link() ?>"><?= $signature->statement->title ?></a> (+<?= $signature->statement->total_signatures - 1 ?> others)</li>
-                        <?php endforeach; ?>
+                        <?php } ?>
                     </ul>
-                <?php endif; ?>
+                <?php } ?>
 
-                <?php if (array_key_exists('edms_signed', $memberships)): ?>
+                <?php if (array_key_exists('edms_signed', $memberships)) { ?>
                     <h3 id="edms_signed"><?=gettext('Recent Early Day Motions signed') ?></h3>
                     <p>Early Day Motions are when MPs can propose and co-sign statements for discussion. In practice, these work as internal petitions where MPs can signal their support for a particular issue or cause.</p>
                     <p><em>Showing Early Day Motions signed in the last 3 months.</em></p>
                     <ul class='list-dates'>
-                        <?php foreach ($memberships['edms_signed'] as $signature): ?>
+                        <?php foreach ($memberships['edms_signed'] as $signature) { ?>
                         <li><?= $signature->date ?>: <a href="<?= $signature->statement->link() ?>"><?= $signature->statement->title ?></a> (+<?= $signature->statement->total_signatures - 1  ?> others)</li>
-                        <?php endforeach; ?>
+                        <?php } ?>
                     </ul>
-                <?php endif; ?>
+                <?php } ?>
 
-                <?php if (array_key_exists('edms_signed', $memberships) || array_key_exists('letters_signed', $memberships) || array_key_exists('annul_motions_signed', $memberships)): ?>
+                <?php if (array_key_exists('edms_signed', $memberships) || array_key_exists('letters_signed', $memberships) || array_key_exists('annul_motions_signed', $memberships)) { ?>
                     <p>
                     <a href="https://votes.theyworkforyou.com/person/<?= $person_id ?>/statements"><?= gettext('All open letters and EDMs signed') ?></a>.
                     </p>
-                    <?php endif; ?>
+                    <?php } ?>
 
-                <?php if (array_key_exists('letters_signed', $memberships) || array_key_exists('edms_signed', $memberships) || array_key_exists('annul_motions_signed', $memberships)): ?>
+                <?php if (array_key_exists('letters_signed', $memberships) || array_key_exists('edms_signed', $memberships) || array_key_exists('annul_motions_signed', $memberships)) { ?>
                     </div>
-                <?php endif; ?>
+                <?php } ?>
 
-                <?php if (array_key_exists('topics_of_interest', $memberships) || array_key_exists('eu_stance', $memberships)): ?>
+                <?php if (array_key_exists('topics_of_interest', $memberships) || array_key_exists('eu_stance', $memberships)) { ?>
                     <div class="panel">
                         <h2 id="topics"><?= gettext('Topics of interest') ?></h2>
 
-                        <?php if (array_key_exists('eu_stance', $memberships)): ?>
+                        <?php if (array_key_exists('eu_stance', $memberships)) { ?>
                             <p>
                                 <?php if ($memberships['eu_stance'] == 'Leave' || $memberships['eu_stance'] == 'Remain') { ?>
                                     <strong><?= $full_name ?></strong> campaigned to <?= $memberships['eu_stance'] == 'Leave' ? 'leave' : 'remain in' ?> the European Union
@@ -80,17 +80,17 @@ $display_wtt_stats_banner = '2015';
                                 <?php } ?>
                                 <small>Source: <a href="https://www.bbc.co.uk/news/uk-politics-eu-referendum-35616946">BBC</a></small>
                             </p>
-                        <?php endif; ?>
+                        <?php } ?>
 
-                        <?php if (array_key_exists('topics_of_interest', $memberships)): ?>
+                        <?php if (array_key_exists('topics_of_interest', $memberships)) { ?>
                             <ul class="comma-list">
-                                <?php foreach ($memberships['topics_of_interest'] as $topic): ?>
+                                <?php foreach ($memberships['topics_of_interest'] as $topic) { ?>
                                 <li><?= $topic ?></li>
-                                <?php endforeach; ?>
+                                <?php } ?>
                             </ul>
-                        <?php endif; ?>
+                        <?php } ?>
                     </div>
-                <?php endif; ?>
+                <?php } ?>
 
                 <?php include('_profile_footer.php'); ?>
 

--- a/www/includes/easyparliament/templates/html/mp/speeches.php
+++ b/www/includes/easyparliament/templates/html/mp/speeches.php
@@ -14,11 +14,11 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
                 <?php include '_donation_banner.php'; ?>
 
-                <?php if ($profile_message): ?>
+                <?php if ($profile_message) { ?>
                 <div class="panel panel--profile-message">
                     <p><?= $profile_message ?></p>
                 </div>
-                <?php endif; ?>
+                <?php } ?>
 
               
                     <div class="panel">
@@ -27,12 +27,12 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                     <?php if (count($recent_appearances['speeches']) > 0) { ?>
 
                         <ul class="appearances speeches">
-                            <?php foreach ($recent_appearances['speeches'] as $speech): ?>
+                            <?php foreach ($recent_appearances['speeches'] as $speech) { ?>
                                 <li>
                                     <h4><a href="<?= $speech['listurl'] ?>"><?= $speech['parent']['body'] ?></a> <span class="date"><?= date('j M Y', strtotime($speech['hdate'])) ?></span></h4>
                                     <blockquote><?= $speech['extract'] ?></blockquote>
                                 </li>
-                            <?php endforeach; ?>
+                            <?php } ?>
                         </ul>
                         <p><a href="<?= $recent_appearances['more_speeches_href'] ?>"><?= $recent_appearances['more_speeches_text'] ?></a></p>
                     
@@ -47,12 +47,12 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                     <?php if (count($recent_appearances['written_questions']) > 0) { ?>
 
                         <ul class="appearances written-questions">
-                            <?php foreach ($recent_appearances['written_questions'] as $written): ?>
+                            <?php foreach ($recent_appearances['written_questions'] as $written) { ?>
                                 <li>
                                     <h4><a href="<?= $written['listurl'] ?>"><?= $written['parent']['body'] ?></a> <span class="date"><?= date('j M Y', strtotime($written['hdate'])) ?></span></h4>
                                     <blockquote><?= $written['extract'] ?></blockquote>
                                 </li>
-                            <?php endforeach; ?>
+                            <?php } ?>
                         </ul>
                         <p><a href="<?= $recent_appearances['more_questions_href'] ?>"><?= $recent_appearances['more_questions_text'] ?></a></p>
                     <?php } else { ?>

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -16,13 +16,13 @@ $covid_policy_list = $policies_obj->getCovidAffected();
                 <div>
                     <h3 class="browse-content"><?= gettext('Browse content') ?></h3>
                     <ul>
-                        <?php if ($has_voting_record): ?>
-                        <?php foreach ($key_votes_segments as $segment): ?>
-                        <?php if (count($segment['votes']->positions) > 0): ?>
+                        <?php if ($has_voting_record) { ?>
+                        <?php foreach ($key_votes_segments as $segment) { ?>
+                        <?php if (count($segment['votes']->positions) > 0) { ?>
                         <li><a href="#<?= $segment['key'] ?>"><?= $segment['title'] ?></a></li>
-                        <?php endif; ?>
-                        <?php endforeach; ?>
-                        <?php endif; ?>
+                        <?php } ?>
+                        <?php } ?>
+                        <?php } ?>
                     </ul>
                     <?php include '_featured_content.php'; ?>
                     <?php include '_donation.php'; ?>
@@ -30,11 +30,11 @@ $covid_policy_list = $policies_obj->getCovidAffected();
             </div>
             <div class="primary-content__unit">
 
-                <?php if ($profile_message): ?>
+                <?php if ($profile_message) { ?>
                 <div class="panel panel--profile-message">
                     <p><?= $profile_message ?></p>
                 </div>
-                <?php endif; ?>
+                <?php } ?>
 
 
                 <div class="panel">
@@ -67,21 +67,21 @@ $covid_policy_list = $policies_obj->getCovidAffected();
                     <p>Learn more about <a href="/support-us/#why-does-mysociety-need-donations-for-these-sites">how we'll use your donation</a> and <a href="/support-us/#i-want-to-be-a-mysociety-supporter">other ways to help</a>.</p>
                 </div>
 
-                <?php if ($party_switcher == true): ?>
+                <?php if ($party_switcher == true) { ?>
                     <?php include('_cross_party_mp_panel.php'); ?>
-                <?php endif; ?>
+                <?php } ?>
 
-                <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+                <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)) { ?>
                 <div class="panel">
                     <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
                 </div>
-                <?php elseif (isset($is_new_mp) && $is_new_mp && !$has_voting_record): ?>
+                <?php } elseif (isset($is_new_mp) && $is_new_mp && !$has_voting_record) { ?>
                 <div class="panel panel--secondary">
                     <h3><?= $full_name ?> is a recently elected MP - elected on <?= format_date($entry_date, LONGDATEFORMAT) ?></h3>
 
                     <p>When <?= $full_name ?> starts to vote on bills, that information will appear on this page.</p>
                 </div>
-                <?php endif; ?>
+                <?php } ?>
 
                 <?php if ($party_member_count > 1) { ?>
                 <div class="panel">
@@ -152,16 +152,16 @@ $covid_policy_list = $policies_obj->getCovidAffected();
                 </div>
                 <?php } ?>
 
-                <?php if ($has_voting_record): ?>
+                <?php if ($has_voting_record) { ?>
                     
                     <?php $policies_obj = new MySociety\TheyWorkForYou\Policies(); ?>
                     <?php $covid_policy_list = $policies_obj->getCovidAffected(); ?>
 
                     <?php $displayed_votes = false; ?>
 
-                    <?php foreach ($key_votes_segments as $segment): ?>
+                    <?php foreach ($key_votes_segments as $segment) { ?>
 
-                        <?php if (count($segment['votes']->positions) > 0): ?>
+                        <?php if (count($segment['votes']->positions) > 0) { ?>
                         <?php $most_recent = ''; ?>
 
                         <div class="panel">
@@ -244,29 +244,29 @@ $covid_policy_list = $policies_obj->getCovidAffected();
 
                             <?php $displayed_votes = true; ?>
 
-                        <?php endif; ?>
+                        <?php } ?>
 
-                    <?php endforeach; ?>
+                    <?php } ?>
 
-                    <?php if ($displayed_votes): ?>
+                    <?php if ($displayed_votes) { ?>
 
-                        <?php if ($segment['votes']->moreLinksString): ?>
+                        <?php if ($segment['votes']->moreLinksString) { ?>
 
                             <div class="panel">
                                 <p><?= $segment['votes']->moreLinksString ?></p>
                             </div>
 
-                        <?php endif; ?>
+                        <?php } ?>
 
-                    <?php else: ?>
+                    <?php } else { ?>
 
                         <div class="panel">
                             <p>This person has not voted on any of the key issues which we keep track of.</p>
                         </div>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
-                <?php endif; ?>
+                <?php } ?>
                 <?php include('_covid19_panel.php'); ?>
 
                 <?php include('_profile_footer.php'); ?>

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -21,16 +21,16 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
                 <?php include '_donation_banner.php'; ?>
 
-                <?php if ($profile_message): ?>
+                <?php if ($profile_message) { ?>
                 <div class="panel panel--profile-message">
                     <p><?= $profile_message ?></p>
                 </div>
-                <?php endif; ?>
+                <?php } ?>
 
 
                 <div class="panel">
                     <h2>Voting summaries</h2>
-                    <?php if (!empty($available_periods)): ?>
+                    <?php if (!empty($available_periods)) { ?>
                         <nav class="subpage-content-list js-accordion" aria-label="Comparison periods">
                             <h3 class="js-accordion-button">For period: <?= $comparison_period->description ?></h3>
                             <ul class="js-accordion-content">
@@ -39,7 +39,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                                 <?php } ?>
                             </ul>
                         </nav>
-                    <?php endif; ?>
+                    <?php } ?>
 
                     <p>
                         MPs have many roles, but one of the most important is that they make decisions. These decisions shape the laws that govern us, and can affect every aspect of how we live our lives. 
@@ -54,16 +54,16 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                         You can read more about <a href="/voting-information/#voting-summaries">our process</a>, <a href="/voting-information/#what-kind-of-votes-are-included-in-theyworkforyou-s-policies">the kinds of votes we include</a>, <a href="/voting-information/#comparison-to-parties">how we compare MPs to parties</a>, and <a href="/voting-information/#votes-are-not-opinions-but-they-matter">why we think this is important</a>.</a>
                     </p>
 
-                            <?php if ($has_voting_record): ?>
+                            <?php if ($has_voting_record) { ?>
                                 <hr>
                                 <p>Below are summaries of how <?= $full_name ?> has voted on key issues, grouped by policy area (randomly ordered).</p>
                                 <nav aria-label="Key issues navigation">
                                     <ul class="votes-navigation-menu">
-                                    <?php foreach ($key_votes_segments as $segment): ?>
-                                        <?php if (count($segment->policy_pairs) > 0): ?>
+                                    <?php foreach ($key_votes_segments as $segment) { ?>
+                                        <?php if (count($segment->policy_pairs) > 0) { ?>
                                         <li><a href="#<?= $segment->group_slug ?>"><?= $segment->group_name ?></a></li>
-                                        <?php endif; ?>
-                                    <?php endforeach; ?>
+                                        <?php } ?>
+                                    <?php } ?>
                                     </ul>
                                 </nav>
                     <?php if ($comparison_period->lslug() === 'labour_2024' && in_array('all_time', array_map(fn($period) => $period->lslug(), $available_periods))) { ?>
@@ -71,25 +71,25 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                     <?php } elseif ($comparison_period->lslug() === 'all_time' && in_array('labour_2024', array_map(fn($period) => $period->lslug(), $available_periods))) { ?>
                         <p>This page shows relevant votes while <?= ucfirst($full_name) ?> has been in Parliament, you can also view a <a href="?comparison_period=labour_2024">summary just for the current Parliament</a>.</p>
                     <?php } ?>
-                            <?php endif; ?>
+                            <?php } ?>
 
                             </div>
 
-                <?php if ($party_switcher == true): ?>
+                <?php if ($party_switcher == true) { ?>
                     <?php include('_cross_party_mp_panel.php'); ?>
-                <?php endif; ?>
+                <?php } ?>
 
-                <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)): ?>
+                <?php if ($party == 'Sinn Féin' && in_array(HOUSE_TYPE_COMMONS, $houses)) { ?>
                 <div class="panel">
                     <p>Sinn F&eacute;in MPs do not take their seats in Parliament.</p>
                 </div>
-                <?php elseif (isset($is_new_mp) && $is_new_mp && !$has_voting_record): ?>
+                <?php } elseif (isset($is_new_mp) && $is_new_mp && !$has_voting_record) { ?>
                 <div class="panel panel--secondary">
                     <h3><?= $full_name ?> is a recently elected MP - elected on <?= format_date($entry_date, LONGDATEFORMAT) ?></h3>
 
                     <p>When <?= $full_name ?> starts to vote on bills, that information will appear on this page.</p>
                 </div>
-                <?php endif; ?>
+                <?php } ?>
 
                 <?php if ($party_member_count > 1 && $party != "Independent") { ?>
                 <div class="panel">
@@ -136,13 +136,13 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                 </div>
                 <?php } ?>
 
-                <?php if ($has_voting_record): ?>
+                <?php if ($has_voting_record) { ?>
                     
                     <?php $displayed_votes = false; ?>
 
-                    <?php foreach ($key_votes_segments as $segment): ?>
+                    <?php foreach ($key_votes_segments as $segment) { ?>
                         
-                        <?php if (count($segment->policy_pairs) > 0): ?>
+                        <?php if (count($segment->policy_pairs) > 0) { ?>
                         <?php $most_recent = ''; ?>
 
                         <div class="panel">
@@ -171,19 +171,19 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
                             <?php $displayed_votes = true; ?>
 
-                        <?php endif; ?>
+                        <?php } ?>
 
-                    <?php endforeach; ?>
+                    <?php } ?>
 
-                    <?php if (!$displayed_votes): ?>
+                    <?php if (!$displayed_votes) { ?>
 
                         <div class="panel">
                             <p>This person has not voted on any of the key issues which we keep track of.</p>
                         </div>
 
-                    <?php endif; ?>
+                    <?php } ?>
 
-                <?php endif; ?>
+                <?php } ?>
                 <?php include('_covid19_panel.php'); ?>
 
                 <?php include('_profile_footer.php'); ?>

--- a/www/includes/easyparliament/templates/html/register/_register_field.php
+++ b/www/includes/easyparliament/templates/html/register/_register_field.php
@@ -1,22 +1,22 @@
 <?php /** @var MySociety\TheyWorkForYou\DataClass\Regmem\Detail $detail */ ?>
 
-<?php if ($detail->type == "container"): ?>
+<?php if ($detail->type == "container") { ?>
     <li class="interest-detail">
     <span class="interest-detail-name"><?= $detail->display_as ?>: </span>
 
     <ul class="interest-detail-values-groups">
         <?php $upper_detail = $detail; ?>
-        <?php foreach ($detail->sub_details() as $detail): ?>
+        <?php foreach ($detail->sub_details() as $detail) { ?>
             <?php include INCLUDESPATH . 'easyparliament/templates/html/register/_register_field.php'; ?>
-        <?php endforeach; ?>
+        <?php } ?>
         <?php $detail = $upper_detail; ?>
     </ul>
     </li>
-<?php else : ?>
+<?php } else { ?>
     <li class="interest-detail">
-    <?php if ($detail->has_value()): ?>
+    <?php if ($detail->has_value()) { ?>
         <span class="interest-detail-name"><?= $detail->display_as ?>: </span>
         <span class="interest-detail-value"><?= htmlspecialchars($detail->value) ?></span>
-    <?php endif; ?>
+    <?php } ?>
     </li>
-<?php endif; ?>
+<?php } ?>

--- a/www/includes/easyparliament/templates/html/topic/list.php
+++ b/www/includes/easyparliament/templates/html/topic/list.php
@@ -9,7 +9,7 @@
         </p>
 
         <ul class="topic-list">
-          <?php foreach ($topics as $topic): ?>
+          <?php foreach ($topics as $topic) { ?>
             <li>
                 <a href="<?= $topic->url(); ?>">
                     <img src="<?= $topic->image_url(); ?>">
@@ -17,7 +17,7 @@
                 </a>
                 <p><?= _htmlspecialchars($topic->description()); ?></p>
             </li>
-          <?php endforeach; ?>
+          <?php } ?>
         </ul>
 
     </div>

--- a/www/includes/easyparliament/templates/html/topic/topic.php
+++ b/www/includes/easyparliament/templates/html/topic/topic.php
@@ -23,7 +23,7 @@
     <div class="full-page__row">
 
         <div class="small-12 large-3 large-push-9 columns">
-          <?php if ($display_postcode_form): ?>
+          <?php if ($display_postcode_form) { ?>
             <div class="topic-sidebar topic-postcode-search">
                 <h3>How did your MP vote?</h3>
                 <form action="#yourrep" method="get">
@@ -32,7 +32,7 @@
                     <input type="submit" value="GO" class="button prefix">
                 </form>
             </div>
-          <?php endif; ?>
+          <?php } ?>
 
           <?php if ($topic->search_string()) { ?>
             <div class="topic-sidebar">
@@ -47,18 +47,18 @@
 
         <div class="topic-content small-12 large-9 large-pull-3 columns">
 
-          <?php if (isset($positions)): ?>
+          <?php if (isset($positions)) { ?>
             <div class="topic-block policies">
                 <h2 id="yourrep">How <?= $member_name ?> voted on <?= $topic->sctitle() ?></h2>
 
-              <?php if ($total_votes == 0): ?>
+              <?php if ($total_votes == 0) { ?>
                 <p>
                     <a href="<?= $member_url ?>"><?= $member_name ?></a> hasn't
                     voted on any of the key issues on <?= _htmlspecialchars($topic->sctitle()) ?>. You may want
                     to <a href="<?= $member_url ?>/votes">see all their votes</a>.
                 </p>
 
-              <?php else: ?>
+              <?php } else { ?>
                 <ul class="vote-descriptions">
                   <?php
                   $policy_ids = [];
@@ -80,11 +80,11 @@
                   } ?>
                 </ul>
 
-              <?php endif; ?>
+              <?php } ?>
             </div>
-          <?php endif; ?>
+          <?php } ?>
 
-          <?php if (isset($recent_divisions)): ?>
+          <?php if (isset($recent_divisions)) { ?>
             <div class="topic-block policies">
                 <h2>Recent votes on <?= _htmlspecialchars($topic->sctitle()) ?></h2>
                 <ul class="vote-descriptions">
@@ -107,20 +107,20 @@
                   <?php } ?>
                 </ul>
             </div>
-          <?php endif; ?>
+          <?php } ?>
 
-          <?php if ($business = $topic->getFullContent()): ?>
+          <?php if ($business = $topic->getFullContent()) { ?>
             <div class="topic-block policies">
                 <h2>Parliamentary business about <?= _htmlspecialchars($topic->sctitle()) ?></h2>
                 <ul class="business-list">
-                  <?php foreach ($business as $item): ?>
+                  <?php foreach ($business as $item) { ?>
                     <li>
                         <?php include(dirname(__DIR__) . '/section/_business_list_item.php'); ?>
                     </li>
-                  <?php endforeach; ?>
+                  <?php } ?>
                 </ul>
             </div>
-          <?php endif; ?>
+          <?php } ?>
 
         </div>
     </div>


### PR DESCRIPTION
This isn't necessarily to be merged but just building on some points in https://github.com/mysociety/theyworkforyou/pull/1856

This applies a rule to enforce the braces as opposed to 'if' 'endif' syntax.

This ends up changing relatively few files - all templates - which makes sense as I was using it because it felt a little more readable in mixed files, but also the IDE is good at finding the matching brace. 

Basically if there are two options and we have a preference, we could have a rule.