### PR TITLE
Alert front end rebase ap

### DIFF
--- a/classes/AlertView/Standard.php
+++ b/classes/AlertView/Standard.php
@@ -188,7 +188,7 @@ class Standard extends \MySociety\TheyWorkForYou\AlertView {
             }
 
             if ($this->data['alert_parts']['match_all']) {
-                $this->data['match_all'] = true;
+                $this->data['match_all'] = false;
             }
 
             $words = get_http_var('words', $this->data['alert_parts']['words'], true);

--- a/classes/AlertView/Standard.php
+++ b/classes/AlertView/Standard.php
@@ -187,8 +187,10 @@ class Standard extends \MySociety\TheyWorkForYou\AlertView {
                 $existing_section = $this->data['alert_parts']['sections'][0];
             }
 
-            if ($this->data['alert_parts']['match_all']) {
-                $this->data['match_all'] = false;
+            # only want to load this the first time, otherwise we want to default to the form
+            # value
+            if (!$this->data['this_step'] && $this->data['alert_parts']['match_all']) {
+                $this->data['match_all'] = true;
             }
 
             $words = get_http_var('words', $this->data['alert_parts']['words'], true);

--- a/classes/AlertView/Standard.php
+++ b/classes/AlertView/Standard.php
@@ -306,8 +306,10 @@ class Standard extends \MySociety\TheyWorkForYou\AlertView {
             FROM hansard
             WHERE hansard.gid = :gid", [':gid' => $gid])->first();
 
-            $last_mention_date = date_create($q['hdate']);
-            $last_mention = date_format($last_mention_date, 'd M Y'); //$se->get_gids()[0];
+            if ($q) {
+                $last_mention_date = date_create($q['hdate']);
+                $last_mention = date_format($last_mention_date, 'd M Y'); //$se->get_gids()[0];
+            }
         }
         return [
             "last_mention" => $last_mention,

--- a/classes/AlertView/Standard.php
+++ b/classes/AlertView/Standard.php
@@ -431,14 +431,6 @@ class Standard extends \MySociety\TheyWorkForYou\AlertView {
             $this->data['members'] = [];
         }
 
-        # If the above search returned one result for constituency
-        # search by postcode, use it immediately
-        if (isset($this->data['constituencies']) && count($this->data['constituencies']) == 1 && $this->data['valid_postcode']) {
-            $MEMBER = new \MEMBER(['constituency' => array_values($this->data['constituencies'])[0], 'house' => 1]);
-            $this->data['pid'] = $MEMBER->person_id();
-            $this->data['pc'] = $text;
-            unset($this->data['constituencies']);
-        }
 
         if (isset($this->data['constituencies'])) {
             $cons = [];
@@ -451,16 +443,9 @@ class Standard extends \MySociety\TheyWorkForYou\AlertView {
                 }
             }
             $this->data['constituencies'] = $cons;
-            if (count($cons) == 1) {
-                $cons = array_values($cons);
-                $this->data['pid'] = $cons[0]->person_id();
-            }
         }
 
         if ($this->data['alertsearch'] && !$this->data['mp_step'] && ($this->data['pid'] || $this->data['members'] || $this->data['constituencies'])) {
-            if (count($this->data['members']) == 1) {
-                $this->data['pid'] = $this->data['members'][0]['person_id'];
-            }
             $this->data['mp_step'] = 'mp_alert';
             $this->data['mp_search'] = $this->data['alertsearch'];
             $this->data['alertsearch'] = '';

--- a/classes/Utility/Alert.php
+++ b/classes/Utility/Alert.php
@@ -60,6 +60,14 @@ class Alert {
             $criteria = self::prettifyCriteria($row['criteria'], $row['ignore_speaker_votes']);
             $parts = self::prettifyCriteria($row['criteria'], $row['ignore_speaker_votes'], true);
             $token = $row['alert_id'] . '-' . $row['registrationtoken'];
+            // simple_criteria is "First term (3 keywords)" or "First term"
+            if (count($parts['words']) > 1) {
+                $simple_criteria = $parts['words'][0] . ' (' . count($parts['words']) . ' keywords)';
+            } elseif (count($parts['words']) == 1) {
+                $simple_criteria = $parts['words'][0];
+            } else {
+                $simple_criteria = $criteria;
+            }
 
             $status = 'confirmed';
             if (!$row['confirmed']) {
@@ -72,6 +80,7 @@ class Alert {
                 'token' => $token,
                 'status' => $status,
                 'criteria' => $criteria,
+                'simple_criteria' => $simple_criteria,
                 'raw' => $row['criteria'],
                 'ignore_speaker_votes' => $row['ignore_speaker_votes'],
                 'keywords' => [],

--- a/classes/Utility/Alert.php
+++ b/classes/Utility/Alert.php
@@ -153,7 +153,7 @@ class Alert {
             } elseif ($spokenby) {
                 $text = implode(' or ', $spokenby) . " speaks";
                 if ($ignore_speaker_votes) {
-                    $text .= " excluding votes";
+                    $text .= " (excluding votes)";
                 }
                 $parts['spokenby'] = $spokenby;
             }

--- a/scripts/import-search-suggestions
+++ b/scripts/import-search-suggestions
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+poetry run python -m twfy_tools.utils.search_suggestions "$@"

--- a/src/twfy_tools/db/models.py
+++ b/src/twfy_tools/db/models.py
@@ -112,3 +112,13 @@ class PersonInfo(
             return str(self.data_value)
         else:
             raise ValueError(f"type: {type(self.data_value)} not supported")
+
+
+class VectorSearchSuggestions(
+    UnmanagedDataclassModel, db_table="vector_search_suggestions"
+):
+    search_term: str = field(models.CharField, max_length=100, primary_key=True)
+    search_suggestion: str = field(models.CharField, max_length=10)
+
+    def __str__(self):
+        return f"{self.search_term}: {self.search_suggestion}"

--- a/src/twfy_tools/utils/search_suggestions.py
+++ b/src/twfy_tools/utils/search_suggestions.py
@@ -1,0 +1,73 @@
+"""
+Functions to update the vector search suggestions
+"""
+
+import pandas as pd
+import rich
+import rich_click as click
+
+from twfy_tools.db.models import VectorSearchSuggestions
+
+
+@click.group()
+def cli():
+    pass
+
+
+def df_to_db(df: pd.DataFrame, verbose: bool = False):
+    """
+    Add search suggestions to the database
+    """
+    df = df.dropna(how="any")
+
+    to_create = []
+
+    for _, row in df.iterrows():
+        search_term = row["original_query"]
+        search_suggestion = row["match"]
+        to_create.append(
+            VectorSearchSuggestions(
+                search_term=search_term, search_suggestion=search_suggestion
+            )
+        )
+
+    VectorSearchSuggestions.objects.all().delete()
+    VectorSearchSuggestions.objects.bulk_create(to_create)
+
+    if verbose:
+        rich.print(f"[green]{len(df)}[/green] rows updated.")
+
+
+@cli.command()
+@click.option(
+    "--file",
+    required=False,
+    default=None,
+    help="A csv file/url to update search suggestions from.",
+)
+@click.option("--verbose", is_flag=True, help="Show verbose output")
+def load(file: str, verbose: bool = False):
+    """
+    Update the vector search suggestions
+    """
+    df = pd.read_csv(file)
+    df_to_db(df, verbose=verbose)
+
+
+@cli.command()
+def count():
+    """
+    For diagnostics to check import has worked
+    """
+
+    count = VectorSearchSuggestions.objects.count()
+
+    rich.print(f"There are [green]{count}[/green] suggestions in the db")
+
+
+def main():
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/www/docs/style/sass/pages/_alert.scss
+++ b/www/docs/style/sass/pages/_alert.scss
@@ -453,6 +453,28 @@
   @extend .accordion__button;
 }
 
+.keyword-alert-accordion__button--suspended {
+  background-color: #cccccc !important; // Gray color for suspended alerts
+  color: $body-font-color !important; // Keep text black for suspended alerts
+  
+  &[aria-expanded="true"] {
+    background-color: #dddddd !important;
+    border: 1px solid #999999 !important;
+    color: $body-font-color !important;
+  }
+  
+  &:focus, &:active, &:hover {
+    background-color: #cccccc !important;
+    color: $body-font-color !important;
+  }
+  
+  &:focus[aria-expanded="false"], &:active[aria-expanded="false"], &:hover[aria-expanded="false"] {
+    background-color: #cccccc !important;
+    border: none !important;
+    color: $body-font-color !important;
+  }
+}
+
 .keyword-alert-accordion__content {
   @extend .accordion__content;
 }

--- a/www/includes/easyparliament/templates/html/alert/_alert_form.php
+++ b/www/includes/easyparliament/templates/html/alert/_alert_form.php
@@ -13,7 +13,7 @@
 
                 <input type="hidden" name="this_step" value="define">
                 <div class="alert-step" id="step1" role="region" aria-labelledby="step1-header">
-                <h2 id="step1-header"><?= gettext('Define alert') ?></h2>
+                <h2 id="step1-header"><?= gettext('Keyword alert') ?></h2>
 
                   <?php if (!$email_verified) { ?>
                   <div class="alert-form__section">
@@ -26,7 +26,7 @@
                   <?php } ?>
 
                   <div class="alert-form__section">
-                  <label for="words[]"><?= gettext('What word or phrase would you like to receive alerts about?') ?></label>
+                  <label for="words[]"><?= gettext('What word or phrase would you like to receive alerts about? (add as many as you like)') ?></label>
                     <?php if (isset($errors['alertsearch']) && $submitted) { ?>
                       <span class="alert-page-error"><?= $errors['alertsearch'] ?></span>
                     <?php } ?>
@@ -39,26 +39,26 @@
                     <?php } ?>
                     <button class="button" type="submit" name="addword" value="add">
                       <i aria-hidden="true" class="fi-save"></i>
-                      <span><?= gettext('Add word') ?></span>
+                      <span><?= gettext('Add another phrase') ?></span>
                     </button>
                   </div>
 
                   <div class="alert-form__section">
                     <div class="checkbox-wrapper">
                       <input type="checkbox" id="match_all" name="match_all"<?= $match_all ? ' checked' : ''?>>
-                      <label for="match_all"><?= gettext('Only alert if all words present, default is if any word is present') ?></label>
+                      <label for="match_all"><?= gettext('Require all phrases to be present (AND rather than OR)') ?></label>
                     </div>
                   </div>
-
+                  <hr />
                   <div class="alert-form__section">
-                    <label for="exclusions"><?= gettext('Is there anything you would not like to receive alerts about? (optional)') ?></label>
-                    <input type="text" id="exclusions" name="exclusions" aria-required="true" value="<?= _htmlspecialchars($exclusions) ?>" placeholder="Eg. 'Freedom of Information', 'FOI'">
+                    <label for="exclusions"><?= gettext('Are there any phrases you would not like to receive alerts about? (optional)') ?></label>
+                    <input type="text" id="exclusions" name="exclusions" aria-required="true" value="<?= _htmlspecialchars($exclusions) ?>" placeholder="Eg. 'Information Rights'">
                   </div>
 
                   <div class="alert-form__section">
-                  <label for="select-section"><?= gettext('Would you like to limit which Parliaments and Assemblies we alert about?') ?></label>
+                  <label for="select-section"><?= gettext('Would you like to limit which debates/questions we alert about?') ?></label>
                     <select name="search_section" id="select-section">
-                    <option value=""><?= gettext('Send alerts for everywhere.') ?></option>
+                    <option value=""><?= gettext('Include all') ?></option>
                       <optgroup label="<?= gettext('UK Parliament') ?>">
                           <option value="uk"<?= $search_section == 'uk' ? ' selected' : '' ?>><?= gettext('All UK') ?></option>
                           <option value="debates"<?= $search_section == 'debates' ? ' selected' : '' ?>><?= gettext('House of Commons debates') ?></option>
@@ -106,12 +106,14 @@
 
                   </div>
 
-
-                  <button type="submit" name="step" value="review" class="next" aria-label="Go to Step 2">Next</button>
                   <button type="submit" class="button button--red" name="action" value="Abandon">
                     <i aria-hidden="true" class="fi-trash"></i>
                     <span><?= gettext('Abandon changes') ?></span>
                   </button>
+                  <button type="submit" name="step" value="review" class="next" aria-label="Go to Step 2">
+                    <span><?= gettext('Next →') ?></span>
+                  </button>
+
                 </div>
               <?php } elseif ($step == "add_vector_related") { ?>
 
@@ -169,7 +171,7 @@
 
                   <hr>
 
-                  <h3><?= gettext('We have also found the following related terms. Pick the ones you’d like to include alert?') ?></h3>
+                  <h3><?= gettext('We have also found the following related terms.') ?></h3>
 
                   <fieldset>
                     <legend><?= gettext('Related Terms') ?></legend>
@@ -186,7 +188,7 @@
 
                         </label>
                       <?php } ?>
-                    </div>
+                                </div>
                                 <hr style="width:100%;margin:1em 0;">
                                   <label>
                                   <input type="checkbox" name="add_all_related" id="add-all"<?= $add_all_related == 'on' ? ' checked' : '' ?>>
@@ -201,6 +203,9 @@
                     <i aria-hidden="true" class="fi-trash"></i>
                     <span><?= gettext('Abandon changes') ?></span>
                   </button>
+                  <button type="submit" name="step" value="define" class="prev" aria-label="Go back to Step 2"><?= gettext('← Previous') ?></button>
+                  <button type="submit" name="step" value="review" class="next" aria-label="Go to Step 3"><?= gettext('Next →') ?></button>
+
                 </div>
               <?php } elseif ($step == "review") { ?>
 
@@ -226,7 +231,7 @@
 
                   <div class="alert-form__section">
                     <?php if ($match_all) { ?>
-                      <h3><?= gettext('You will get an alert if all of these words are in a speech') ?>:</h3>
+                      <h3><?= gettext('If you click \'save alert\', you will get an alert if all of these words are in a speech') ?>:</h3>
                     <?php } else { ?>
                       <h3><?= gettext('You will get an alert if any of these words are in a speech') ?>:</h3>
                     <?php } ?>
@@ -294,15 +299,16 @@
                   <?php } ?>
 
                   <hr>
+                  <button type="submit" class="button button--red" name="action" value="Abandon">
+                    <i aria-hidden="true" class="fi-trash"></i>
+                    <span><?= gettext('Abandon changes') ?></span>
+                  </button>
                   <button type="submit" name="step" value="define" class="prev" aria-label="Go back to Step 2">Go Back</button>
                   <button class="button" type="submit" name="step" value="confirm">
                     <i aria-hidden="true" class="fi-save"></i>
                     <span><?= gettext('Save alert') ?></span>
                   </button>
-                  <button type="submit" class="button button--red" name="action" value="Abandon">
-                    <i aria-hidden="true" class="fi-trash"></i>
-                    <span><?= gettext('Abandon changes') ?></span>
-                  </button>
+
                   <?php if ($token) { ?>
                   <button type="submit" class="button button--red" name="action" value="Delete">
                     <i aria-hidden="true" class="fi-trash"></i>

--- a/www/includes/easyparliament/templates/html/alert/_alert_form.php
+++ b/www/includes/easyparliament/templates/html/alert/_alert_form.php
@@ -103,10 +103,7 @@
                       <p><?= gettext("Or edit the name") ?></p>
                     <?php } ?>
                       <input type="text" id="representative" name="representative" value="<?= _htmlspecialchars($representative) ?>" aria-required="true">
-                      <div class="checkbox-wrapper">
-                        <input type="checkbox" id="ignore_speaker_votes" name="ignore_speaker_votes"<?= $ignore_speaker_votes ? ' checked' : ''?>>
-                        <label for="ignore_speaker_votes"><?= gettext('Do not include votes') ?></label>
-                      </div>
+
                   </div>
 
 

--- a/www/includes/easyparliament/templates/html/alert/_alert_form.php
+++ b/www/includes/easyparliament/templates/html/alert/_alert_form.php
@@ -144,21 +144,25 @@
                     </ul>
                   </div>
 
-                  <?php if ($search_result_count > 0 || isset($lastmention)) { ?>
+                  <?php if ($search_results["all_time_count"] > 0 || isset($search_results["last_mention"])) { ?>
                     <hr>
                     <dl class="alert-meta">
                       <div class="alert-meta__results">
-                        <?php if ($search_result_count > 0) { ?>
+                        <?php if ($search_results["all_time_count"] > 0) { ?>
+                          <div class="alert-meta__item">
+                            <dt><?= gettext('All time') ?></dt>
+                            <dd><?= sprintf(gettext('%d mentions'), $search_results["all_time_count"]) ?></dd>
+                          </div>
                           <div class="alert-meta__item">
                             <dt><?= gettext('Last 7 days') ?></dt>
-                            <dd><?= sprintf(gettext('%d mentions'), $search_result_count) ?></dd>
+                            <dd><?= sprintf(gettext('%d mentions'), $search_results["last_week_count"]) ?></dd>
                           </div>
                         <?php } ?>
 
-                        <?php if (isset($lastmention)) { ?>
+                        <?php if (isset($search_results["last_mention"])) { ?>
                           <div class="alert-meta__item">
                           <dt><?= gettext('Date of last mention') ?></dt>
-                            <dd><?= $lastmention ?></dd>
+                            <dd><?= $search_results["last_mention"] ?></dd>
                           </div>
                         <?php } ?>
                       </div>
@@ -267,25 +271,21 @@
                   </div>
                   <?php } ?>
 
-                  <?php if ($search_result_count > 0 || isset($lastmention)) { ?>
+                  <?php if ($search_results["all_time_count"] > 0 || isset($last_mention)) { ?>
                     <hr>
                     <dl class="alert-meta">
-                      <h3>See mentions for this alert</h3>
+                      <h3><?= gettext("Alert statistics") ?></h3>
 
                       <div class="alert-meta__results">
-                        <?php if ($search_result_count > 0) { ?>
                           <div class="alert-meta__item">
                             <dt><?= gettext('Last 7 days') ?></dt>
-                            <dd><?= sprintf(gettext('%d mentions'), $search_result_count) ?></dd>
+                            <dd><?= sprintf(gettext('%d mentions'), $search_results["all_time_count"]) ?></dd>
                           </div>
-                        <?php } ?>
 
-                        <?php if (isset($lastmention)) { ?>
                           <div class="alert-meta__item">
                             <dt><?= gettext('Date of last mention') ?></dt>
-                            <dd><?= $lastmention ?></dd>
+                            <dd><?= $search_results["last_mention"] ?></dd>
                           </div>
-                        <?php } ?>
                       </div>
 
                       <a href="/search/?q=<?= _htmlspecialchars($criteria) ?>" target="_blank" aria-label="See results for this alert - Opens in a new tab"><?= gettext('See results for this alert 	&rarr;') ?></a>

--- a/www/includes/easyparliament/templates/html/alert/_alert_form.php
+++ b/www/includes/easyparliament/templates/html/alert/_alert_form.php
@@ -174,7 +174,6 @@
                   <fieldset>
                     <legend><?= gettext('Related Terms') ?></legend>
                     <div class="checkbox-group">
-                      <label><input type="checkbox" name="add_all_related" id="add-all"<?= $add_all_related == 'on' ? ' checked' : '' ?>><?= gettext('Add all related terms') ?></label>
                       <?php foreach ($suggestions as $suggestion) { ?>
                         <input type="hidden" name="related_terms[]" value="<?= _htmlspecialchars($suggestion) ?>">
                         <label>
@@ -188,11 +187,16 @@
                         </label>
                       <?php } ?>
                     </div>
+                                <hr style="width:100%;margin:1em 0;">
+                                  <label>
+                                  <input type="checkbox" name="add_all_related" id="add-all"<?= $add_all_related == 'on' ? ' checked' : '' ?>>
+                                  <?= gettext('Add all related terms') ?>
+                                  </label>
+ </div>
+
+
                   </fieldset>
 
-
-                  <button type="submit" name="step" value="define" class="prev" aria-label="Go back to Step 2">Previous</button>
-                  <button type="submit" name="step" value="review" class="next" aria-label="Go to Step 3">Next</button>
                   <button type="submit" class="button button--red" name="action" value="Abandon">
                     <i aria-hidden="true" class="fi-trash"></i>
                     <span><?= gettext('Abandon changes') ?></span>

--- a/www/includes/easyparliament/templates/html/alert/_keyword_alert_list.php
+++ b/www/includes/easyparliament/templates/html/alert/_keyword_alert_list.php
@@ -226,15 +226,5 @@
                         </form>
                       </div>
                     <?php } ?>
-                    <?php if (!in_array(implode('', $person_alerts[0]['spokenby']), $all_keywords)) { ?>
-                      <p class="alert-form__subtitle">Alert when <?= _htmlspecialchars(implode(', ', $person_alerts[0]['spokenby'])) ?> is <strong>mentioned</strong></p>
-                      <form action="<?= $actionurl ?>" method="post">
-                        <input type="hidden" name="words[]" value="<?= _htmlentities(implode('', $person_alerts[0]['spokenby'])) ?>">
-                        <button type="submit" class="button small" name="action" value="Subscribe">
-                          <i aria-hidden="true" role="img" class="fi-megaphone"></i>
-                          <?= gettext('Create new alert') ?>
-                        </button>
-                      </form>
-                    <?php } ?>
                   </div>
                 <?php } ?>

--- a/www/includes/easyparliament/templates/html/alert/_keyword_alert_list.php
+++ b/www/includes/easyparliament/templates/html/alert/_keyword_alert_list.php
@@ -1,7 +1,7 @@
                 <div class="keyword-alert-accordion">
                   <?php foreach ($keyword_alerts as $index => $alert) { ?>
                     <div class="keyword-alert-accordion__item">
-                      <button class="keyword-alert-accordion__button js-accordion-button" href="#accordion-content-<?= $index ?>" aria-expanded="false">
+                      <button class="keyword-alert-accordion__button js-accordion-button <?= ($alert['status'] == 'suspended') ? 'keyword-alert-accordion__button--suspended' : '' ?>" href="#accordion-content-<?= $index ?>" aria-expanded="false">
                         <div class="keyword-alert-accordion__button-content">
                           <span class="keyword-alert-accordion__title"><?= _htmlspecialchars($alert['simple_criteria']) ?></span>
                           <?php if (array_key_exists("search_results", $alert)) { ?>

--- a/www/includes/easyparliament/templates/html/alert/_keyword_alert_list.php
+++ b/www/includes/easyparliament/templates/html/alert/_keyword_alert_list.php
@@ -127,7 +127,7 @@
                     <input type="hidden" name="mp_step" value="mp_alert">
                     <button type="submit" class="button small">
                       <i aria-hidden="true" role="img" class="fi-megaphone"></i>
-                      <?= gettext('Create new MP alert') ?>
+                      <?= gettext('Create new Representative alert') ?>
                     </button>
                   </form>
                 </div>

--- a/www/includes/easyparliament/templates/html/alert/_keyword_alert_list.php
+++ b/www/includes/easyparliament/templates/html/alert/_keyword_alert_list.php
@@ -3,9 +3,9 @@
                     <div class="keyword-alert-accordion__item">
                       <button class="keyword-alert-accordion__button js-accordion-button" href="#accordion-content-<?= $index ?>" aria-expanded="false">
                         <div class="keyword-alert-accordion__button-content">
-                          <span class="keyword-alert-accordion__title"><?= _htmlspecialchars($alert['criteria']) ?></span>
-                          <?php if (array_key_exists("mentions", $alert)) { ?>
-                            <span class="keyword-alert-accordion__subtitle"><?= sprintf(gettext('%d mentions this week'), $alert['mentions']) ?></span>
+                          <span class="keyword-alert-accordion__title"><?= _htmlspecialchars($alert['simple_criteria']) ?></span>
+                          <?php if (array_key_exists("search_results", $alert)) { ?>
+                            <span class="keyword-alert-accordion__subtitle"><?= sprintf(gettext('%d mentions this week'), $alert['search_results']['last_week_count']) ?></span>
                           <?php } ?>
                         </div>
                         <i aria-hidden="true" role="img" class="fi-plus"></i>
@@ -47,17 +47,18 @@
                             </form>
                           </div>
                           <dl class="alert-meta-info">
-                            <?php if (array_key_exists("mentions", $alert)) { ?>
+                            <?php if (array_key_exists("search_results", $alert)) { ?>
+                              <div class="content-header-item">
+                                <dt><?= gettext('All time') ?></dt>
+                                <dd><?= sprintf(gettext('%d mentions'), $alert['search_results']['all_time_count']) ?></dd>
+                              </div>
                               <div class="content-header-item">
                                 <dt><?= gettext('This week') ?></dt>
-                                <dd><?= sprintf(gettext('%d mentions'), $alert['mentions']) ?></dd>
+                                <dd><?= sprintf(gettext('%d mentions'), $alert['search_results']['last_week_count']) ?></dd>
                               </div>
-                            <?php } ?>
-
-                            <?php if (array_key_exists("last_mention", $alert)) { ?>
                               <div class="content-header-item">
                                 <dt><?= gettext('Date of last mention') ?></dt>
-                                <dd><?= $alert['last_mention'] ?></dd>
+                                <dd><?= $alert['search_results']['last_mention'] ?></dd>
                               </div>
                             <?php } ?>
 

--- a/www/includes/easyparliament/templates/html/alert/_keyword_alert_list.php
+++ b/www/includes/easyparliament/templates/html/alert/_keyword_alert_list.php
@@ -61,8 +61,7 @@
                                 <dd><?= $alert['search_results']['last_mention'] ?></dd>
                               </div>
                             <?php } ?>
-
-                            <a href="/search/?q=<?= $alert['raw'] ?>"><?= gettext('See results for this alert &rarr;') ?></a>
+                            <a href="/search/?q=<?= _htmlspecialchars($alert['raw']) ?>"><?= gettext('See results for this alert &rarr;') ?></a>
                           </dl>
                         </div>
 

--- a/www/includes/easyparliament/templates/html/alert/_mp_alert_form.php
+++ b/www/includes/easyparliament/templates/html/alert/_mp_alert_form.php
@@ -15,6 +15,32 @@
           </li>
     <?php } ?>
   </ul>
+<?php } elseif ($members) {
+    $member_options = true; ?>
+  <h3><?= sprintf(gettext('Sign up for alerts when people matching <i>%s</i> speaks'), _htmlspecialchars($search_term)) ?></h3>
+  <ul>
+    <?php
+      foreach ($members as $row) {
+          ?>
+      <li>
+          <form action="<?= $actionurl ?>" method="post">
+              <input type="hidden" name="t" value="<?= _htmlspecialchars($token) ?>">
+              <input type="hidden" name="email" value="<?= _htmlspecialchars($email) ?>">
+              <input type="hidden" name="pid" value="<?= $row['person_id'] ?>">
+              <input type="hidden" name="ignore_speaker_votes" value="<?= $ignore_speaker_votes ?>">
+              <?php
+                    $name = member_full_name($row['house'], $row['title'], $row['given_name'], $row['family_name'], $row['lordofname']);
+          if ($row['constituency']) {
+              $name .= ' (' . gettext($row['constituency']) . ')';
+          }
+          printf(gettext('When %s speaks.'), $name);
+          ?>
+              <input type="submit" class="button small" value="<?= gettext('Subscribe') ?>"></form>
+          </form>
+      </li>
+    <?php } ?>
+  </ul>
+  <hr />
 <?php } else { ?>
   <form action="<?= $actionurl ?>" method="post" class="alerts-form">
     <?php if (!$email_verified) { ?>

--- a/www/includes/easyparliament/templates/html/alert/_mp_alert_form.php
+++ b/www/includes/easyparliament/templates/html/alert/_mp_alert_form.php
@@ -45,7 +45,7 @@
       <div class="alert-form__section">
         <div class="checkbox-wrapper">
           <input type="checkbox" id="ignore_speaker_votes" name="ignore_speaker_votes"<?= $ignore_speaker_votes ? ' checked' : ''?>>
-          <label for="ignore_speaker_votes"><?= gettext('Do not include votes') ?></label>
+          <label for="ignore_speaker_votes"><?= gettext('Do not include votes in the alert') ?></label>
         </div>
       </div>
 

--- a/www/includes/easyparliament/templates/html/alert/index.php
+++ b/www/includes/easyparliament/templates/html/alert/index.php
@@ -123,7 +123,7 @@
       <?php if ($mp_step) { ?>
         <div class="alert-section">
             <div class="alert-section__primary">
-              <h1><?= gettext("Create an MP Alert") ?></h1>
+              <h1><?= gettext("Create an Representative Alert") ?></h1>
               <?php include '_mp_alert_form.php' ?>
               </div>
           </div>
@@ -299,7 +299,7 @@
                   <input type="hidden" name="mp_step" value="mp_alert">
                   <button type="submit" class="button small">
                     <i aria-hidden="true" role="img" class="fi-megaphone"></i>
-                    <?= gettext('Create new MP alert') ?>
+                    <?= gettext('Create new Representative alert') ?>
                   </button>
                 </form>
               </div>

--- a/www/includes/easyparliament/templates/html/alert/index.php
+++ b/www/includes/easyparliament/templates/html/alert/index.php
@@ -168,6 +168,7 @@
                     </li>
                   <?php } ?>
                 </ul>
+                <hr />
               <?php } ?>
 
               <?php if (isset($constituencies) && count($constituencies) > 0) {


### PR DESCRIPTION
Ok, this is looking really really good! I've just gone in and tweaked stuff rather than making a list.

This is mostly a set of formatting/copy changes to the alerts display and view - but I've also made some changes to the logic. 

- The search results bit wasn't working for the main view - so I've tided up connections between the two places that is used. Similarly, copied the way the results view url worked inside the form itself. 
- I've removed the 'don't include speaker votes' bit from the *keyword* search because this didn't seem relevant (but may have mis-understood).
- For the MP alert search,  I've taken away the shortcuts that automatically subscribe if there is only one result. This is because I was getting unexpected behaviour when i did a typo (got someone's name wrong,  but it *was* a match for a constituency). It's just one extra button and I think works fine. 


