### PR TITLE
[alerts] Don't change step based on vector form

### DIFF
--- a/classes/AlertView/Standard.php
+++ b/classes/AlertView/Standard.php
@@ -829,7 +829,10 @@ class Standard extends \MySociety\TheyWorkForYou\AlertView {
             $this->data['delete_token'] = $this->data['alerts'][0]['token'];
         }
         if ($this->data['addword'] != '' || ($this->data['step'] && count($this->data['errors']) > 0)) {
-            $this->data["step"] = get_http_var('this_step');
+            // transitioning between add_vector_related step handled elsewhere
+            if (get_http_var('this_step') != "add_vector_related") {
+                $this->data["step"] = get_http_var('this_step');
+            }
         } elseif ($this->data['mp_step'] && count($this->data['errors']) > 0) {
             $this->data["mp_step"] = 'mp_alert';
         } else {


### PR DESCRIPTION
https://github.com/mysociety/theyworkforyou/pull/1965 was along the right lines. - the issue was the form setting the step after that extra processing. 

This just adds an exception for that specific step - given the progression from this step is handled elsewhere. 