### PR TITLE
Annotation update leaves lastupdate alone

### DIFF
--- a/src/twfy_tools/utils/votes2db.py
+++ b/src/twfy_tools/utils/votes2db.py
@@ -498,7 +498,8 @@ def process_annotations():
     INSERT INTO persondivisionvotes (person_id, division_id, annotation)
     VALUES (%s, %s, %s)
     ON DUPLICATE KEY UPDATE
-        annotation = VALUES(annotation)
+        annotation = VALUES(annotation),
+        lastupdate = lastupdate;
     """
 
     BATCH = 1000


### PR DESCRIPTION
Current problem:

Syncing annotations into the persondivisionvotes table updates lastupdate - which the alerts in turn interprets as being a vote worth reporting on. 

We don't want annotations to be realerted. 

This tweak to the query keeps the lastupdate the same through the update. Tested on my local setup and lastupdate stays what they were previously set to. 