### PR TITLE
Add more details to committees/appgs

### DIFF
--- a/classes/DataClass/APPGs/APPGDetails.php
+++ b/classes/DataClass/APPGs/APPGDetails.php
@@ -15,7 +15,7 @@ class APPGDetails extends BaseModel {
     public string $slug;
     public string $title;
     public string $purpose;
-    public string $website;
+    public ?string $website;
     public string $source_url;
     // public Array $categories;
 }

--- a/classes/DataClass/APPGs/APPGMembership.php
+++ b/classes/DataClass/APPGs/APPGMembership.php
@@ -6,10 +6,8 @@ namespace MySociety\TheyWorkForYou\DataClass\APPGs;
 
 use MySociety\TheyWorkForYou\DataClass\BaseModel;
 
-/**
- * @extends BaseModel<Category>
- */
 class APPGMembership extends BaseModel {
     public string $role;
+    public string $membership_source_url;
     public APPGDetails $appg;
 }

--- a/classes/DataClass/APPGs/APPGMembershipList.php
+++ b/classes/DataClass/APPGs/APPGMembershipList.php
@@ -7,7 +7,7 @@ namespace MySociety\TheyWorkForYou\DataClass\APPGs;
 use MySociety\TheyWorkForYou\DataClass\BaseCollection;
 
 /**
- * @extends BaseCollection<Category>
+ * @extends BaseCollection<APPGMembership>
  */
 class APPGMembershipList extends BaseCollection {
     public function __construct(APPGMembership ...$memberships) {

--- a/classes/DataClass/BaseInterface.php
+++ b/classes/DataClass/BaseInterface.php
@@ -5,7 +5,10 @@ namespace MySociety\TheyWorkForYou\DataClass;
 use function Rutek\Dataclass\transform;
 
 trait BaseInterface {
-    public static function fromJson(string $json): self {
+    /**
+     * @return static
+     */
+    public static function fromJson(string $json) {
         $data = json_decode($json, true);
         try {
             return transform(static::class, $data);
@@ -15,12 +18,18 @@ trait BaseInterface {
         }
     }
 
-    public static function fromFile(string $file): self {
+    /**
+     * @return static
+     */
+    public static function fromFile(string $file) {
         $content = file_get_contents($file);
         return static::fromJson($content);
     }
 
-    public static function fromArray(array $data): self {
+    /**
+     * @return static
+     */
+    public static function fromArray(array $data) {
         try {
             return transform(static::class, $data);
         } catch (\Exception $transformException) {

--- a/classes/DataClass/BaseInterface.php
+++ b/classes/DataClass/BaseInterface.php
@@ -27,6 +27,23 @@ trait BaseInterface {
     }
 
     /**
+     * @return static|null
+     */
+    public static function fromCachedFile(string $file) {
+        if (!file_exists($file)) {
+            return null;
+        }
+
+        $memcache = new \MySociety\TheyWorkForYou\Memcache();
+        $content = $memcache->get($file);
+        if (!$content) {
+            $content = file_get_contents($file);
+            $memcache->set($file, $content, 60 * 60 * 1); // Cache for 1 hour
+        }
+        return static::fromJson($content);
+    }
+
+    /**
      * @return static
      */
     public static function fromArray(array $data) {

--- a/classes/DataClass/Groups/MiniGroup.php
+++ b/classes/DataClass/Groups/MiniGroup.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Classes to manage a very basic 'Group' format (which can take key properties of committees, APPGs)
+ * @package TheyWorkForYou
+ */
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Groups;
+
+use MySociety\TheyWorkForYou\DataClass\BaseModel;
+
+class MiniGroup extends BaseModel {
+    public string $slug = "";
+    public string $name = "";
+    public string $description = "";
+    public string $external_url = "";
+    public string $group_type = "";
+    public MiniGroupCategoryList $group_categories;
+    public MiniMemberList $members;
+}

--- a/classes/DataClass/Groups/MiniGroupCategoryList.php
+++ b/classes/DataClass/Groups/MiniGroupCategoryList.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Groups;
+
+use MySociety\TheyWorkForYou\DataClass\BaseCollection;
+
+/**
+ * @extends BaseCollection<string>
+ */
+class MiniGroupCategoryList extends BaseCollection {
+    public function __construct(string ...$categories) {
+        $this->items = $categories;
+    }
+}

--- a/classes/DataClass/Groups/MiniGroupList.php
+++ b/classes/DataClass/Groups/MiniGroupList.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Groups;
+
+use MySociety\TheyWorkForYou\DataClass\BaseCollection;
+
+/**
+ * @extends BaseCollection<MiniGroup>
+ */
+class MiniGroupList extends BaseCollection {
+    public function __construct(MiniGroup ...$members) {
+        $this->items = $members;
+    }
+
+    public function findByName(string $name): ?MiniGroup {
+        foreach ($this->items as $member) {
+            if ($member->name === $name) {
+                return $member;
+            }
+        }
+        return null;
+    }
+
+    public function findBySlug(string $slug): ?MiniGroup {
+        foreach ($this->items as $member) {
+            if ($member->slug === $slug) {
+                return $member;
+            }
+        }
+        return null;
+    }
+
+    public static function uk_committees(): self {
+        $file_dir = RAWDATA . "scrapedjson/committees/uk_committees_groups.json";
+
+        $result = self::fromCachedFile($file_dir);
+        // if $result is null the file isn't present, return an empty list
+        if ($result === null) {
+            return new self();
+        }
+        return $result;
+    }
+}

--- a/classes/DataClass/Groups/MiniMember.php
+++ b/classes/DataClass/Groups/MiniMember.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Mirrors pydantic model for deseralisation in a PHP context.
+ * For adding display related helper functions.
+ * @package TheyWorkForYou
+ */
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Groups;
+
+use MySociety\TheyWorkForYou\DataClass\BaseModel;
+
+class MiniMember extends BaseModel {
+    public string $name;
+    public ?string $twfy_id = null;
+    public ?string $officer_role = null;
+    public bool $external_member = false;
+    public bool $is_current = false;
+}

--- a/classes/DataClass/Groups/MiniMemberList.php
+++ b/classes/DataClass/Groups/MiniMemberList.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MySociety\TheyWorkForYou\DataClass\Groups;
+
+use MySociety\TheyWorkForYou\DataClass\BaseCollection;
+
+/**
+ * @extends BaseCollection<MiniMember>
+ */
+class MiniMemberList extends BaseCollection {
+    public function __construct(MiniMember ...$members) {
+        $this->items = $members;
+    }
+}

--- a/classes/Member.php
+++ b/classes/Member.php
@@ -315,6 +315,8 @@ class Member extends \MEMBER {
 
         $officeObject = new Office();
         $officeObject->title = prettify_office($row['position'], $row['dept']);
+        $officeObject->position = $row['position'];
+        $officeObject->dept = $row['dept'];
         $officeObject->from_date = $row['from_date'];
         $officeObject->to_date = $row['to_date'];
         $officeObject->source = $row['source'];

--- a/classes/Office.php
+++ b/classes/Office.php
@@ -16,6 +16,12 @@ class Office {
     public $from_date;
     public $to_date;
     public $source;
+    public $position = "";
+    public $dept = "";
+    public $slug = "";
+    public $desc = "";
+    public $external_url = "";
+
 
     /**
      * To String
@@ -31,6 +37,29 @@ class Office {
         } else {
             return 'Unnamed Office';
         }
+    }
+
+
+    /**
+     * Converts the description text into HTML paragraphs.
+     *
+     * This method takes the description text stored in the `$desc` property,
+     * splits it into paragraphs based on newline characters, and wraps each
+     * non-empty paragraph in `<p>` tags.
+     * @return string The HTML representation of the description text.
+     */
+    public function htmlDesc() {
+        $paragraphs = explode("\n", $this->desc);
+        $html = '';
+
+        foreach ($paragraphs as $paragraph) {
+            $trimmed = trim($paragraph);
+            if (!empty($trimmed)) {
+                $html .= '<p>' . htmlspecialchars($trimmed, ENT_QUOTES, 'UTF-8') . '</p>';
+            }
+        }
+
+        return $html;
     }
 
     /**

--- a/locale/TheyWorkForYou.pot
+++ b/locale/TheyWorkForYou.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-13 12:45+0000\n"
+"POT-Creation-Date: 2025-08-22 11:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -65,28 +65,28 @@ msgstr ""
 msgid "Subscribe to our newsletter"
 msgstr ""
 
-#: classes/Member.php:394 classes/Member.php:406
+#: classes/Member.php:396 classes/Member.php:408
 #: www/includes/easyparliament/member.php:33
 #: www/includes/easyparliament/templates/html/divisions/index.php:63
 msgid "House of Lords"
 msgstr ""
 
-#: classes/Member.php:398
+#: classes/Member.php:400
 #, php-format
 msgid "Previously MP for %s until %s"
 msgstr ""
 
-#: classes/Member.php:414 classes/Member.php:418
+#: classes/Member.php:416 classes/Member.php:420
 #: www/includes/easyparliament/member.php:32
 #: www/includes/easyparliament/templates/html/divisions/index.php:62
 msgid "House of Commons"
 msgstr ""
 
-#: classes/Member.php:421 classes/Member.php:422
+#: classes/Member.php:423 classes/Member.php:424
 msgid "Assembly"
 msgstr ""
 
-#: classes/Member.php:423 classes/Member.php:424
+#: classes/Member.php:425 classes/Member.php:426
 #: www/includes/easyparliament/hansardlist.php:1227
 #: www/includes/easyparliament/member.php:35
 #: www/includes/easyparliament/templates/html/divisions/index.php:65
@@ -94,34 +94,34 @@ msgstr ""
 msgid "Scottish Parliament"
 msgstr ""
 
-#: classes/Member.php:425 classes/Member.php:426
+#: classes/Member.php:427 classes/Member.php:428
 #: www/includes/easyparliament/member.php:36
 #: www/includes/easyparliament/templates/html/divisions/index.php:66
 msgid "Senedd"
 msgstr ""
 
-#: classes/Member.php:427 classes/Member.php:428
+#: classes/Member.php:429 classes/Member.php:430
 #: www/includes/easyparliament/member.php:37
 #: www/includes/easyparliament/templates/html/search/form_options.php:76
 msgid "London Assembly"
 msgstr ""
 
-#: classes/Member.php:438
+#: classes/Member.php:440
 #, php-format
 msgid "Entered the %s in %s"
 msgstr ""
 
-#: classes/Member.php:440
+#: classes/Member.php:442
 #, php-format
 msgid "Entered the %s on %s"
 msgstr ""
 
-#: classes/Member.php:454
+#: classes/Member.php:456
 #, php-format
 msgid "Left the %s in %s"
 msgstr ""
 
-#: classes/Member.php:456
+#: classes/Member.php:458
 #, php-format
 msgid "Left the %s on %s"
 msgstr ""
@@ -605,7 +605,7 @@ msgstr ""
 #: www/docs/interests/category.php:93
 #: www/includes/easyparliament/metadata.php:119
 #: www/includes/easyparliament/metadata.php:120
-#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:12
+#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:15
 #: www/includes/easyparliament/templates/html/mp/register.php:51
 msgid "Register of Interests"
 msgstr ""
@@ -694,35 +694,35 @@ msgstr ""
 msgid "More of %s’s recent appearances"
 msgstr ""
 
-#: www/docs/mp/index.php:1206
+#: www/docs/mp/index.php:1216
 msgid ""
 "You have one constituency MS (Member of the Senedd) and multiple region MSs."
 msgstr ""
 
-#: www/docs/mp/index.php:1207
+#: www/docs/mp/index.php:1217
 #, php-format
 msgid ""
 "Your <strong>constituency MS</strong> is <a href=\"%s\">%s</a>, MS for %s."
 msgstr ""
 
-#: www/docs/mp/index.php:1208
+#: www/docs/mp/index.php:1218
 #: www/includes/easyparliament/templates/html/postcode/index.php:94
 #, php-format
 msgid "Your <strong>%s region MSs</strong> are:"
 msgstr ""
 
-#: www/docs/mp/index.php:1210
+#: www/docs/mp/index.php:1220
 msgid ""
 "You had one constituency MS (Member of the Senedd) and multiple region MSs."
 msgstr ""
 
-#: www/docs/mp/index.php:1211
+#: www/docs/mp/index.php:1221
 #, php-format
 msgid ""
 "Your <strong>constituency MS</strong> was <a href=\"%s\">%s</a>, MS for %s."
 msgstr ""
 
-#: www/docs/mp/index.php:1212
+#: www/docs/mp/index.php:1222
 #: www/includes/easyparliament/templates/html/postcode/index.php:102
 #, php-format
 msgid "Your <strong>%s region MSs</strong> were:"
@@ -947,7 +947,7 @@ msgstr ""
 #: www/includes/easyparliament/metadata.php:460
 #: www/includes/easyparliament/templates/html/divisions/index.php:5
 #: www/includes/easyparliament/templates/html/homepage/recent-votes.php:3
-#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:9
+#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:12
 msgid "Recent Votes"
 msgstr ""
 
@@ -1812,8 +1812,16 @@ msgstr ""
 msgid "New entry or subentry"
 msgstr ""
 
+#: www/includes/easyparliament/templates/html/mp/_chamber_info_panel.php:37
+msgid "Committees and groups"
+msgstr ""
+
+#: www/includes/easyparliament/templates/html/mp/_chamber_info_panel.php:47
+msgid "Signatures"
+msgstr ""
+
 #: www/includes/easyparliament/templates/html/mp/election_register.php:46
-#: www/includes/easyparliament/templates/html/mp/memberships.php:18
+#: www/includes/easyparliament/templates/html/mp/memberships.php:21
 #: www/includes/easyparliament/templates/html/mp/profile.php:18
 #: www/includes/easyparliament/templates/html/mp/recent.php:57
 #: www/includes/easyparliament/templates/html/mp/register.php:14
@@ -1894,71 +1902,80 @@ msgstr ""
 msgid "Browse all MPs"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/memberships.php:21
+#: www/includes/easyparliament/templates/html/mp/memberships.php:24
 msgid "Memberships"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/memberships.php:24
+#: www/includes/easyparliament/templates/html/mp/memberships.php:27
 msgid "Previous Memberships"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/memberships.php:28
-#: www/includes/easyparliament/templates/html/mp/memberships.php:87
+#: www/includes/easyparliament/templates/html/mp/memberships.php:31
 msgid "APPG Offices held"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/memberships.php:31
-#: www/includes/easyparliament/templates/html/mp/memberships.php:96
+#: www/includes/easyparliament/templates/html/mp/memberships.php:34
 msgid "APPG memberships"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/memberships.php:35
+#: www/includes/easyparliament/templates/html/mp/memberships.php:38
 msgid "Recent open letters"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/memberships.php:38
+#: www/includes/easyparliament/templates/html/mp/memberships.php:41
 msgid "Recent EDMs"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/memberships.php:41
-#: www/includes/easyparliament/templates/html/mp/memberships.php:133
+#: www/includes/easyparliament/templates/html/mp/memberships.php:44
+#: www/includes/easyparliament/templates/html/mp/memberships.php:164
 msgid "Topics of interest"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/memberships.php:53
-msgid "Interests"
+#: www/includes/easyparliament/templates/html/mp/memberships.php:56
+msgid "Committees"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/memberships.php:58
-msgid "Current committee memberships"
-msgstr ""
-
-#: www/includes/easyparliament/templates/html/mp/memberships.php:73
+#: www/includes/easyparliament/templates/html/mp/memberships.php:77
 msgid "Committee memberships held in the past"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/memberships.php:106
+#: www/includes/easyparliament/templates/html/mp/memberships.php:91
+msgid "All-Party Parliamentary Groups (APPGs)"
+msgstr ""
+
+#: www/includes/easyparliament/templates/html/mp/memberships.php:97
+#, php-format
+msgid "%s is an officer of the following groups"
+msgstr ""
+
+#: www/includes/easyparliament/templates/html/mp/memberships.php:98
+#, php-format
+msgid "%s is a member of the following groups"
+msgstr ""
+
+#. * @var MySociety\TheyWorkForYou\DataClass\APPGs\APPGMembership $membership
+#: www/includes/easyparliament/templates/html/mp/memberships.php:139
 msgid "Recent open letters signed"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/memberships.php:116
+#: www/includes/easyparliament/templates/html/mp/memberships.php:148
 msgid "Recent Early Day Motions signed"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/memberships.php:127
+#: www/includes/easyparliament/templates/html/mp/memberships.php:158
 msgid "All open letters and EDMs signed"
 msgstr ""
 
 #: www/includes/easyparliament/templates/html/mp/_person_navigation.php:6
+msgid "Committees / APPGs / Signatures"
+msgstr ""
+
+#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:9
 msgid "Voting Summary"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:15
-msgid "2024 Election Donations"
-msgstr ""
-
 #: www/includes/easyparliament/templates/html/mp/_person_navigation.php:18
-msgid "Committees / APPGs / Signatures"
+msgid "2024 Election Donations"
 msgstr ""
 
 #: www/includes/easyparliament/templates/html/mp/_profile_footer.php:2

--- a/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
+++ b/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-13 12:45+0000\n"
+"POT-Creation-Date: 2025-08-22 11:44+0000\n"
 "PO-Revision-Date: 2023-03-20 17:59-0000\n"
 "Language-Team: mySociety\n"
 "Language: fr\n"
@@ -54,28 +54,28 @@ msgstr "Fe wnaeth pleidleisio  % s ar <em>%s</EM>"
 msgid "Subscribe to our newsletter"
 msgstr "Cofrestrwch am y newyddion diweddaraf gan mySociety"
 
-#: classes/Member.php:394 classes/Member.php:406
+#: classes/Member.php:396 classes/Member.php:408
 #: www/includes/easyparliament/member.php:33
 #: www/includes/easyparliament/templates/html/divisions/index.php:63
 msgid "House of Lords"
 msgstr "Tŷ'r Arglwyddi"
 
-#: classes/Member.php:398
+#: classes/Member.php:400
 #, php-format
 msgid "Previously MP for %s until %s"
 msgstr "Yn flaenorol AS am %s tan %s"
 
-#: classes/Member.php:414 classes/Member.php:418
+#: classes/Member.php:416 classes/Member.php:420
 #: www/includes/easyparliament/member.php:32
 #: www/includes/easyparliament/templates/html/divisions/index.php:62
 msgid "House of Commons"
 msgstr "Tŷ'r Cyffredin"
 
-#: classes/Member.php:421 classes/Member.php:422
+#: classes/Member.php:423 classes/Member.php:424
 msgid "Assembly"
 msgstr "Cynulliad"
 
-#: classes/Member.php:423 classes/Member.php:424
+#: classes/Member.php:425 classes/Member.php:426
 #: www/includes/easyparliament/hansardlist.php:1227
 #: www/includes/easyparliament/member.php:35
 #: www/includes/easyparliament/templates/html/divisions/index.php:65
@@ -83,34 +83,34 @@ msgstr "Cynulliad"
 msgid "Scottish Parliament"
 msgstr "Senedd yr Alban"
 
-#: classes/Member.php:425 classes/Member.php:426
+#: classes/Member.php:427 classes/Member.php:428
 #: www/includes/easyparliament/member.php:36
 #: www/includes/easyparliament/templates/html/divisions/index.php:66
 msgid "Senedd"
 msgstr "Senedd"
 
-#: classes/Member.php:427 classes/Member.php:428
+#: classes/Member.php:429 classes/Member.php:430
 #: www/includes/easyparliament/member.php:37
 #: www/includes/easyparliament/templates/html/search/form_options.php:76
 msgid "London Assembly"
 msgstr "Cynulliad Llundain"
 
-#: classes/Member.php:438
+#: classes/Member.php:440
 #, php-format
 msgid "Entered the %s in %s"
 msgstr "Aeth i mewn i'r %s yn %s"
 
-#: classes/Member.php:440
+#: classes/Member.php:442
 #, php-format
 msgid "Entered the %s on %s"
 msgstr "Aeth i mewn i'r  %s ar %s"
 
-#: classes/Member.php:454
+#: classes/Member.php:456
 #, php-format
 msgid "Left the %s in %s"
 msgstr "Gadawodd y %s mewn %s"
 
-#: classes/Member.php:456
+#: classes/Member.php:458
 #, php-format
 msgid "Left the %s on %s"
 msgstr "Gadawodd y %s ar %s"
@@ -590,7 +590,7 @@ msgstr "Rhannwch hyn"
 #: www/docs/interests/category.php:93
 #: www/includes/easyparliament/metadata.php:119
 #: www/includes/easyparliament/metadata.php:120
-#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:12
+#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:15
 #: www/includes/easyparliament/templates/html/mp/register.php:51
 msgid "Register of Interests"
 msgstr "Cofrestr Buddiannau"
@@ -677,31 +677,31 @@ msgstr "Cyn %s"
 msgid "More of %s’s recent appearances"
 msgstr "Mwy o ymddangosiadau diweddar %s"
 
-#: www/docs/mp/index.php:1206
+#: www/docs/mp/index.php:1216
 msgid "You have one constituency MS (Member of the Senedd) and multiple region MSs."
 msgstr "Gennych un AS (Aelod o'r Senedd) ar gyfer eich etholaeth a nifer o ASau rhanbarthol."
 
-#: www/docs/mp/index.php:1207
+#: www/docs/mp/index.php:1217
 #, php-format
 msgid "Your <strong>constituency MS</strong> is <a href=\"%s\">%s</a>, MS for %s."
 msgstr "<strong>AS eich etholaeth</strong> yw <a href=\"%s\">%s</a>, AS ar gyfer %s."
 
-#: www/docs/mp/index.php:1208
+#: www/docs/mp/index.php:1218
 #: www/includes/easyparliament/templates/html/postcode/index.php:94
 #, php-format
 msgid "Your <strong>%s region MSs</strong> are:"
 msgstr "Eich ASau <strong>%s</strong> yw:"
 
-#: www/docs/mp/index.php:1210
+#: www/docs/mp/index.php:1220
 msgid "You had one constituency MS (Member of the Senedd) and multiple region MSs."
 msgstr "Roedd gennych un AS (Aelod o'r Senedd) ar gyfer eich etholaeth a nifer o ASau rhanbarthol."
 
-#: www/docs/mp/index.php:1211
+#: www/docs/mp/index.php:1221
 #, php-format
 msgid "Your <strong>constituency MS</strong> was <a href=\"%s\">%s</a>, MS for %s."
 msgstr "<strong>AS eich etholaeth</strong> (Aelod o'r Senedd) oedd <a href=\"%s\">%s</a>, %s"
 
-#: www/docs/mp/index.php:1212
+#: www/docs/mp/index.php:1222
 #: www/includes/easyparliament/templates/html/postcode/index.php:102
 #, php-format
 msgid "Your <strong>%s region MSs</strong> were:"
@@ -917,7 +917,7 @@ msgstr "Newyddion"
 #: www/includes/easyparliament/metadata.php:460
 #: www/includes/easyparliament/templates/html/divisions/index.php:5
 #: www/includes/easyparliament/templates/html/homepage/recent-votes.php:3
-#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:9
+#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:12
 msgid "Recent Votes"
 msgstr "Pleidleisiau diweddar"
 
@@ -1743,8 +1743,16 @@ msgstr "Categorïau"
 msgid "New entry or subentry"
 msgstr "Mynediad newydd"
 
+#: www/includes/easyparliament/templates/html/mp/_chamber_info_panel.php:37
+msgid "Committees and groups"
+msgstr "Pwyllgorau a grwpiau"
+
+#: www/includes/easyparliament/templates/html/mp/_chamber_info_panel.php:47
+msgid "Signatures"
+msgstr "Llofnodau"
+
 #: www/includes/easyparliament/templates/html/mp/election_register.php:46
-#: www/includes/easyparliament/templates/html/mp/memberships.php:18
+#: www/includes/easyparliament/templates/html/mp/memberships.php:21
 #: www/includes/easyparliament/templates/html/mp/profile.php:18
 #: www/includes/easyparliament/templates/html/mp/recent.php:57
 #: www/includes/easyparliament/templates/html/mp/register.php:14
@@ -1821,84 +1829,93 @@ msgid "Browse all MPs"
 msgstr "Pori pob AS"
 
 # google translated
-#: www/includes/easyparliament/templates/html/mp/memberships.php:21
+#: www/includes/easyparliament/templates/html/mp/memberships.php:24
 msgid "Memberships"
 msgstr "Aelodaethau"
 
 # google translated
-#: www/includes/easyparliament/templates/html/mp/memberships.php:24
+#: www/includes/easyparliament/templates/html/mp/memberships.php:27
 msgid "Previous Memberships"
 msgstr "Aelodaethau blaenorol"
 
 # google translated
-#: www/includes/easyparliament/templates/html/mp/memberships.php:28
-#: www/includes/easyparliament/templates/html/mp/memberships.php:87
+#: www/includes/easyparliament/templates/html/mp/memberships.php:31
 msgid "APPG Offices held"
 msgstr "Swyddfeydd APPG a gynhaliwyd"
 
 # google translated
-#: www/includes/easyparliament/templates/html/mp/memberships.php:31
-#: www/includes/easyparliament/templates/html/mp/memberships.php:96
+#: www/includes/easyparliament/templates/html/mp/memberships.php:34
 msgid "APPG memberships"
 msgstr "Aelodaethau APPG"
 
 # google translated
-#: www/includes/easyparliament/templates/html/mp/memberships.php:35
+#: www/includes/easyparliament/templates/html/mp/memberships.php:38
 msgid "Recent open letters"
 msgstr "Llythyrau agored diweddar"
 
 # google translated
-#: www/includes/easyparliament/templates/html/mp/memberships.php:38
+#: www/includes/easyparliament/templates/html/mp/memberships.php:41
 msgid "Recent EDMs"
 msgstr "EDMs diweddar"
 
-#: www/includes/easyparliament/templates/html/mp/memberships.php:41
-#: www/includes/easyparliament/templates/html/mp/memberships.php:133
+#: www/includes/easyparliament/templates/html/mp/memberships.php:44
+#: www/includes/easyparliament/templates/html/mp/memberships.php:164
 msgid "Topics of interest"
 msgstr "Themau o ddiddordeb"
 
-# google translated
-#: www/includes/easyparliament/templates/html/mp/memberships.php:53
-msgid "Interests"
-msgstr "Diddordebau"
+#: www/includes/easyparliament/templates/html/mp/memberships.php:56
+msgid "Committees"
+msgstr "Pwyllgorau"
 
 # google translated
-#: www/includes/easyparliament/templates/html/mp/memberships.php:58
-msgid "Current committee memberships"
-msgstr "Aelodaethau pwyllgor presennol"
-
-# google translated
-#: www/includes/easyparliament/templates/html/mp/memberships.php:73
+#: www/includes/easyparliament/templates/html/mp/memberships.php:77
 msgid "Committee memberships held in the past"
 msgstr "Aelodaethau pwyllgor a gynhaliwyd yn y gorffennol"
 
+#: www/includes/easyparliament/templates/html/mp/memberships.php:91
+msgid "All-Party Parliamentary Groups (APPGs)"
+msgstr "APPGs"
+
+# Auto-translated - revise if more prominent
+#: www/includes/easyparliament/templates/html/mp/memberships.php:97
+#, php-format
+msgid "%s is an officer of the following groups"
+msgstr "Mae %s yn swyddog yn y grwpiau canlynol"
+
+# Auto-translated - revise if more prominent
+#: www/includes/easyparliament/templates/html/mp/memberships.php:98
+#, php-format
+msgid "%s is a member of the following groups"
+msgstr "Mae %s yn aelod o'r grwpiau canlynol"
+
 # google translated
-#: www/includes/easyparliament/templates/html/mp/memberships.php:106
+#. * @var MySociety\TheyWorkForYou\DataClass\APPGs\APPGMembership $membership
+#: www/includes/easyparliament/templates/html/mp/memberships.php:139
 msgid "Recent open letters signed"
 msgstr "Llythyrau agored diweddar wedi'u llofnodi"
 
 # google translated
-#: www/includes/easyparliament/templates/html/mp/memberships.php:116
+#: www/includes/easyparliament/templates/html/mp/memberships.php:148
 msgid "Recent Early Day Motions signed"
 msgstr "EDMs diweddar wedi'u llofnodi"
 
 # google translated
-#: www/includes/easyparliament/templates/html/mp/memberships.php:127
+#: www/includes/easyparliament/templates/html/mp/memberships.php:158
 msgid "All open letters and EDMs signed"
 msgstr "Pob llythyr agored ac EDM wedi'u llofnodi"
 
+# google translated
 #: www/includes/easyparliament/templates/html/mp/_person_navigation.php:6
+msgid "Committees / APPGs / Signatures"
+msgstr "Pwyllgorau / APPGs / Llofnodau"
+
+#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:9
 msgid "Voting Summary"
 msgstr "Record bleidleisio"
 
-#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:15
+#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:18
 msgid "2024 Election Donations"
 msgstr "2024 Election Donations"
-
-# google translated
-#: www/includes/easyparliament/templates/html/mp/_person_navigation.php:18
-msgid "Committees / APPGs / Signatures"
-msgstr "Pwyllgorau / APPGs / Llofnodau"
 
 #: www/includes/easyparliament/templates/html/mp/_profile_footer.php:2
 msgid "Note for journalists and researchers: The data on this page may be used freely, on condition that TheyWorkForYou.com is cited as the source."
@@ -2906,6 +2923,14 @@ msgstr "Ymddiheuriadau, mae gwall wedi digwydd"
 #: www/includes/utility.php:179
 msgid "We've been notified by email and will try to fix the problem soon!"
 msgstr "Rydym wedi derbyn y wybodaeth trwy e-bost, a byddwn yn ceisio datrys y broblem yn fuan!"
+
+# google translated
+#~ msgid "Interests"
+#~ msgstr "Diddordebau"
+
+# google translated
+#~ msgid "Current committee memberships"
+#~ msgstr "Aelodaethau pwyllgor presennol"
 
 #~ msgid "Some vote information from <a href=\"https://www.publicwhip.org.uk/\">PublicWhip</a>."
 #~ msgstr "Mae rhywfaint o wybodaeth pleidleisio gan <a href=\"https://www.publicwhip.org.uk/\">PublicWhip</a>."

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -1009,6 +1009,8 @@ function person_statements($member) {
 function memberships($member) {
     $out = [];
 
+    $committee_lookup = MySociety\TheyWorkForYou\DataClass\Groups\MiniGroupList::uk_committees();
+
     $topics = person_topics($member);
     if ($topics) {
         $out['topics'] = $topics;
@@ -1016,6 +1018,14 @@ function memberships($member) {
 
     $posts = $member->offices('current', false, true);
     if ($posts) {
+        // for each post we want to add the description and external_url from the committee lookup if possible
+        foreach ($posts as $post) {
+            $committee = $committee_lookup->findByName($post->dept);
+            if ($committee) {
+                $post->desc = $committee->description;
+                $post->external_url = $committee->external_url;
+            }
+        }
         $out['posts'] = $posts;
     }
 
@@ -1041,10 +1051,10 @@ function memberships($member) {
 
     $statments_signed = person_statements($member);
     if ($statments_signed) {
-        if ($statments_signed["edms"] && $statments_signed["edms"]->count() > 0) {
+        if (isset($statments_signed["edms"]) && $statments_signed["edms"]->count() > 0) {
             $out['edms_signed'] = $statments_signed["edms"];
         }
-        if ($statments_signed["letters"] && $statments_signed["letters"]->count() > 0) {
+        if (isset($statments_signed["letters"]) && $statments_signed["letters"]->count() > 0) {
             $out['letters_signed'] = $statments_signed["letters"];
         }
     }

--- a/www/docs/style/sass/pages/_mp.scss
+++ b/www/docs/style/sass/pages/_mp.scss
@@ -852,3 +852,11 @@ h6.interest-summary {
 .active-comparison-period {
     font-weight: bold;
 }
+
+.appg-property-label {
+    font-weight: bold;
+}
+.appg-more-info, .committee-more-info {
+    margin-top: 20px;
+    margin-left: 20px;
+}

--- a/www/includes/easyparliament/templates/html/mp/_chamber_info_panel.php
+++ b/www/includes/easyparliament/templates/html/mp/_chamber_info_panel.php
@@ -7,7 +7,7 @@
 <div class="panel">
     <h2>About your Member of Parliament</h2>
     <p>
-    Your MP (<?= ucfirst($full_name) ?>) represents you, and all of the people who live in <?= $latest_membership['constituency'] ?>,
+    <?= ucfirst($full_name) ?> represents the people who live in <?= $latest_membership['constituency'] ?>,
         at the UK Parliament in Westminster.
     </p>
     <p>
@@ -30,10 +30,31 @@
     What you can do
     </h2>
     <ul class="rep-actions">
-        <li>Find out <a href="#profile">more about your MP</a>, including <a href="<?= $member_url ?>/votes">their voting summary</a><?php if ($register_interests) { ?>, <a href="<?= $member_url ?>/register">register of interests</a><?php } ?> and <a href="#appearances">recent speeches</a>.</li>
-    <?php if ($current_member[1]) { ?>
-        <li><a href="https://www.writetothem.com/">Write to your MP</a>, or find out about your other local representatives <a href="https://www.writetothem.com">on WriteToThem.com</a>.</li>
-    <?php } ?>
+        <li>Find out <a href="#profile">more about this MP</a>, including:
+            <ul class="rep-actions">
+                <?php if ($memberships) { ?>
+                    <li <?php if ($pagetype == "memberships"): ?>class="active"<?php endif; ?>>
+                        <a href="<?= $member_url ?>/memberships"><?= gettext('Committees and groups') ?></a> they are part of.
+                    </li>
+                <?php } ?>
+                <li><a href="<?= $member_url ?>/votes">Voting record summary</a> or a list of <a href="<?= $member_url ?>/recent">recent votes</a>.</li>
+                <?php if ($register_interests) { ?>
+                    <li><a href="<?= $member_url ?>/register">Declared financial interests</a>.</li>
+                <?php } ?>
+                <li><a href="#appearances">Recent speeches</a></li>
+                <?php if ($memberships) { ?>
+                    <li <?php if ($pagetype == "memberships"): ?>class="active"<?php endif; ?>>
+                        <a href="<?= $member_url ?>/memberships#letters-and-edms"><?= gettext('Signatures') ?></a> (open letters and EDMs)
+                    </li>
+                <?php } ?>
+            </ul>
+        </li>
+        <?php if ($current_member[1]) { ?>
+            <li>
+                <a href="https://www.writetothem.com/">Write to your MP</a>, or find out about your other local representatives 
+                <a href="https://www.writetothem.com">on WriteToThem.com</a>.
+            </li>
+        <?php } ?>
     <?php if ($latest_membership['end_date'] == '2024-05-30') { ?>
         <li>Find out more about <a href="https://www.localintelligencehub.com/area/WMC/<?= $latest_membership['constituency'] ?>"><?= $latest_membership['constituency'] ?></a> on the <a href="https://www.localintelligencehub.com/">Local Intelligence Hub</a>.</li>
     <?php } elseif ($current_member[1]) { ?>
@@ -41,5 +62,7 @@
     <?php } ?>
     </ul>
 </div>
+
+
 
 <?php } ?>

--- a/www/includes/easyparliament/templates/html/mp/_person_navigation.php
+++ b/www/includes/easyparliament/templates/html/mp/_person_navigation.php
@@ -2,6 +2,9 @@
 
     <ul>
         <li <?php if ($pagetype == ""): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>"><?= gettext('Overview') ?></a></li>
+          <?php if ($memberships): ?>
+            <li <?php if ($pagetype == "memberships"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/memberships"><?= gettext('Committees / APPGs / Signatures') ?></a></li>
+          <?php endif; ?>
           <?php if ($this_page == "mp"): ?>
             <li <?php if ($pagetype == "votes"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/votes"><?= gettext('Voting Summary') ?></a></li>
           <?php endif; ?>
@@ -13,9 +16,6 @@
           <?php endif; ?>
           <?php if ($register_2024_enriched): ?>
                 <li <?php if ($pagetype == "election_register"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/election_register"><?= gettext('2024 Election Donations') ?></a></li>
-          <?php endif; ?>
-          <?php if ($memberships): ?>
-            <li <?php if ($pagetype == "member_interests"): ?>class="active"<?php endif; ?>><a href="<?= $member_url ?>/memberships"><?= gettext('Committees / APPGs / Signatures') ?></a></li>
           <?php endif; ?>
     </ul>
 </div>

--- a/www/includes/easyparliament/templates/html/mp/memberships.php
+++ b/www/includes/easyparliament/templates/html/mp/memberships.php
@@ -25,10 +25,10 @@ $display_wtt_stats_banner = '2015';
                         <?php endif; ?>
                         <?php if (array_key_exists('appg_membership', $memberships)): ?>
                             <?php if ($memberships['appg_membership']->is_an_officer()): ?>
-                              <li><a href="#appg_officer"><?= gettext('APPG Offices held') ?></a></li>
+                              <li><a href="#appg_is_officer_of"><?= gettext('APPG Offices held') ?></a></li>
                             <?php endif; ?>
                             <?php if ($memberships['appg_membership']->is_a_member()): ?>
-                              <li><a href="#appg_memberships"><?= gettext('APPG memberships') ?></a></li>
+                              <li><a href="#appg_is_ordinary_member_of"><?= gettext('APPG memberships') ?></a></li>
                             <?php endif; ?>
                         <?php endif; ?>
                         <?php if (array_key_exists('letters_signed', $memberships)): ?>
@@ -50,23 +50,26 @@ $display_wtt_stats_banner = '2015';
 
                 <div class="panel">
                     <a name="interests"></a>
-                    <h2><?=gettext('Interests') ?></h2>
-
-
+                    <h2 id="posts"><?=gettext('Committees') ?></h2>
+                    <p>
+                    In the UK Parliament, committees are groups of MPs or Peers who examine specific issues in more detail than can be done in debates.</p>
+                    <p>Some committees focus on checking the government’s decisions and spending, while others investigate specific topics and proposed legislation.</p>
                     <?php if (array_key_exists('posts', $memberships)): ?>
+                    <p><?= $full_name ?> is currently a member of the following committees:</p>
+                    <?php foreach ($memberships['posts'] as $office): ?>
+                    <h4><?= $office ?></h4>
+                    <div class="committee-more-info">
+                    <?= $office->htmlDesc() ?>
 
-                    <h3 id="posts"><?=gettext('Current committee memberships') ?></h3>
+                    <?php if (!empty($office->external_url)): ?>
+                        <p><a href="<?= $office->external_url ?>">Learn more about this committee</a></p>
+                    <?php endif; ?>
+                    </div>
+                    <hr/>
+                    <?php endforeach; ?>
 
-                    <ul class='list-dates'>
-
-                        <?php foreach ($memberships['posts'] as $office): ?>
-                        <li><?= $office ?> <small>(<?= $office->pretty_dates() ?>)</small></li>
-                        <?php endforeach; ?>
-
-                    </ul>
 
                     <?php endif; ?>
-
                     <?php if (array_key_exists('previous_posts', $memberships)): ?>
 
                     <a ></a>
@@ -79,45 +82,72 @@ $display_wtt_stats_banner = '2015';
                         <?php endforeach; ?>
 
                     </ul>
-
+                        </div>
                     <?php endif; ?>
 
                     <?php if (array_key_exists('appg_membership', $memberships)): ?>
-                        <?php if ($memberships['appg_membership']->is_an_officer()): ?>
-                            <h3 id="appg_officer"><?=gettext('APPG Offices held') ?></h3>
-                            <ul class='list-dates'>
-                                <?php foreach ($memberships['appg_membership']->is_officer_of as $membership): ?>
-                                    <li><?= $membership->appg->title ?> <?= $membership->role ? '(' . $membership->role . ')' : '' ?></li>
-                                <?php endforeach; ?>
-                            </ul>
-                        <?php endif; ?>
+                        <div class="panel">
+                        <h2><?=gettext('All-Party Parliamentary Groups (APPGs)') ?></h2>
+                        <p>All-Party Parliamentary Groups (APPGs) are informal cross-party groups made up of MPs and Peers who share an interest in a particular country or subject.</p>
+                        <p>They do not have formal powers or funding, but can book rooms on the parliamentary estate and may receive funding from outside organisations and companies.</p>
+                        <p>We source information on APPG memberships from lists on APPG websites or asking APPGs for unpublished lists. Please <a href="https://survey.alchemer.com/s3/8446196/TheyWorkForYou-APPG-data">report any incorrect or outdated information</a>.</p>
+                        <?php
+                        $appg_roles = [
+                            'is_officer_of' => sprintf(gettext('%s is an officer of the following groups'), $full_name),
+                            'is_ordinary_member_of' => sprintf(gettext('%s is a member of the following groups'), $full_name),
+                        ];
+                        ?>
 
-                        <?php if ($memberships['appg_membership']->is_a_member()): ?>
-                            <h3 id="appg_memberships"><?=gettext('APPG memberships') ?></h3>
-                            <ul class='list-dates'>
-                                    <?php foreach ($memberships['appg_membership']->is_ordinary_member_of as $membership): ?>
-                                        <li><?= $membership->appg->title ?></li>
-                                    <?php endforeach; ?>
-                            </ul>
-                        <?php endif; ?>
+                        <?php foreach ($appg_roles as $role_key => $role_title): ?>
+
+                            <?php if (!$memberships['appg_membership']->$role_key->isEmpty()): ?>
+                                <h3 id="appg_<?= $role_key ?>"><?= $role_title ?></h3>
+                                <?php /** @var MySociety\TheyWorkForYou\DataClass\APPGs\APPGMembership $membership */ ?>
+
+                                <?php foreach ($memberships['appg_membership']->$role_key as $membership): ?>
+                                    <hr>
+                                    <p>
+                                        <span><?= $membership->appg->title ?> <?= $membership->role ? '(' . $membership->role . ')' : '' ?></span>
+                                        <details>
+                                            <summary>More info</summary>
+                                            <div class="appg-more-info">
+                                                <ul>
+                                                    <li><span class="appg-property-label">Purpose:</span> <?= $membership->appg->purpose ?></li>
+                                                    <li><span class="appg-property-label">Membership Source:</span> <a href="<?= $membership->membership_source_url ?>">Source</a></li>
+                                                    <li><span class="appg-property-label">APPG Website:</span> <?php if ($membership->appg->website): ?><a href="<?= $membership->appg->website ?>"><?= $membership->appg->website ?></a><?php else: ?>N/A<?php endif; ?></li>
+                                                    <li><span class="appg-property-label">APPG register:</span> <a href="<?= $membership->appg->source_url ?>">Parliament website</a></li>
+                                                </ul>
+                                            </div>
+                                        </details>
+                                    </p>
+                                <?php endforeach; ?>
+                            <?php endif; ?>
+                        <?php endforeach; ?>
+                        </div>
                     <?php endif; ?>
 
+                    
+                    <?php if (array_key_exists('letters_signed', $memberships) || array_key_exists('edms_signed', $memberships)): ?>
+                        <div class="panel">
+                        <h2 id="letters-and-edms">Letters and EDMs</h2>
+                        <p>Early Day Motions are when MPs can propose and co-sign statements for discussion. In practice, these work as internal petitions where MPs can signal their support for a particular issue or cause.</p>
+
+                        <p>We're starting to collect and display when MPs sign open letters outside Parliament - if there are examples we're missing, <a href="https://survey.alchemer.com/s3/8440376/TheyWorkForYou-Open-Letter">please let us know</a>. </p>
+                    <?php endif; ?>
                     <?php if (array_key_exists('letters_signed', $memberships)): ?>
                         <h3 id="letters_signed"><?=gettext('Recent open letters signed') ?></h3>
-
                         <ul class='list-dates'>
                             <?php foreach ($memberships['letters_signed'] as $signature): ?>
-                            <li><?= $signature->date ?>: <a href="<?= $signature->statement->link() ?>"><?= $signature->statement->title ?></a> (+<?= $signature->statement->total_signatures ?> others)</li>
+                            <li><?= $signature->date ?>: <a href="<?= $signature->statement->link() ?>"><?= $signature->statement->title ?></a> (+<?= $signature->statement->total_signatures - 1 ?> others)</li>
                             <?php endforeach; ?>
                         </ul>
                     <?php endif; ?>
 
                     <?php if (array_key_exists('edms_signed', $memberships)): ?>
                         <h3 id="edms_signed"><?=gettext('Recent Early Day Motions signed') ?></h3>
-
                         <ul class='list-dates'>
                             <?php foreach ($memberships['edms_signed'] as $signature): ?>
-                            <li><?= $signature->date ?>: <a href="<?= $signature->statement->link() ?>"><?= $signature->statement->title ?></a> (+<?= $signature->statement->total_signatures ?> others)</li>
+                            <li><?= $signature->date ?>: <a href="<?= $signature->statement->link() ?>"><?= $signature->statement->title ?></a> (+<?= $signature->statement->total_signatures - 1  ?> others)</li>
                             <?php endforeach; ?>
                         </ul>
                     <?php endif; ?>
@@ -126,35 +156,36 @@ $display_wtt_stats_banner = '2015';
                         <p>
                         <a href="https://votes.theyworkforyou.com/person/<?= $person_id ?>/statements"><?= gettext('All open letters and EDMs signed') ?></a>.
                         </p>
+                        <?php endif; ?>
+ 
+                    <?php if (array_key_exists('letters_signed', $memberships) || array_key_exists('edms_signed', $memberships)): ?>
+                        </div>
                     <?php endif; ?>
 
                     <?php if (array_key_exists('topics_of_interest', $memberships) || array_key_exists('eu_stance', $memberships)): ?>
+                        <div class="panel">
+                            <h2 id="topics"><?= gettext('Topics of interest') ?></h2>
 
-                        <h3 id="topics"><?= gettext('Topics of interest') ?></h3>
+                            <?php if (array_key_exists('eu_stance', $memberships)): ?>
+                                <p>
+                                    <?php if ($memberships['eu_stance'] == 'Leave' || $memberships['eu_stance'] == 'Remain') { ?>
+                                        <strong><?= $full_name ?></strong> campaigned to <?= $memberships['eu_stance'] == 'Leave' ? 'leave' : 'remain in' ?> the European Union
+                                    <?php } else { ?>
+                                        We don't know whether <strong><?= $full_name ?></strong> campaigned to leave, or stay in the European Union
+                                    <?php } ?>
+                                    <small>Source: <a href="https://www.bbc.co.uk/news/uk-politics-eu-referendum-35616946">BBC</a></small>
+                                </p>
+                            <?php endif; ?>
 
-                        <?php if (array_key_exists('eu_stance', $memberships)): ?>
-                            <p>
-                                <?php if ($memberships['eu_stance'] == 'Leave' || $memberships['eu_stance'] == 'Remain') { ?>
-                                    <strong><?= $full_name ?></strong> campaigned to <?= $memberships['eu_stance'] == 'Leave' ? 'leave' : 'remain in' ?> the European Union
-                                <?php } else { ?>
-                                    We don't know whether <strong><?= $full_name ?></strong> campaigned to leave, or stay in the European Union
-                                <?php } ?>
-                                <small>Source: <a href="https://www.bbc.co.uk/news/uk-politics-eu-referendum-35616946">BBC</a></small>
-                            </p>
-                        <?php endif; ?>
-
-                        <?php if (array_key_exists('topics_of_interest', $memberships)): ?>
-                            <ul class="comma-list">
-
-                                <?php foreach ($memberships['topics_of_interest'] as $topic): ?>
-                                <li><?= $topic ?></li>
-                                <?php endforeach; ?>
-
-                            </ul>
-                        <?php endif; ?>
+                            <?php if (array_key_exists('topics_of_interest', $memberships)): ?>
+                                <ul class="comma-list">
+                                    <?php foreach ($memberships['topics_of_interest'] as $topic): ?>
+                                    <li><?= $topic ?></li>
+                                    <?php endforeach; ?>
+                                </ul>
+                            <?php endif; ?>
+                        </div>
                     <?php endif; ?>
-
-                </div>
 
                 <?php include('_profile_footer.php'); ?>
 


### PR DESCRIPTION
This builds on the new committees/appg view to bring more details into the page.

## Committees

Using the new json produced by https://github.com/mysociety/parlparse/pull/233 ([can use this one](https://gist.github.com/ajparsons/8c5fbc1bdc1520ea88cf4ad33581ee9a)) - we can pull the purpose and URLs for committees into the main flow of the page.

Note: This is currently loaded as a whole json and put in memcache - good or bad approach?

## APPGs

Here (because are so many more), the purpose of the group is put inside a details box (which can also then include details about the source of the membership information).

I've turned back on the AI scraper results after spot checking a few (something the above makes easier). 

## Open letters

Bit of handholding text here and added link to form to report letters.

## Misc

A few fixs to the typehinting approach.


