### PR TITLE
load and display APPG info for MPs

### DIFF
--- a/classes/DataClass/APPGs/APPGDetails.php
+++ b/classes/DataClass/APPGs/APPGDetails.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Mirrors pydantic model for deseralisation in a PHP context.
+ * For adding display related helper functions.
+ * @package TheyWorkForYou
+ */
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\APPGs;
+
+use MySociety\TheyWorkForYou\DataClass\BaseModel;
+
+class APPGDetails extends BaseModel {
+    public string $slug;
+    public string $title;
+    public string $purpose;
+    public string $website;
+    public string $source_url;
+    // public Array $categories;
+}

--- a/classes/DataClass/APPGs/APPGMembership.php
+++ b/classes/DataClass/APPGs/APPGMembership.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\APPGs;
+
+use MySociety\TheyWorkForYou\DataClass\BaseModel;
+
+/**
+ * @extends BaseModel<Category>
+ */
+class APPGMembership extends BaseModel {
+    public string $role;
+    public APPGDetails $appg;
+}

--- a/classes/DataClass/APPGs/APPGMembershipAssignment.php
+++ b/classes/DataClass/APPGs/APPGMembershipAssignment.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Mirrors pydantic model for deseralisation in a PHP context.
+ * For adding display related helper functions.
+ * @package TheyWorkForYou
+ */
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\APPGs;
+
+use MySociety\TheyWorkForYou\DataClass\BaseModel;
+
+class APPGMembershipAssignment extends BaseModel {
+    public APPGMembershipList $is_officer_of;
+    public APPGMembershipList $is_ordinary_member_of;
+
+    public function is_an_officer() {
+        return $this->is_officer_of->count() > 0;
+    }
+
+    public function is_a_member() {
+        return $this->is_ordinary_member_of->count() > 0;
+    }
+}

--- a/classes/DataClass/APPGs/APPGMembershipList.php
+++ b/classes/DataClass/APPGs/APPGMembershipList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\APPGs;
+
+use MySociety\TheyWorkForYou\DataClass\BaseCollection;
+
+/**
+ * @extends BaseCollection<Category>
+ */
+class APPGMembershipList extends BaseCollection {
+    public function __construct(APPGMembership ...$memberships) {
+        $this->items = $memberships;
+    }
+
+    public function count() {
+        return count($this->items);
+    }
+}

--- a/src/twfy_tools/utils/personinfo.py
+++ b/src/twfy_tools/utils/personinfo.py
@@ -157,11 +157,19 @@ def load_appg_membership(quiet: bool = False):
 
     id_to_person = defaultdict(list)
     df = pd.read_parquet(appg_membership_url)
+    df = df.sort_values("appg")
     for _, row in df.iterrows():
         if pd.isna(row["twfy_id"]):
             continue
         int_id = int(row["twfy_id"].split("/")[-1])
-        id_to_person[int_id].append(appg_lookup[row["appg"]])
+        details = {
+            "name": appg_lookup[row["appg"]],
+            "officer": "",
+        }
+        if row["is_officer"] == 1:
+            details["officer"] = row["officer_role"]
+
+        id_to_person[int_id].append(details)
 
     upload_person_info(
         "appg_membership",

--- a/src/twfy_tools/utils/personinfo.py
+++ b/src/twfy_tools/utils/personinfo.py
@@ -169,7 +169,7 @@ def upload_enhanced_2024_regmem(quiet: bool = False):
 
 
 @app.command()
-def load_appg_membership(quiet: bool = False):
+def load_appg_membership(quiet: bool = False, include_ai_sources: bool = False):
     """
     Upload APPG membership information
     """
@@ -180,6 +180,9 @@ def load_appg_membership(quiet: bool = False):
         APPGMembershipAssignment
     )
     df = pd.read_parquet(appg_membership_url)
