### PR TITLE
Remove signatures without person_id

### DIFF
--- a/src/twfy_tools/utils/personinfo.py
+++ b/src/twfy_tools/utils/personinfo.py
@@ -311,6 +311,9 @@ def load_statement_signatures(quiet: bool = False):
 
     df = pd.read_parquet(signatures_url)
 
+    # remove nan person_ids (this is non-parliamentary signatures)
+    df = df[~pd.isna(df["person_id"])]
+
     signature_counts = pd.pivot_table(
         df, values="person_id", index="statement_id", aggfunc="count"
     )


### PR DESCRIPTION
Storage now includes non-parliamentary signatures.
These can't be associated with people here.