### PR TITLE
Ensure policies JSON always has expected keys

### DIFF
--- a/scripts/json2db.pl
+++ b/scripts/json2db.pl
@@ -125,7 +125,12 @@ sub fetch_policies {
     my $policies = $json->decode($policies_json);
 
     my @ids;
-    my $out = {};
+    my $out = {
+        sets => {},
+        set_descs => {},
+        policies => {},
+        agreements => {},
+    };
     foreach my $policy (@$policies) {
         say "Processing policy $policy->{id} $policy->{name}" if $verbose;
         push @ids, $policy->{id};


### PR DESCRIPTION
The `classes/Policies.php` code expects the `scrapedjson/policies.json` file to contain certain keys, however if the [twfy-votes active/all.json](https://votes.theyworkforyou.com/policies/commons/active/all.json) didn't contain a `groups` key then the `set_descs` and `sets` keys in `scrapedjson/policies.json` weren't getting set.

This was the code that was causing an error when the `set_descs` and `sets` key were missing from `scrapedjson/policies.json`.

https://github.com/mysociety/theyworkforyou/blob/9c33051d28c804837dc1c2b958b4c6eb6a5672d8/classes/Policies.php#L68-L77

This change ensures that the expected keys are always set in policies.json, regardless of the input JSON.

Related to https://github.com/mysociety/twfy-votes-django/issues/46