+    # skip this by default while we validate the results
+    if not include_ai_sources:
+        df = df[df["source"] != "ai_search"]
     df = df.sort_values("appg")
     for _, row in df.iterrows():
         if pd.isna(row["twfy_id"]):

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -983,7 +983,7 @@ function person_appg_memberships($member) {
 
     $extra_info = $member->extra_info();
     if (isset($extra_info['appg_membership'])) {
-        $out = $extra_info['appg_membership'];
+        $out = MySociety\TheyWorkForYou\DataClass\APPGs\APPGMembershipAssignment::fromJson($extra_info['appg_membership']);
     }
 
     return $out;
@@ -1019,7 +1019,7 @@ function member_interests($member) {
 
     $appg_membership = person_appg_memberships($member);
     if ($appg_membership) {
-        $out['appg_membership'] = json_decode($appg_membership);
+        $out['appg_membership'] = $appg_membership;
     }
 
     return $out;

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -978,6 +978,17 @@ function person_topics($member) {
     return $out;
 }
 
+function person_appg_memberships($member) {
+    $out = [];
+
+    $extra_info = $member->extra_info();
+    if (isset($extra_info['appg_membership'])) {
+        $out = $extra_info['appg_membership'];
+    }
+
+    return $out;
+}
+
 function member_interests($member) {
     $out = [];
 
@@ -1004,6 +1015,11 @@ function member_interests($member) {
     $topics_of_interest = person_topics($member);
     if ($topics_of_interest) {
         $out['topics_of_interest'] = $topics_of_interest;
+    }
+
+    $appg_membership = person_appg_memberships($member);
+    if ($appg_membership) {
+        $out['appg_membership'] = json_decode($appg_membership);
     }
 
     return $out;

--- a/www/includes/easyparliament/templates/html/mp/interests.php
+++ b/www/includes/easyparliament/templates/html/mp/interests.php
@@ -23,6 +23,14 @@ $display_wtt_stats_banner = '2015';
                         <?php if (array_key_exists('previous_posts', $member_interests)): ?>
                           <li><a href="#previous_posts"><?= gettext('Previous Memberships') ?></a></li>
                         <?php endif; ?>
+                        <?php if (array_key_exists('appg_membership', $member_interests)): ?>
+                            <?php if ($member_interests['appg_membership']->is_an_officer()): ?>
+                              <li><a href="#appg_officer"><?= gettext('APPG Offices held') ?></a></li>
+                            <?php endif; ?>
+                            <?php if ($member_interests['appg_membership']->is_a_member()): ?>
+                              <li><a href="#appg_memberships"><?= gettext('APPG memberships') ?></a></li>
+                            <?php endif; ?>
+                        <?php endif; ?>
                         <?php if (array_key_exists('topics_of_interest', $member_interests) || array_key_exists('eu_stance', $member_interests)): ?>
                           <li><a href="#topics"><?= gettext('Topics of interest') ?></a></li>
                         <?php endif; ?>

--- a/www/includes/easyparliament/templates/html/mp/interests.php
+++ b/www/includes/easyparliament/templates/html/mp/interests.php
@@ -68,6 +68,19 @@ $display_wtt_stats_banner = '2015';
 
                     <?php endif; ?>
 
+                    <?php if (array_key_exists('appg_membership', $member_interests)): ?>
+                    <h3><?=gettext('APPG Memberships') ?></h3>
+
+                    <ul class='list-dates'>
+
+                        <?php foreach ($member_interests['appg_membership'] as $appg): ?>
+                            <li><?= $appg ?></li>
+                        <?php endforeach; ?>
+
+                    </ul>
+
+                    <?php endif; ?>
+
                     <?php if (array_key_exists('topics_of_interest', $member_interests) || array_key_exists('eu_stance', $member_interests)): ?>
 
                         <h3 id="topics"><?= gettext('Topics of interest') ?></h3>

--- a/www/includes/easyparliament/templates/html/mp/interests.php
+++ b/www/includes/easyparliament/templates/html/mp/interests.php
@@ -69,16 +69,23 @@ $display_wtt_stats_banner = '2015';
                     <?php endif; ?>
 
                     <?php if (array_key_exists('appg_membership', $member_interests)): ?>
-                    <h3><?=gettext('APPG Memberships') ?></h3>
+                        <?php if ($member_interests['appg_membership']->is_an_officer()): ?>
+                            <h3 id="appg_officer"><?=gettext('APPG Offices held') ?></h3>
+                            <ul class='list-dates'>
+                                <?php foreach ($member_interests['appg_membership']->is_officer_of as $membership): ?>
+                                    <li><?= $membership->appg->title ?> <?= $membership->role ? '(' . $membership->role . ')' : '' ?></li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
 
-                    <ul class='list-dates'>
-
-                        <?php foreach ($member_interests['appg_membership'] as $appg): ?>
-                            <li><?= $appg ?></li>
-                        <?php endforeach; ?>
-
-                    </ul>
-
+                        <?php if ($member_interests['appg_membership']->is_a_member()): ?>
+                            <h3 id="appg_memberships"><?=gettext('APPG memberships') ?></h3>
+                            <ul class='list-dates'>
+                                    <?php foreach ($member_interests['appg_membership']->is_ordinary_member_of as $membership): ?>
+                                        <li><?= $membership->appg->title ?></li>
+                                    <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
                     <?php endif; ?>
 
                     <?php if (array_key_exists('topics_of_interest', $member_interests) || array_key_exists('eu_stance', $member_interests)): ?>


### PR DESCRIPTION
Imports and display APPG memberships on member's interests tab.

Stores things in the personinfo table as json with name of APPG and the name of any role they might have in the APPG. Splits the display out into officer and membership sections.

<img width="1115" height="439" alt="Screenshot 2025-08-05 at 15 59 36" src="https://github.com/user-attachments/assets/f5b95f73-de48-4abd-a1b6-22d07f178a71" />


Part of #1895