### PR TITLE
Show permission error for glossary pages

### DIFF
--- a/www/docs/addterm/index.php
+++ b/www/docs/addterm/index.php
@@ -9,9 +9,7 @@ $data = $view->display();
 
 // Check for permission errors
 if (isset($data['error']) && !isset($data['template_name'])) {
-    $PAGE->page_start();
-    echo '<p>' . $data['error'] . '</p>';
-    $PAGE->page_end();
+    $PAGE->error_message($data['error'], true);
     exit;
 }
 

--- a/www/docs/editterm/index.php
+++ b/www/docs/editterm/index.php
@@ -9,9 +9,7 @@ $data = $view->display();
 
 // Check for permission errors
 if (isset($data['error']) && !isset($data['template_name'])) {
-    $PAGE->page_start();
-    echo '<p>' . $data['error'] . '</p>';
-    $PAGE->page_end();
+    $PAGE->error_message($data['error'], true);
     exit;
 }
 


### PR DESCRIPTION
Currently if you don't have permission and try to get to additem it doesn't work - but it fails because the template_name is missing. 

This shows the error to the user and prevents the error message. 

(Normal admin approach in page_start not right here because in principle this could work for non admin users at some point). 