### PR TITLE
Extra MP Differs text.

### DIFF
--- a/tests/PartyTest.php
+++ b/tests/PartyTest.php
@@ -119,7 +119,7 @@ class PartyTest extends FetchPageTestCase {
         $page = $this->fetch_page(['pagetype' => 'votes', 'pid' => 15, 'url' => '/mp/15/test_mp_g_party_1/test_westminster_constituency/votes']);
         $this->assertStringContainsString('is a G Party MP', $page);
         $this->assertStringContainsString('Test MP G Party 1', $page);
-        $this->assertStringContainsString('sometimes <b>differs</b> from their party', $page);
+        $this->assertStringContainsString('sometimes differs from their party', $page);
     }
 
     public function testSingleMemberPartyPolicyText() {
@@ -151,7 +151,7 @@ class PartyTest extends FetchPageTestCase {
         $page = $this->fetch_page(['pagetype' => 'votes', 'pid' => 16,  'url' => '/mp/16/test_mp_g_party_2/test_westminster_constituency/votes']);
         $this->assertStringContainsString('Test MP G Party 2', $page);
 
-        $this->assertStringNotContainsString('sometimes <b>differs</b> from their party colleagues', $page);
+        $this->assertStringNotContainsString('sometimes differs from their party colleagues', $page);
     }
 
 

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -121,7 +121,10 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                         </p>
                     <?php } else { ?>
                         <p>
-                        However, <?= $full_name ?> sometimes <b>differs</b> from their party colleagues, such as:
+                        Where MPs <b>differ</b> is either because they have made a decision not to follow the party whip (rebelling), or where they have differed from the majority of their colleagues in a free vote.
+                        </p>
+                        <p>
+                        <?= $full_name ?> sometimes differs from their party colleagues, such as:
                         </p>
                     <?php } ?>
 


### PR DESCRIPTION
We have an number of MPs where we are *only* highlighting a free vote difference. Expanding language to not imply all differences are rebellions. 