### PR TITLE
Only fetch search counts if displaying

### DIFF
--- a/classes/AlertView/Standard.php
+++ b/classes/AlertView/Standard.php
@@ -74,11 +74,9 @@ class Standard extends \MySociety\TheyWorkForYou\AlertView {
 
         // Determine if we should fetch alert counts
         // We skip counts when in form workflows (step, mp_step, disambiguation)
-        $in_active_workflow = $this->data['step'] ||           // Alert creation wizard steps
-                             $this->data['mp_step'] ||         // MP alert creation
-                             ($this->data['members'] && is_array($this->data['members']) && count($this->data['members']) > 0) || // Member disambiguation
-                             (isset($this->data['constituencies']) && count($this->data['constituencies']) > 0) ||  // Constituency disambiguation
-                             ($this->data['alertsearch'] && !$this->data['results']); // Search disambiguation (but not if showing results)
+        $in_active_workflow = $this->data['step']           // Alert creation wizard steps
+                             || $this->data['mp_step']         // MP alert creation
+                             || $this->data['alertsearch']; // Search disambiguation (but not if showing results)
 
         $this->data['showing_main_alert_list'] = !$in_active_workflow;
 


### PR DESCRIPTION
The form steps are a bit slow on live when you have multiple existing alerts.

I think this is because of fetching the search results each time the form advances. This change doesn't fetch that when we're not displaying it.

Questions:

- the conditions are fiddly - I tried a more basic check to see if it's a POST request but that doesn't work when the form finally returns to the alert list (I used a code agent to put this condition list together). Is there a better place to indicate we're on the main alert page?
- is it better to intervene a few lines up and not get the alerts list at all? I wasn't sure if the form steps needed at least some of this information.