### PR TITLE
Make banner button smaller on mobile

### DIFF
--- a/www/docs/style/sass/layout/_header.scss
+++ b/www/docs/style/sass/layout/_header.scss
@@ -428,13 +428,15 @@ $badge-horizontal-shadow-desktop: -8px;
             display: flex;
             flex-direction: column;
             align-items: center;
+            row-gap: 0.5em;
+            padding: 0.75em 1em;
+            font-size: 0.9rem;
         }
-        
+
         a.button {
             font-size: 0.75em !important;
-            padding: 0.4em 0.8em 0.35em 0.8em !important;
+            padding: 0.4em 0.8em 0.45em 0.8em !important;
             margin-left: 0 !important;
-            margin-top: 0.75em !important;
             display: inline-block;
         }
     }


### PR DESCRIPTION
I feel this is the slightly wrong approach but @lucascumsille might have a better one.

On mobile the banner button sits a bit weirdly:

<img width="373" height="142" alt="image" src="https://github.com/user-attachments/assets/de98f471-692e-4386-880d-cf0f8a8ddcc2" />

This shunts it to a newline and shrinks a bit (but still bigger footprint than currently)

<img width="375" height="131" alt="image" src="https://github.com/user-attachments/assets/f0383a65-da5f-442e-8c1c-aa6e4944882a" />