### PR TITLE
add annotations permission to accounts

### DIFF
--- a/classes/User.php
+++ b/classes/User.php
@@ -68,6 +68,8 @@ class User {
         $data["status"] = $user->status();
         $data["facebook_id"] = $user->facebook_id();
         $data['facebook_user'] = $user->facebook_user();
+        $data['can_annotate'] = $user->can_annotate();
+        $data['organisation'] = $user->organisation();
         return $data;
     }
 

--- a/classes/User.php
+++ b/classes/User.php
@@ -118,6 +118,9 @@ class User {
         if ($this_page == "otheruseredit") {
             $details["user_id"] = trim(get_http_var("u"));
             $details["status"] = trim(get_http_var("status"));
+            $details["can_annotate"] = get_http_var("can_annotate") == "true" ? true : false;
+            $details["organisation"] = trim(get_http_var("organisation"));
+
 
             if (get_http_var("deleted") != "") {
                 $deleted = get_http_var("deleted");

--- a/db/0029-add-user-annotation-permission.sql
+++ b/db/0029-add-user-annotation-permission.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `users`
+  ADD COLUMN `can_annotate` tinyint(1) NOT NULL default 0,
+  ADD COLUMN `organisation` varchar(255) default NULL;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -442,6 +442,8 @@ CREATE TABLE `users` (
   `api_key` char(24) default NULL,
   `facebook_id` char(24) default NULL,
   `facebook_token` char(200) default NULL,
+  `can_annotate` tinyint(1) NOT NULL default 0,
+  `organisation` varchar(255) default NULL,
   PRIMARY KEY  (`user_id`),
   UNIQUE KEY `api_key` (`api_key`),
   KEY `email` (`email`)

--- a/locale/TheyWorkForYou.pot
+++ b/locale/TheyWorkForYou.pot
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-09-24 10:37+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -215,27 +215,27 @@ msgstr ""
 msgid "Learn more about TheyWorkForYou"
 msgstr ""
 
-#: classes/User.php:196
+#: classes/User.php:201
 msgid "Please enter a password"
 msgstr ""
 
-#: classes/User.php:199 classes/User.php:215
+#: classes/User.php:204 classes/User.php:220
 msgid "Please enter at least six characters"
 msgstr ""
 
-#: classes/User.php:203
+#: classes/User.php:208
 msgid "Please enter a password again"
 msgstr ""
 
-#: classes/User.php:207 classes/User.php:219
+#: classes/User.php:212 classes/User.php:224
 msgid "The passwords did not match. Please try again."
 msgstr ""
 
-#: classes/User.php:227
+#: classes/User.php:232
 msgid "Sorry, this isn't a valid UK postcode."
 msgstr ""
 
-#: classes/User.php:235
+#: classes/User.php:240
 msgid "Sorry, we could not find an MP for that postcode."
 msgstr ""
 
@@ -3022,7 +3022,7 @@ msgid "We use this to show you information about your MP."
 msgstr ""
 
 #: www/includes/easyparliament/templates/html/user/form.php:29
-#: www/includes/easyparliament/templates/html/user/form.php:192
+#: www/includes/easyparliament/templates/html/user/form.php:204
 msgid "Update details"
 msgstr ""
 
@@ -3064,17 +3064,21 @@ msgstr ""
 msgid "Optional and public"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/user/form.php:163
+#: www/includes/easyparliament/templates/html/user/form.php:152
+msgid "Organisation:"
+msgstr ""
+
+#: www/includes/easyparliament/templates/html/user/form.php:175
 msgid "Can we send you occasional emails about TheyWorkForYou.com?"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/user/form.php:164
+#: www/includes/easyparliament/templates/html/user/form.php:176
 msgid ""
 "Do you want to receive our newsletter about our wider democracy work, "
 "including our research and campaigns?"
 msgstr ""
 
-#: www/includes/easyparliament/templates/html/user/form.php:165
+#: www/includes/easyparliament/templates/html/user/form.php:177
 #: www/includes/easyparliament/templates/html/user/join.php:92
 msgid ""
 "Do you want to receive the monthly newsletter from mySociety, with news on "

--- a/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
+++ b/locale/cy_GB.UTF-8/LC_MESSAGES/TheyWorkForYou.po
@@ -200,27 +200,27 @@ msgstr "Cyfrannu"
 msgid "Learn more about TheyWorkForYou"
 msgstr "Ynglŷn â TheyWorkForYou"
 
-#: classes/User.php:196
+#: classes/User.php:201
 msgid "Please enter a password"
 msgstr "Rhowch eich cyfrinair"
 
-#: classes/User.php:199 classes/User.php:215
+#: classes/User.php:204 classes/User.php:220
 msgid "Please enter at least six characters"
 msgstr "Mae angen o leiaf chwe mewnbwn"
 
-#: classes/User.php:203
+#: classes/User.php:208
 msgid "Please enter a password again"
 msgstr "Nodwch eich cyfrinair eto"
 
-#: classes/User.php:207 classes/User.php:219
+#: classes/User.php:212 classes/User.php:224
 msgid "The passwords did not match. Please try again."
 msgstr "Mae’n rhaid i’r cyfrineiriau fod yr un fath. Ceisiwch eto os gwelwch yn dda."
 
-#: classes/User.php:227
+#: classes/User.php:232
 msgid "Sorry, this isn't a valid UK postcode."
 msgstr "Mae'n ddrwg gennym, nid yw hwn yn gôd post dilys"
 
-#: classes/User.php:235
+#: classes/User.php:240
 msgid "Sorry, we could not find an MP for that postcode."
 msgstr "Mae'n ddrwg gennym, ni allwn ddod o hyd i AS ar gyfer y côd post hwnnw."
 
@@ -2859,7 +2859,7 @@ msgid "We use this to show you information about your MP."
 msgstr "Rydym yn defnyddio hyn i ddangos gwybodaeth i chi am eich AS."
 
 #: www/includes/easyparliament/templates/html/user/form.php:29
-#: www/includes/easyparliament/templates/html/user/form.php:192
+#: www/includes/easyparliament/templates/html/user/form.php:204
 msgid "Update details"
 msgstr "Diweddaru manylion"
 
@@ -2900,15 +2900,19 @@ msgstr "Eich gwefan:"
 msgid "Optional and public"
 msgstr "Dewisol a chyhoeddus"
 
-#: www/includes/easyparliament/templates/html/user/form.php:163
+#: www/includes/easyparliament/templates/html/user/form.php:152
+msgid "Organisation:"
+msgstr "Sefydliad"
+
+#: www/includes/easyparliament/templates/html/user/form.php:175
 msgid "Can we send you occasional emails about TheyWorkForYou.com?"
 msgstr "A ydych chi am dderbyn e-byst achlysurol ynglŷn â TheyWorkForYou.com?"
 
-#: www/includes/easyparliament/templates/html/user/form.php:164
+#: www/includes/easyparliament/templates/html/user/form.php:176
 msgid "Do you want to receive our newsletter about our wider democracy work, including our research and campaigns?"
 msgstr "A ydych chi am dderbyn ein cylchlythyr am ein gwaith democratiaeth ehangach, gan gynnwys ein hymchwil a'n hymgyrchoedd?"
 
-#: www/includes/easyparliament/templates/html/user/form.php:165
+#: www/includes/easyparliament/templates/html/user/form.php:177
 #: www/includes/easyparliament/templates/html/user/join.php:92
 msgid "Do you want to receive the monthly newsletter from mySociety, with news on TheyWorkForYou and our other projects?"
 msgstr "Ydych chi am dderbyn y cylchlythyr misol gan mySociety, gyda newyddion am TheyWorkForYou a'n prosiectau eraill?"

--- a/www/includes/easyparliament/templates/html/user/form.php
+++ b/www/includes/easyparliament/templates/html/user/form.php
@@ -142,6 +142,18 @@
                   </div>
 
                   <div class="row">
+                  <span class="label"><label for="can_annotate">Can add annotations?</label></span>
+                  <span class="formw"><input type="checkbox" name="can_annotate[]" id="can_annotate" value="true"
+                    <?= isset($can_annotate) && $can_annotate == true ? 'checked' : '' ?>
+                  ></span>
+                  </div>
+
+                  <div class="row">
+                  <span class="label"><label for="organisation"><?= gettext('Organisation:') ?></label></span>
+                  <span class="formw"><input type="text" name="organisation" id="organisation" value="<?= _htmlentities($organisation) ?>" maxlength="255" size="30" class="form"></span>
+                  </div>
+
+                  <div class="row">
                   <span class="label"><label for="confirmed">Confirmed?</label></span>
                   <span class="formw"><input type="checkbox" name="confirmed[]" id="confirmed" value="true"
                     <?= isset($confirmed) && $confirmed == true ? 'checked' : '' ?>

--- a/www/includes/easyparliament/user.php
+++ b/www/includes/easyparliament/user.php
@@ -779,6 +779,7 @@ class USER {
         $confirmedsql = "";
         $statussql = "";
         $emailsql = '';
+        $annotatesql = '';
 
         $params = [];
 
@@ -827,6 +828,12 @@ class USER {
 
         }
 
+        if (isset($details["can_annotate"])) {
+            $annotatesql = "can_annotate = :can_annotate, organisation = :organisation, ";
+            $params[':can_annotate'] = $details['can_annotate'] ? 1 : 0;
+            $params[':organisation'] = $details['organisation'];
+        }
+
         if (isset($details['email']) && $details['email']) {
             $emailsql = "email = :email, ";
             $params[':email'] = $details['email'];
@@ -841,7 +848,8 @@ class USER {
                                 . $deletedsql
                                 . $confirmedsql
                                 . $emailsql
-                                . $statussql . "
+                                . $statussql
+                                . $annotatesql . "
                                 optin       = :optin
                         WHERE   user_id     = :user_id
                         ", array_merge($params, [

--- a/www/includes/easyparliament/user.php
+++ b/www/includes/easyparliament/user.php
@@ -70,6 +70,8 @@ class USER {
     public $confirmed = '';        // boolean - Has the user confirmed via email?
     public $facebook_id = '';      // Facebook ID for users who login with FB
     public $facebook_token = '';   // Facebook token for users who login with FB
+    public $can_annotate = false;  // Can the user add annotations
+    public $organisation = '';     // The organisation the user belongs to
     // Don't use the status to check access privileges - use the is_able_to() function.
     public $status = "Viewer";
 
@@ -106,7 +108,9 @@ class USER {
                                 deleted,
                                 confirmed,
                                 facebook_id,
-                                facebook_token
+                                facebook_token,
+                                can_annotate,
+                                organisation
                         FROM    users
                         WHERE   user_id = :user_id",
             [':user_id' => $user_id]
@@ -131,8 +135,10 @@ class USER {
             $this->registrationip       = $q["registrationip"];
             $this->optin                = $q["optin"];
             $this->status               = $q["status"];
+            $this->organisation         = $q["organisation"];
             $this->deleted = $q["deleted"] == 1 ? true : false;
             $this->confirmed = $q["confirmed"] == 1 ? true : false;
+            $this->can_annotate = $q["can_annotate"] == 1 ? true : false;
 
             return true;
 
@@ -726,6 +732,13 @@ class USER {
         return $this->confirmed;
     }
 
+    public function can_annotate() {
+        return $this->can_annotate;
+    }
+
+    public function organisation() {
+        return $this->organisation;
+    }
 
     public function postcode_is_set() {
         // So we can tell if the, er, postcode is set or not.


### PR DESCRIPTION
Adds a `can_annotate` boolean to users, plus updates the admin front end to allow editing this.

Also adds an `organisation` column to users and updates associated properties in user mode.

Fixes 1909