### PR TITLE
increase length of alerts criteria to 1000 characters

### DIFF
--- a/db/0035-increase-alerts-criteria-length.sql
+++ b/db/0035-increase-alerts-criteria-length.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `alerts` MODIFY COLUMN `criteria` VARCHAR(1000) NOT NULL default '';

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -334,7 +334,7 @@ CREATE TABLE `future_people` (
 CREATE TABLE `alerts` (
   `alert_id` mediumint(8) unsigned NOT NULL auto_increment,
   `email` varchar(255) NOT NULL default '',
-  `criteria` varchar(255) NOT NULL default '',
+  `criteria` varchar(1000) NOT NULL default '',
   `deleted` tinyint(1) NOT NULL default '0',
   `registrationtoken` varchar(34) NOT NULL default '',
   `confirmed` tinyint(1) NOT NULL default '0',


### PR DESCRIPTION
now that we're using suggested terms alerts can be longer so we need to update the length of the criteria to cope

Part of #1970