### PR TITLE
Seperating Recent Appearances 

### DIFF
--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -40,7 +40,7 @@ include_once '../api/api_getGeometry.php';
 include_once '../api/api_getConstituencies.php';
 
 // Ensure that page type is set
-$allowed_page_types = ['divisions', 'votes', 'policy_set_svg', 'policy_set_png', 'recent', 'register', 'election_register'];
+$allowed_page_types = ['divisions', 'votes', 'policy_set_svg', 'policy_set_png', 'recent', 'register', 'election_register', 'recent_appearances'];
 
 if (get_http_var('pagetype')) {
     $pagetype = get_http_var('pagetype');
@@ -508,6 +508,11 @@ switch ($pagetype) {
         policy_image($data, $MEMBER, 'png');
         break;
 
+    case 'recent_appearances':
+        $data['recent_appearances'] = person_recent_appearances($MEMBER);
+        MySociety\TheyWorkForYou\Renderer::output('mp/recent_appearances', $data);
+        break;
+
     case '':
     default:
         // if extra detail needed for overview page in future
@@ -688,7 +693,7 @@ function person_error_page($message) {
             break;
         default:
             $people = new MySociety\TheyWorkForYou\People\MPs();
-            $SEARCHURL = new \MySociety\TheyWorkForYou\Url('mp');
+            $SEARCHURL = new MySociety\TheyWorkForYou\Url('mp');
             $SEARCHURL = $SEARCHURL->generate();
             $MPSURL = new \MySociety\TheyWorkForYou\Url('mps');
     }

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -284,14 +284,14 @@
     ul {
         @include unstyled-list;
         @include inline-list;
-        font-size: em-calc(18);
+        font-size: em-calc(16);
         margin-left: 0px;
         li {
             top: 1px;
             position: relative;
-            line-height: 48px;
+            line-height: 42px;
             margin-left: 0px;
-            margin-right: 30px;
+            margin-right: 20px;
             a {
                 color: #6c6b68;
             }

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -281,17 +281,33 @@
 
 .person-navigation {
     color: $light-text;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch; 
+    
     ul {
         @include unstyled-list;
         @include inline-list;
-        font-size: em-calc(16);
+        font-size: em-calc(14); 
         margin-left: 0px;
+        white-space: nowrap;
+        padding-bottom: 5px; 
+        
+        @media (min-width: $medium-screen) {
+            font-size: em-calc(16); 
+            white-space: normal;
+        }
+        
         li {
             top: 1px;
             position: relative;
-            line-height: 42px;
+            line-height: 38px;
             margin-left: 0px;
-            margin-right: 20px;
+            margin-right: 12px;
+            
+            @media (min-width: $medium-screen) {
+                line-height: 42px;
+                margin-right: 20px;
+            }
             a {
                 color: #6c6b68;
             }

--- a/www/includes/easyparliament/templates/html/mp/_person_navigation.php
+++ b/www/includes/easyparliament/templates/html/mp/_person_navigation.php
@@ -5,6 +5,7 @@
           <?php if ($this_page == "mp"): ?>
             <li <?php if ($pagetype == "votes"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/votes">🗳️ <?= gettext('Voting Summary') ?></a></li>
           <?php endif; ?>
+          <li <?php if ($pagetype == "recent_appearances"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/recent_appearances">💬 <?= gettext('Speeches / Questions') ?></a></li>
           <?php if (in_array($this_page, ["mp", "msp", "ms"])): ?>
             <li <?php if ($pagetype == "recent"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/recent">📜 <?= gettext('Recent Votes') ?></a></li>
           <?php endif; ?>
@@ -14,6 +15,5 @@
           <?php if ($register_2024_enriched): ?>
                 <li <?php if ($pagetype == "election_register"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/election_register">🏛️ <?= gettext('2024 Election Donations') ?></a></li>
           <?php endif; ?>
-          <li <?php if ($pagetype == "recent_appearances"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/recent_appearances">🎤 <?= gettext('Recent Appearances') ?></a></li>
     </ul>
 </div>

--- a/www/includes/easyparliament/templates/html/mp/_person_navigation.php
+++ b/www/includes/easyparliament/templates/html/mp/_person_navigation.php
@@ -14,5 +14,6 @@
           <?php if ($register_2024_enriched): ?>
                 <li <?php if ($pagetype == "election_register"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/election_register">🏛️ <?= gettext('2024 Election Donations') ?></a></li>
           <?php endif; ?>
+          <li <?php if ($pagetype == "recent_appearances"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/recent_appearances">🎤 <?= gettext('Recent Appearances') ?></a></li>
     </ul>
 </div>

--- a/www/includes/easyparliament/templates/html/mp/profile.php
+++ b/www/includes/easyparliament/templates/html/mp/profile.php
@@ -18,12 +18,9 @@ $display_wtt_stats_banner = '2015';
                     <h3 class="browse-content"><?= gettext('Browse content') ?></h3>
                     <ul>
                         <li><a href="#profile"><?= gettext('Profile') ?></a></li>
-                        <?php if (count($recent_appearances['appearances'])): ?>
-                          <li><a href="#appearances"><?= gettext('Appearances') ?></a></li>
-                        <?php endif; ?>
-                      </ul>
-                      <?php include '_featured_content.php'; ?>
-                      <?php include '_donation.php'; ?>
+                    </ul>
+                    <?php include '_featured_content.php'; ?>
+                    <?php include '_donation.php'; ?>
                 </div>
             </div>
 
@@ -211,42 +208,6 @@ $display_wtt_stats_banner = '2015';
                     <?php endif; ?>
 
                 </div>
-
-
-                <?php if (count($recent_appearances['appearances'])): ?>
-                <div class="panel">
-                    <a name="appearances"></a>
-                    <h2><?=gettext('Recent appearances') ?></h2>
-
-                    <?php if (count($recent_appearances['appearances']) > 0): ?>
-
-                        <ul class="appearances">
-
-                        <?php foreach ($recent_appearances['appearances'] as $recent_appearance): ?>
-
-                            <li>
-                                <h4><a href="<?= $recent_appearance['listurl'] ?>"><?= $recent_appearance['parent']['body'] ?></a> <span class="date"><?= date('j M Y', strtotime($recent_appearance['hdate'])) ?></span></h4>
-                                <blockquote><?= $recent_appearance['extract'] ?></blockquote>
-                            </li>
-
-                        <?php endforeach; ?>
-
-                        </ul>
-
-                        <p><a href="<?= $recent_appearances['more_href'] ?>"><?= $recent_appearances['more_text'] ?></a></p>
-
-                        <?php if (isset($recent_appearances['additional_links'])): ?>
-                        <?= $recent_appearances['additional_links'] ?>
-                        <?php endif; ?>
-
-                    <?php else: ?>
-
-                        <p><?=gettext('No recent appearances to display.') ?></p>
-
-                    <?php endif; ?>
-
-                </div>
-                <?php endif; ?>
 
                 <?php include('_profile_footer.php'); ?>
 

--- a/www/includes/easyparliament/templates/html/mp/recent_appearances.php
+++ b/www/includes/easyparliament/templates/html/mp/recent_appearances.php
@@ -1,0 +1,44 @@
+<?php
+include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
+?>
+<div class="full-page">
+    <div class="full-page__row">
+        <div class="full-page__unit">
+            <?php include '_person_navigation.php'; ?>
+        </div>
+        <div class="person-panels">
+            <div class="sidebar__unit in-page-nav">
+                <div>
+                    <h3 class="browse-content"><?= gettext('Browse content') ?></h3>
+                    <ul>
+                        <li class="active"><a href="#recent_appearances"><?= gettext('Recent Appearances') ?></a></li>
+                    </ul>
+                    <?php include '_featured_content.php'; ?>
+                    <?php include '_donation.php'; ?>
+                </div>
+            </div>
+            <div class="primary-content__unit">
+                <div class="panel">
+                    <h2><?=gettext('Recent appearances') ?></h2>
+                    <?php if (count($recent_appearances['appearances']) > 0): ?>
+                        <ul class="appearances">
+                        <?php foreach ($recent_appearances['appearances'] as $recent_appearance): ?>
+                            <li>
+                                <h4><a href="<?= $recent_appearance['listurl'] ?>"><?= $recent_appearance['parent']['body'] ?></a> <span class="date"><?= date('j M Y', strtotime($recent_appearance['hdate'])) ?></span></h4>
+                                <blockquote><?= $recent_appearance['extract'] ?></blockquote>
+                            </li>
+                        <?php endforeach; ?>
+                        </ul>
+                        <p><a href="<?= $recent_appearances['more_href'] ?>"><?= $recent_appearances['more_text'] ?></a></p>
+                        <?php if (isset($recent_appearances['additional_links'])): ?>
+                        <?= $recent_appearances['additional_links'] ?>
+                        <?php endif; ?>
+                    <?php else: ?>
+                        <p><?=gettext('No recent appearances to display.') ?></p>
+                    <?php endif; ?>
+                </div>
+                <?php include('_profile_footer.php'); ?>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Just starting a draft PR because I hit a wall on this being an easy thing. 

I wanted to move 'Recent Appearances' into its own page so it can sit on its own in the top menu. 

This works fine and isn't hard! But it pushes a problem I've been making worse for a while over the  line that that top nav hasn't historically had a lot of stuff and starts to overflow. This is then worse on mobile. 

I've done one thing that is probably fine, and another that seems like the wrong approach:

On desktop - just shrank all the items slightly so it's on one line:

![image](https://github.com/user-attachments/assets/734ae963-5519-4f97-814d-73884ace52e4)

On mobile, horizontal nav bar after failing to make a hamburger menu easily. This is the wrong approach - but is my "I give up commit". Need a designer to have a think about what's best here. 

![image](https://github.com/user-attachments/assets/455555a0-1de2-42f1-8b51-d8e723da2c0c)

