### PR TITLE
remove spurious extra MP alert sign up

### DIFF
--- a/www/includes/easyparliament/templates/html/alert/index.php
+++ b/www/includes/easyparliament/templates/html/alert/index.php
@@ -257,7 +257,6 @@
               <h3><?= gettext('Not quite right? Search again to refine your email alert.') ?></h3>
                 <?php } ?>
               <?php } ?>
-              <?php include '_mp_alert_form.php' ?>
             </div>
         </div>
         <?php } else { ?>


### PR DESCRIPTION
If you only matched a single name when trying to sign up for a representative alert you ended up with the signup form repeated twice, remove the second one.