### PR TITLE
Supporters page

### DIFF
--- a/classes/Renderer/Markdown.php
+++ b/classes/Renderer/Markdown.php
@@ -23,7 +23,7 @@ class Markdown {
         # title is the first h1
         preg_match('/<h1>([^<]+)<\/h1>/i', $html, $matches);
 
-        $title = $matches[1];
+        $title = $extra_vars['_page_title'] ?? $matches[1];
 
         $html = preg_replace_callback('/<h([1-3])>([^<]+)<\/h[1-3]>/i', function ($matches) {
             $level = $matches[1];

--- a/classes/Renderer/Markdown.php
+++ b/classes/Renderer/Markdown.php
@@ -9,15 +9,9 @@ namespace MySociety\TheyWorkForYou\Renderer;
  */
 
 
-function render_php($template_file) {
-    $path = INCLUDESPATH . 'easyparliament/templates/html/' . $template_file . '.php';
-    ob_start();
-    include($path);
-    return ob_get_clean();
-}
 
 class Markdown {
-    public function markdown_document($this_page, $show_menu = true) {
+    public function markdown_document(string $this_page, bool $show_menu = true, array $extra_vars = []) {
         // This function takes a markdown file and converts it to HTML
 
         $markdown_file = '../../../markdown/' . $this_page . '.md';
@@ -46,17 +40,31 @@ class Markdown {
         // Create new panel when horizontal line used
         $html = preg_replace('/<hr \/>/i', '</div><div class="panel">', $html);
 
-        // render donate box
-        if (strpos($html, '{{ donate_box }}') !== false) {
-            $html = str_replace('{{ donate_box }}', render_php('donate/_stripe_donate'), $html);
-        }
+        foreach ($extra_vars as $key => $value) {
+            $html = str_replace('{{ ' . $key . ' }}', $value, $html);
+        };
 
-        \MySociety\TheyWorkForYou\Renderer::output('static/markdown_template', [
+        $context = [
             'html' => $html,
             'this_page' => $this_page,
             'page_title' => $title,
             'show_menu' => $show_menu,
-        ]);
+        ];
 
+        // Add extra variables to the context
+        foreach ($extra_vars as $key => $value) {
+            $context[$key] = $value;
+        }
+
+        \MySociety\TheyWorkForYou\Renderer::output('static/markdown_template', $context);
+
+    }
+
+    public static function render_php($template_file, array $context = []) {
+        $path = INCLUDESPATH . 'easyparliament/templates/html/' . $template_file . '.php';
+        extract($context, EXTR_SKIP);
+        ob_start();
+        include($path);
+        return ob_get_clean();
     }
 }

--- a/markdown/support-us.md
+++ b/markdown/support-us.md
@@ -1,26 +1,31 @@
-# Support TheyWorkForYou and mySociety
+# Support TheyWorkForYou for {{ verbose_amount }}
 
-[Skip to donate form.](#donate-form)
+**Or less, or more.**
+ 
 
-We want MPs to meet the standards and expectations of the people who elected them - **you**!
+<button type="button" class="default-donate-button button button-primary button-mobile button--large" style="margin-right: 10px" onclick="restrict_to_default('{{ how_much }}', '{{ payment_type }}')">
+        Donate {{ verbose_amount }}
+</button>
 
-TheyWorkForYou started twenty years ago as a volunteer project, when a bunch of people got together to make Parliament more transparent. We don’t have to wait for a better politics to be given to us – **we can work together to make it happen now**.
+<input type="button" value="Donate another amount" class="open-form-button button button-primary button-mobile  button--large">
 
-These sites need attention every day to:
+For over 20 years, TheyWorkForYou has been making our democracy more transparent and our politicians more accountable. We need your support to: 
 
-* Keep the data flowing and ensuring that the comprehensive data about politicians is up to date.
-* Make improvements such as [recent changes to voting records](https://www.mysociety.org/2024/04/23/improving-the-focus-of-theyworkforyous-voting-summaries/).
-* Provide support on how to use the sites and the data we provide - we’re here for you.
+* **Hold Power to Account** — With your help, we highlight what our representatives are doing – so they know the public is watching. By making votes more visible, the register of interests easier to explore, and sending email alerts on issues you care about, we make politicians more accountable. 
+* **Keep It Free and Accessible** — TheyWorkForYou has no paywalls because everyone deserves unbiased and high quality information about decisions made on their behalf. Your support keeps it free for all the organisations and community groups who can’t afford costly political monitoring. Together, we strengthen countless good causes.
+* **Innovate and go further** — We’re always looking for new ways we can do more to improve on official data, or work with our volunteers to create new information and analysis. With you behind us, we’ll keep pioneering new ways of improving our democracy.
 
-And that's not enough: we want to experiment with new approaches like our new campaign ([WhoFundsThem.com](https://www.mysociety.org/democracy/who-funds-them/)) to uncover the influence of money in politics.
+We're not funded by the government and we run this for the public, not MPs. We're not going to wait for a better political system to be given to us – **we want to work together to make it happen now**.
 
-This is an example of one of mySociety’s innovative projects. To support this and other similar work donate below.
+By becoming a TheyWorkForYou Supporter, you ensure that this crucial service not only stays up and running, but gives us the freedom to innovate and be bolder.
+
+We can't offer much beyond what we give to everyone for free - but for **{{ verbose_amount }}** (or whatever you like) you can be part of something that makes a real difference. 
 
 {{ donate_box }}
 
 ***
 
-## I want to be a mySociety supporter
+## I want to support in non-financial ways
 
 There are three key ways you can support mySociety, and our work on projects like TheyWorkForYou. 
 

--- a/www/docs/js/main.js
+++ b/www/docs/js/main.js
@@ -419,6 +419,63 @@ function amounts_oneoff(){
   $('.donate-one-off-amount').show();
 }
 
+function restrict_to_default($howmuch, $howoften){
+  $('.donate-form').show();
+  $('html, body').animate({
+    scrollTop: $('.donate-form').offset().top
+  }, 500);
+
+  // if howoften monthly hide annually and one-off
+  if ($howoften == 'monthly') {
+    $('#how-often-one-off').parent().hide();
+    $('#how-often-annually').parent().hide();
+    $('#how-often-monthly').prop('checked', true);
+    amounts_monthly()
+    $('.donate-monthly-amount').hide();
+    $('#how-much-other').parent().hide();
+    $('#how-much-monthly-' + $howmuch).parent().show();
+    $('#how-much-monthly-' + $howmuch).prop('checked', true);
+  }
+  if ($howoften == 'annually') {
+    $('#how-often-one-off').parent().hide();
+    $('#how-often-monthly').parent().hide();
+    $('#how-often-annually').prop('checked', true);
+    amounts_annually()
+    $('.donate-annually-amount').hide();
+    $('#how-much-other').parent().hide();
+    $('#how-much-annually-' + $howmuch).parent().show();
+    $('#how-much-annually-' + $howmuch).prop('checked', true);
+  }
+  if ($howoften == 'one-off') {
+    $('#how-often-monthly').parent().hide();
+    $('#how-often-annually').parent().hide();
+    $('#how-often-one-off').prop('checked', true);
+    amounts_oneoff()
+    $('.donate-one-off-amount').hide();
+    $('#how-much-other').parent().hide();
+    $('#how-much-one-off-' + $howmuch).parent().show();
+    $('#how-much-one-off-' + $howmuch).prop('checked', true);
+  }
+
+}
+
+function show_all_options(){
+  $('#how-often-one-off').parent().show();
+  $('#how-often-annually').parent().show();
+  $('#how-often-monthly').parent().show();
+  if ($('#how-often-one-off').is(':checked')) {
+    amounts_oneoff();
+  } else if ($('#how-often-monthly').is(':checked')) {
+    amounts_monthly();
+  }
+  else if ($('#how-often-annually').is(':checked')) {
+    amounts_annually();
+  }
+  $('#how-much-other').parent().show();
+
+  
+}
+
 function wrap_error($message){
   return '<div class="donate-form__error-wrapper"><p class="donate-form__error">' + $message + '</p></div>';
 }

--- a/www/docs/js/main.js
+++ b/www/docs/js/main.js
@@ -454,6 +454,14 @@ $(function() {
   });
   othervalue_toggle($('#how-much-other').is(':checked'));
   
+  $('.open-form-button').click(function(e) {
+    $('.donate-form').slideDown(100);
+    show_all_options();
+    $('html, body').animate({
+      scrollTop: $('.donate-form').offset().top
+    }, 500);
+  });
+
   $('#donate_button').click(function(e) {
     e.preventDefault();
     var giftaid = $('input[name=gift-aid]:checked').val();

--- a/www/docs/js/main.js
+++ b/www/docs/js/main.js
@@ -494,7 +494,7 @@ $(function() {
     amounts_monthly();
     othervalue_hide();
   });
-  $('#how-often-once').click(function() {
+  $('#how-often-one-off').click(function() {
     var defaultValue = $(this).data('default-amount');
     $('#how-much-one-off-' + defaultValue).prop('checked', true);
     amounts_oneoff();

--- a/www/docs/support-us/index.php
+++ b/www/docs/support-us/index.php
@@ -40,7 +40,7 @@ $default_amounts = [
 ];
 
 
-$default_type = 'monthly';
+$default_type = 'annually';
 
 # use the how-often parameter if set, if not default to option at end of line (options are 'monthly', 'annually', or 'one-off')
 $payment_type = get_http_var('how-often', $default_type);

--- a/www/docs/support-us/index.php
+++ b/www/docs/support-us/index.php
@@ -11,5 +11,84 @@ check_for_stripe_submission(
 
 use MySociety\TheyWorkForYou\Renderer\Markdown;
 
+# define array of payment amounts and current/one-off options
+# note - new annual and monthly payments need to be defined as new prices in stripe
+# e.g. 'donate_monthly_10'.
+$payment_amounts = [
+    'monthly' => [
+        '2' => '£2',
+        '5' => '£5',
+        '10' => '£10',
+    ],
+    'annually' => [
+        '10' => '£10',
+        '25' => '£25',
+        '50' => '£50',
+    ],
+    'one-off' => [
+        '5' => '£5',
+        '10' => '£10',
+        '50' => '£50',
+    ],
+];
+
+
+$default_amounts = [
+    'monthly' => '5',
+    'annually' => '25',
+    'one-off' => '10',
+];
+
+
+$default_type = 'monthly';
+
+# use the how-often parameter if set, if not default to option at end of line (options are 'monthly', 'annually', or 'one-off')
+$payment_type = get_http_var('how-often', $default_type);
+
+// check $payment_type is a valid option
+if (!array_key_exists($payment_type, $payment_amounts)) {
+    $payment_type = $default_type;
+}
+
+# use the how-much parameter if set, if not default to default amount for initial payment type
+$how_much = get_http_var('how-much', $default_amounts[$payment_type]);
+
+# check this is a str of an int
+
+if (!is_numeric($how_much)) {
+    $how_much = $default_amounts[$payment_type];
+}
+
+$verbose_amount = "£" . number_format($how_much, 0);
+if ($payment_type == 'monthly') {
+    $verbose_amount .= " a month";
+} elseif ($payment_type == 'annually') {
+    $verbose_amount .= " a year";
+} else {
+    $verbose_amount .= " as a one-off payment";
+}
+
+
+# if how-much is not in the allowed values for the current payment type, set to 'other', and set $other_how_much to the value of how-much
+if (!array_key_exists($how_much, $payment_amounts[$payment_type] ?? [])) {
+    $how_much = 'other';
+    $other_how_much = get_http_var('how-much');
+} else {
+    $other_how_much = '';
+}
+
+
 $markdown = new Markdown();
-$markdown->markdown_document('support-us');
+$markdown->markdown_document('support-us', true, [
+    'donate_box' => Markdown::render_php('donate/_stripe_donate', [
+        'payment_type' => $payment_type,
+        'how_much' => $how_much,
+        'verbose_amount' => $verbose_amount,
+        'payment_amounts' => $payment_amounts,
+        'default_amounts' => $default_amounts,
+        'other_how_much' => $other_how_much,
+    ]),
+    'payment_type' => $payment_type,
+    'how_much' => $how_much,
+    'verbose_amount' => $verbose_amount,
+]);

--- a/www/docs/support-us/index.php
+++ b/www/docs/support-us/index.php
@@ -91,4 +91,5 @@ $markdown->markdown_document('support-us', true, [
     'payment_type' => $payment_type,
     'how_much' => $how_much,
     'verbose_amount' => $verbose_amount,
+    '_page_title' => 'Support Us - TheyWorkForYou',
 ]);

--- a/www/includes/easyparliament/templates/html/donate/_stripe_donate.php
+++ b/www/includes/easyparliament/templates/html/donate/_stripe_donate.php
@@ -7,14 +7,14 @@
 
 <a name="donate-form"></a>
 
-<button type="button" class="default-donate-button button button-primary button--large" style="margin-right: 10px" onclick="restrict_to_default('<?= $how_much ?>', '<?= $payment_type ?>')">
+<button type="button" id="default_donate_button" class="button button-primary button--large" style="margin-right: 10px" onclick="restrict_to_default('<?= $how_much ?>', '<?= $payment_type ?>')">
         Donate <?= $verbose_amount ?>
 </button>
 
 <input type="button" value="Donate another amount" class="open-form-button button button-primary button--large" >
     
 
-<form class="donate-form" method="post" name="donation_form" style="display: None";>
+<form class="donate-form" method="post" name="donation_form">
 
     <div class="donate-form__error-wrapper">
         <noscript>
@@ -110,10 +110,14 @@
     <input type="hidden" name="utm_content" value="<?=htmlspecialchars(get_http_var('utm_content')) ?>">
     <input type="hidden" name="utm_medium" value="<?=htmlspecialchars(get_http_var('utm_medium')) ?>">
     <input type="hidden" name="utm_campaign" value="<?=htmlspecialchars(get_http_var('utm_campaign', 'twfy_donate_page')) ?>">
-
+    
 </form>
 
 <script src="https://js.stripe.com/v3"></script>
 <script>
 var stripe = Stripe('<?=STRIPE_DONATE_PUBLIC_KEY ?>', { apiVersion: '<?= STRIPE_API_VERSION ?>' });
+</script>
+<script>
+    // hide .donate-form by default
+    document.querySelector('.donate-form').style.display = 'none';
 </script>

--- a/www/includes/easyparliament/templates/html/donate/_stripe_donate.php
+++ b/www/includes/easyparliament/templates/html/donate/_stripe_donate.php
@@ -1,53 +1,20 @@
 <?php
 
-# define array of payment amounts and current/one-off options
-# note - new annual and monthly payments need to be defined as new prices in stripe
-# e.g. 'donate_monthly_10'.
-$payment_amounts = [
-    'monthly' => [
-        '2' => '£2',
-        '5' => '£5',
-        '10' => '£10',
-    ],
-    'annually' => [
-        '10' => '£10',
-        '50' => '£50',
-        '100' => '£100',
-    ],
-    'one-off' => [
-        '5' => '£5',
-        '10' => '£10',
-        '20' => '£20',
-    ],
-];
 
-$default_amounts = [
-    'monthly' => '5',
-    'annually' => '10',
-    'one-off' => '10',
-];
-
-$default_type = 'one-off';
-
-# use the how-often parameter if set, if not default to option at end of line (options are 'monthly', 'annually', or 'one-off')
-$initial_payment_type = get_http_var('how-often', $default_type);
-
-# use the how-much parameter if set, if not default to default amount for initial payment type
-$how_much = get_http_var('how-much', $default_amounts[$initial_payment_type]);
-
-# if how-much is not in the allowed values for the current payment type, set to 'other', and set $other_how_much to the value of how-much
-if (!array_key_exists($how_much, $payment_amounts[$initial_payment_type] ?? [])) {
-    $how_much = 'other';
-    $other_how_much = get_http_var('how-much');
-} else {
-    $other_how_much = '';
-}
 
 ?>
 <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 
 <a name="donate-form"></a>
-<form class="donate-form" method="post" name="donation_form">
+
+<button type="button" class="default-donate-button button button-primary button--large" style="margin-right: 10px" onclick="restrict_to_default('<?= $how_much ?>', '<?= $payment_type ?>')">
+        Donate <?= $verbose_amount ?>
+</button>
+
+<input type="button" value="Donate another amount" class="open-form-button button button-primary button--large" >
+    
+
+<form class="donate-form" method="post" name="donation_form" style="display: None";>
 
     <div class="donate-form__error-wrapper">
         <noscript>
@@ -61,9 +28,9 @@ if (!array_key_exists($how_much, $payment_amounts[$initial_payment_type] ?? []))
     <h2>Donate to TheyWorkForYou and mySociety</h3>
 
     <div class="fat-radio-buttons">
-        <label for="how-often-one-off" class="inline-radio-label"><input type="radio" id="how-often-one-off" name="how-often" value="one-off" data-default-amount="<?= $default_amounts["one-off"] ?>" required <?php get_checked($initial_payment_type, 'one-off') ?>>One-off donation</label>
-        <label for="how-often-annually" class="inline-radio-label"><input type="radio" id="how-often-annually" name="how-often" value="annually" data-default-amount="<?= $default_amounts["annually"] ?>" required <?php get_checked($initial_payment_type, 'annually') ?>>Annual donation</label>
-        <label for="how-often-monthly" class="inline-radio-label"><input type="radio" id="how-often-monthly" name="how-often" value="monthly" data-default-amount="<?= $default_amounts["monthly"] ?>" required <?php get_checked($initial_payment_type, 'monthly') ?>>Monthly donation</label>
+        <label for="how-often-one-off" class="inline-radio-label"><input type="radio" id="how-often-one-off" name="how-often" value="one-off" data-default-amount="<?= $default_amounts["one-off"] ?>" required <?php get_checked($payment_type, 'one-off') ?>>One-off donation</label>
+        <label for="how-often-annually" class="inline-radio-label"><input type="radio" id="how-often-annually" name="how-often" value="annually" data-default-amount="<?= $default_amounts["annually"] ?>" required <?php get_checked($payment_type, 'annually') ?>>Annual donation</label>
+        <label for="how-often-monthly" class="inline-radio-label"><input type="radio" id="how-often-monthly" name="how-often" value="monthly" data-default-amount="<?= $default_amounts["monthly"] ?>" required <?php get_checked($payment_type, 'monthly') ?>>Monthly donation</label>
     </div>
 
     <h3>How much would you like to give?</h3>
@@ -74,13 +41,13 @@ if (!array_key_exists($how_much, $payment_amounts[$initial_payment_type] ?? []))
         <label
           for="how-much-<?=$payment_type?>-<?=$amount?>"
           class="donate-<?=$payment_type?>-amount inline-radio-label"
-          <?php if ($payment_type != $initial_payment_type) { ?>style="display:none"<?php } ?> />
+          <?php if ($payment_type != $payment_type) { ?>style="display:none"<?php } ?> />
             <input
               type="radio"
               id="how-much-<?=$payment_type?>-<?=$amount?>"
               name="how-much"
               value="<?=$amount?>"
-              required <?= (($how_much == $amount) and ($payment_type == $initial_payment_type)) ? ' checked' : '' ?> />
+              required <?= (($how_much == $amount) and ($payment_type == $payment_type)) ? ' checked' : '' ?> />
             <span class="radio-label-large"><?=$label?></span>
         </label>
       <?php } ?>
@@ -132,7 +99,7 @@ if (!array_key_exists($how_much, $payment_amounts[$initial_payment_type] ?? []))
 
     <div class="donate-submit">
       <div id='recaptcha' class="g-recaptcha" data-sitekey="<?=OPTION_RECAPTCHA_SITE_KEY ?>" data-callback="onDonatePass" data-size="invisible"></div>
-      <input type="submit" id="donate_button" value="Donate" class="button button-primary button--large">
+      <input type="submit" id="donate_button" value="Donate now" class="button button-primary button--large">
       <div id="spinner" class="mysoc-spinner mysoc-spinner--small" role="status">
           <span class="sr-only">Processing…</span>
       </div>


### PR DESCRIPTION
This changes the supporters page:

* Simplifies copy before donate form.
* Simplifies choices - leans harder into a default value (currently £10 a year). This is the only option visible unless another option is selected. 

On desktop:

![image](https://github.com/user-attachments/assets/701d11b8-6ec2-4668-bdc7-ff06b8389779)

On mobile, button at top are immediately visible:

![image](https://github.com/user-attachments/assets/da0275b4-1a80-4c8f-b7fb-ce57181ec3f8)

Clicking the default amount gives a simplified form:

![image](https://github.com/user-attachments/assets/73b4cff6-44f4-4d4c-a926-54fffcc496a0)

Clicking the  other gives the normal form:

![image](https://github.com/user-attachments/assets/30cc21af-2129-4c8d-980b-1cedccf5c3b3)
