### PR TITLE
improve handling of missing/bad registers

### DIFF
--- a/classes/DataClass/Regmem/Register.php
+++ b/classes/DataClass/Regmem/Register.php
@@ -16,6 +16,12 @@ class Register extends BaseModel {
     public PersonList $persons;
 
 
+    private function checkChamberSlug($chamber) {
+        if ($chamber && preg_match('[^a-z0-9\-\.]', $chamber)) {
+            throw new \Exception("No register found for $chamber");
+        }
+    }
+
     public function getPersonFromId(string $personId): ?Person {
         foreach ($this->persons as $person) {
             if ($person->person_id === $personId) {
@@ -26,6 +32,8 @@ class Register extends BaseModel {
     }
 
     public static function getDate(string $chamber, string $date): Register {
+        self::checkChamberSlug($chamber);
+
         $file_dir = RAWDATA . "scrapedjson/universal_format_regmem/" . $chamber . "/";
         $file_end = $date . ".json";
         // see if there's a file that matches this - but might have a bit in the middle
@@ -40,6 +48,8 @@ class Register extends BaseModel {
     }
 
     public static function latestAsOfDate(string $chamber, string $date): Register {
+        self::checkChamberSlug($chamber);
+
         $file_dir = RAWDATA . "scrapedjson/universal_format_regmem/" . $chamber . "/";
         $files = glob($file_dir . "*.json");
         if (count($files) === 0) {
@@ -57,6 +67,8 @@ class Register extends BaseModel {
     }
 
     public static function getLatest(string $chamber): Register {
+        self::checkChamberSlug($chamber);
+
         $file_dir = RAWDATA . "scrapedjson/universal_format_regmem/" . $chamber . "/";
         if ($chamber == "senedd") {
             $file_dir .= LANGUAGE . "/";
@@ -71,6 +83,8 @@ class Register extends BaseModel {
     }
 
     public static function getMisc(string $file): Register {
+        self::checkChamberSlug($chamber);
+
         $file_path = RAWDATA . "scrapedjson/universal_format_regmem/misc/" . $file;
         return self::fromFile($file_path);
     }

--- a/classes/DataClass/Regmem/Register.php
+++ b/classes/DataClass/Regmem/Register.php
@@ -6,6 +6,8 @@ namespace MySociety\TheyWorkForYou\DataClass\Regmem;
 
 use MySociety\TheyWorkForYou\DataClass\BaseModel;
 
+class RegisterNotFoundException extends \Exception {}
+
 class Register extends BaseModel {
     use HasChamber;
     public string $chamber;
@@ -18,7 +20,7 @@ class Register extends BaseModel {
 
     private function checkChamberSlug($chamber) {
         if ($chamber && preg_match('[^a-z0-9\-\.]', $chamber)) {
-            throw new \Exception("No register found for $chamber");
+            throw new RegisterNotFoundException("No register found for $chamber");
         }
     }
 
@@ -39,7 +41,7 @@ class Register extends BaseModel {
         // see if there's a file that matches this - but might have a bit in the middle
         $files = glob($file_dir . "*" . $file_end);
         if (count($files) === 0) {
-            throw new \Exception("No register found for $chamber on $date");
+            throw new RegisterNotFoundException("No register found for $chamber on $date");
         }
         if (count($files) > 1) {
             throw new \Exception("Multiple registers found for $chamber on $date");
@@ -53,7 +55,7 @@ class Register extends BaseModel {
         $file_dir = RAWDATA . "scrapedjson/universal_format_regmem/" . $chamber . "/";
         $files = glob($file_dir . "*.json");
         if (count($files) === 0) {
-            throw new \Exception("No register found for $chamber");
+            throw new RegisterNotFoundException("No register found for $chamber");
         }
         # sort most recent to least, find the first one before the date
         rsort($files);
@@ -63,7 +65,7 @@ class Register extends BaseModel {
                 return self::fromFile($file);
             }
         }
-        throw new \Exception("No register found for $chamber on or before $date");
+        throw new Exception("No register found for $chamber on or before $date");
     }
 
     public static function getLatest(string $chamber): Register {
@@ -75,7 +77,7 @@ class Register extends BaseModel {
         }
         $files = glob($file_dir . "*.json");
         if (count($files) === 0) {
-            throw new \Exception("No register found for $chamber");
+            throw new RegisterNotFoundException("No register found for $chamber");
         }
         $latest = max($files);
         // raise exception with name of $latest

--- a/www/includes/easyparliament/templates/html/interests/category.php
+++ b/www/includes/easyparliament/templates/html/interests/category.php
@@ -1,3 +1,14 @@
+<?php if (isset($error)) { ?>
+    <div class="full-page static-page toc-page">
+        <div class="full-page__row">
+            <div class="toc-page__col">
+                <div class="panel">
+                <?= $error ?>
+                </div>
+            </div>
+        </div>
+    </div>
+<?php } else { ?>
 
 <div class="full-page static-page toc-page">
     <div class="full-page__row">
@@ -131,3 +142,5 @@ function toggleDetails() {
   }
 }
 </script>
+
+<?php } ?>


### PR DESCRIPTION
If someone puts a bad value in the chamber arg then throw a 404, otherwise carry on throwing a 500 so we are warned if expected registers aren't there.