### PR TITLE
Record emails sent in GA

### DIFF
--- a/conf/general-example
+++ b/conf/general-example
@@ -212,3 +212,7 @@ define('REDIS_SENTINEL_PORT', '26379');
 define('REDIS_SERVICE_NAME', 'mymaster');
 
 define('OPENGRAPH_IMAGE_SALT', 'your_secret_key_here');
+
+// Google Analytics 4 measurement protocol secret
+define('MEASUREMENT_PROTOCOL_SECRET', '');
+

--- a/conf/general-example
+++ b/conf/general-example
@@ -213,6 +213,8 @@ define('REDIS_SERVICE_NAME', 'mymaster');
 
 define('OPENGRAPH_IMAGE_SALT', 'your_secret_key_here');
 
+// Tracking analytics
+define('GOOGLE_ANALYTICS_ID', 'G-W8M9N1MJFT');
+
 // Google Analytics 4 measurement protocol secret
 define('MEASUREMENT_PROTOCOL_SECRET', '');
-

--- a/scripts/alertmailer.php
+++ b/scripts/alertmailer.php
@@ -431,12 +431,29 @@ if ($globalsuccess) {
 }
 $sss .= (getmicrotime() - $global_start) . "\n\n";
 mlog($sss);
+
+
+
 if (!$nomail && !$onlyemail) {
     $fp = fopen(RAWDATA . '/alerts-lastsent', 'w');
     fwrite($fp, time() . "\n");
     fwrite($fp, $max_batch_id);
     fclose($fp);
     mail(ALERT_STATS_EMAILS, 'Email alert statistics', $sss, 'From: Email Alerts <fawkes@dracos.co.uk>');
+
+    // Send Google Analytics event with the number of alerts sent
+    if ($sentemails > 0) {
+        $ga_success = send_ga_event('alerts_sent', [
+            'email_counts' => $sentemails,
+        ]);
+
+        if ($ga_success) {
+            mlog("Google Analytics event sent: $sentemails alerts\n");
+        } else {
+            mlog("Failed to send Google Analytics event\n");
+        }
+    }
+
 }
 mlog(date('r') . "\n");
 

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -64,14 +64,14 @@
 
     <!-- Google tag (gtag.js) -->
     <script defer>Object.defineProperty(document,"cookie",{get:function(){var t=Object.getOwnPropertyDescriptor(Document.prototype,"cookie").get.call(document);return t.trim().length>0&&(t+="; "),t+="_ga=GA1.1."+Math.floor(1e9*Math.random())+"."+Math.floor(1e9*Math.random())},set:function(t){t.trim().startsWith("_ga")||Object.getOwnPropertyDescriptor(Document.prototype,"cookie").set.call(document,t)}});</script>
-    <script defer src="https://www.googletagmanager.com/gtag/js?id=G-W8M9N1MJFT"></script>
+    <script defer src="https://www.googletagmanager.com/gtag/js?id=<?= GOOGLE_ANALYTICS_ID ?>"></script>
   
     <script>
         var client_id = Math.floor(Math.random() * 1000000000) + '.' + Math.floor(Math.random() * 1000000000);
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config','G-W8M9N1MJFT', {'client_id': client_id, 'cookie_expires': 1 });
+        gtag('config','<?= GOOGLE_ANALYTICS_ID ?>', {'client_id': client_id, 'cookie_expires': 1 });
     </script>
 
     <script>

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -74,16 +74,6 @@
         gtag('config','<?= GOOGLE_ANALYTICS_ID ?>', {'client_id': client_id, 'cookie_expires': 1 });
     </script>
 
-    <script>
-        (function (i,s,o,g,r,a,m) {i['GoogleAnalyticsObject']=r;i[r]=i[r]||function () {
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-660910-1', {'storage':'none'});
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
   <?php endif; ?>
 
 </head>

--- a/www/includes/utility.php
+++ b/www/includes/utility.php
@@ -1210,7 +1210,7 @@ function send_ga_event($event_name, $parameters = []) {
         return false;
     }
 
-    $measurement_id = 'G-W8M9N1MJFT'; // TheyWorkForYou GA4 tracking ID
+    $measurement_id = GOOGLE_ANALYTICS_ID; // TheyWorkForYou GA4 tracking ID
     $api_secret = MEASUREMENT_PROTOCOL_SECRET;
 
     // Generate client_id as two 32-bit integers separated by a dot


### PR DESCRIPTION
For better tracking of "hey how many emails did we send this month/year", we want to stash the amount of emails sent in google analytics.

This uses the measurement protocol to send events - the python version of this function is here: https://github.com/mysociety/research-repository/blob/7180805ee9522c4272019357df6de4c9dc738aa7/repository/views.py#L399

In the long run, we might want to add a few more stats from the alerts (keep track of keyword/representative ones separately) - but this gets the basic approach in. 