### PR TITLE
Allow annotations to use Markdown

### DIFF
--- a/classes/User.php
+++ b/classes/User.php
@@ -90,9 +90,6 @@ class User {
 
             $details["url"] = trim(get_http_var("url"));
 
-            $details["can_annotate"] = get_http_var("can_annotate") == "true" ? true : false;
-            $details["organisation"] = trim(get_http_var("organisation"));
-
             $optin_service = get_http_var("optin_service") == "true" ? true : false;
             $optin_stream = get_http_var("optin_stream") == "true" ? true : false;
             $optin_org = get_http_var("optin_org") == "true" ? true : false;

--- a/tests/CommentTest.php
+++ b/tests/CommentTest.php
@@ -37,19 +37,27 @@ It also spans multiple lines.");
 
     /**
      * Makes sure a comment is correctly rendered, testing HTML cleaning.
-     */
+     * As we're now doing markdown we don't do this anymore
     public function testHTMLCleaningPrepareCommentForDisplay() {
         $comment = new COMMENT(1);
-        $this->assertEquals(prepare_comment_for_display($comment->body()), "This is a test comment, including <a href=\"https://www.theyworkforyou.com\" rel=\"nofollow\">https://www.theyworkforyou.com</a> <a href=\"https://www.theyworkforyou.com\">links</a>, email addresses like <a href=\"mailto:test@theyworkforyou.com\">test@theyworkforyou.com</a>, <b>bold</b>, <i>italics</i>, and stray &lt; brackets to ensure they're rendered correctly.<br>
-<br>
-It also spans multiple lines.");
+        $this->assertEquals(prepare_comment_for_display($comment->body()), "<p>This is a test comment, including <a href=\"https://www.theyworkforyou.com\" rel=\"nofollow\">https://www.theyworkforyou.com</a> <a href=\"https://www.theyworkforyou.com\">links</a>, email addresses like <a href=\"mailto:test@theyworkforyou.com\">test@theyworkforyou.com</a>, <b>bold</b>, <i>italics</i>, and stray &lt; brackets to ensure they're rendered correctly.</p>
+<p>It also spans multiple lines.</p>");
     }
+     */
 
     public function testCommentWithVeryLongLink() {
         $comment = new COMMENT(2);
         $this->assertEquals(
             prepare_comment_for_display($comment->body()),
-            '<a href="https://www.theyworkforyou.example.org/this/is/a/coment/with/a/very/long/URL/that/contains/http://something/as/it/is/an/archive" rel="nofollow">https://www.theyworkforyou.example.org/this/is/a/coment/with...</a>'
+            '<p><a href="https://www.theyworkforyou.example.org/this/is/a/coment/with/a/very/long/URL/that/contains/http://something/as/it/is/an/archive" rel="nofollow">https://www.theyworkforyou.example.org/this/is/a/coment/with...</a></p>'
+        );
+    }
+
+    public function testMarkdownInComments() {
+        $comment = new COMMENT(3);
+        $this->assertEquals(
+            prepare_comment_for_display($comment->body()),
+            '<p>This is a comment with <strong>bold</strong> and <a href="https://www.theyworkforyou.com" rel="nofollow">a link</a>.</p>'
         );
     }
 
@@ -185,11 +193,10 @@ It also spans multiple lines.", $comment->body());
     }
 
     public function testHTMLCleaningWithNonASCIIChars() {
-        // this file is UTF-8 but odd comments are sent up looking like Windows-1252 so we need the
-        // input text to be encoded thus otherwise the output is different
+        // everything is UTF-8 so we don't need to encode
         $text = "This is a curly  ’ apostrophe. Is 2 &lt; 3 ø ø €  ’ « ö à";
 
-        $this->assertEquals("This is a curly  &rsquo; apostrophe. Is 2 &lt; 3 &oslash; &oslash; &euro;  &rsquo; &laquo; &ouml; &agrave;", prepare_comment_for_display($text));
+        $this->assertEquals("<p>This is a curly  ’ apostrophe. Is 2 &lt; 3 ø ø €  ’ « ö à</p>", prepare_comment_for_display($text));
     }
 
 }

--- a/tests/_fixtures/comment.xml
+++ b/tests/_fixtures/comment.xml
@@ -40,6 +40,16 @@ It also spans multiple lines.</field>
 		<field name="visible">1</field>
 		<field name="original_gid" xsi:nil="true" />
 	</row>
+	<row>
+		<field name="comment_id">3</field>
+		<field name="user_id">1</field>
+		<field name="epobject_id">1</field>
+		<field name="body">This is a comment with **bold** and [a link](https://www.theyworkforyou.com).</field>
+		<field name="posted" xsi:nil="true" />
+		<field name="modflagged" xsi:nil="true" />
+		<field name="visible">1</field>
+		<field name="original_gid" xsi:nil="true" />
+	</row>
 	</table_data>
 	<table_data name="consinfo">
 	</table_data>

--- a/www/includes/easyparliament/page.php
+++ b/www/includes/easyparliament/page.php
@@ -1072,7 +1072,8 @@ class PAGE {
 
                 <p><small>
 Please read our <a href="<?php echo $RULESURL->generate(); ?>"><strong>House Rules</strong></a> before posting an annotation.
-Annotations should be information that adds value to the contribution, not opinion, rants, or messages to a politician.
+Annotations should be information that adds value to the contribution, not opinion, rants, or messages to a politician. You
+can use basic Markdown to format comments.
 </small></p>
 
                 <form accept-charset="utf-8" action="<?php echo $ADDURL->generate(); ?>" method="post">


### PR DESCRIPTION
Replaces previous custom comment parsing code with Parsedown to enable markdown formatting. Enables parsedown's safe mode to strip anything suspicious. Also does a bit of post formatting to retain nofollow links and contraction of long raw urls.

Fixes #1912 