### PR TITLE
[api] Do not double escape json values

### DIFF
--- a/tests/_fixtures/api.xml
+++ b/tests/_fixtures/api.xml
@@ -30,6 +30,16 @@
 	<table_data name="comments">
 	</table_data>
 	<table_data name="consinfo">
+		<row>
+			<field name="constituency">Amber Valley</field>
+			<field name="data_key">demographics</field>
+			<field name="data_value">{"population": 72000, "age_groups": {"18-35": 25, "36-55": 40, "56+": 35}}</field>
+		</row>
+		<row>
+			<field name="constituency">Amber Valley</field>
+			<field name="data_key">description</field>
+			<field name="data_value">A parliamentary constituency in Derbyshire</field>
+		</row>
 	</table_data>
 	<table_data name="constituency">
 	<row>
@@ -184,6 +194,21 @@
 		</row>
 	</table_data>
 	<table_data name="personinfo">
+		<row>
+			<field name="person_id">2</field>
+			<field name="data_key">test_json_field</field>
+			<field name="data_value">{"name": "Test Person", "location": "London", "interests": ["politics", "technology"]}</field>
+		</row>
+		<row>
+			<field name="person_id">2</field>
+			<field name="data_key">test_plain_field</field>
+			<field name="data_value">Simple text value</field>
+		</row>
+		<row>
+			<field name="person_id">3</field>
+			<field name="data_key">test_json_array</field>
+			<field name="data_value">[{"id": 1, "name": "Item 1"}, {"id": 2, "name": "Item 2"}]</field>
+		</row>
 	</table_data>
 	<table_data name="postcode_lookup">
       <row>

--- a/www/docs/api/api_functions.php
+++ b/www/docs/api/api_functions.php
@@ -213,6 +213,17 @@ function api_sidebar($subscription) {
     return $sidebar;
 }
 
+# Utility functions
+
+function api_decode_json($data_value) {
+    // Try to decode as JSON - if successful, use the decoded value
+    $json_decoded = json_decode($data_value, true);
+    if (json_last_error() === JSON_ERROR_NONE && $json_decoded !== null) {
+        return $json_decoded;
+    }
+    return $data_value;
+}
+
 # Output functions
 
 function api_output($arr, $last_mod = null) {

--- a/www/docs/api/api_functions.php
+++ b/www/docs/api/api_functions.php
@@ -223,6 +223,22 @@ function api_sidebar($subscription) {
     return $sidebar;
 }
 
+# Utility functions
+
+function api_decode_value($data_value) {
+    // For JSON-based outputs (json, default JS), decode stored JSON so it
+    // isn't double-encoded. For xml/php/rabx, return as-is.
+    $output = get_http_var('output');
+    if (in_array($output, ['xml', 'php', 'rabx'])) {
+        return $data_value;
+    }
+    $json_decoded = json_decode($data_value, true);
+    if (json_last_error() === JSON_ERROR_NONE && $json_decoded !== null) {
+        return $json_decoded;
+    }
+    return $data_value;
+}
+
 # Output functions
 
 function api_output($arr, $last_mod = null) {

--- a/www/docs/api/api_getConstituency.php
+++ b/www/docs/api/api_getConstituency.php
@@ -62,7 +62,13 @@ function _api_getConstituency_name($constituency) {
     $output = [];
     foreach ($q as $row) {
         $data_key = $row['data_key'];
-        $output[$data_key] = $row['data_value'];
+        // Check if data_value is valid JSON and we're outputting JSON format
+        if (get_http_var('output') == 'json') {
+            $data_value = api_decode_json($row['data_value']);
+        } else {
+            $data_value = $row['data_value'];
+        }
+        $output[$data_key] = $data_value;
     }
     ksort($output);
     $output['name'] = $constituency;

--- a/www/docs/api/api_getConstituency.php
+++ b/www/docs/api/api_getConstituency.php
@@ -62,7 +62,7 @@ function _api_getConstituency_name($constituency) {
     $output = [];
     foreach ($q as $row) {
         $data_key = $row['data_key'];
-        $output[$data_key] = $row['data_value'];
+        $output[$data_key] = api_decode_value($row['data_value']);
     }
     ksort($output);
     $output['name'] = $constituency;

--- a/www/docs/api/api_getMPsInfo.php
+++ b/www/docs/api/api_getMPsInfo.php
@@ -38,7 +38,13 @@ function _api_getMPsInfo_id($ids) {
                 continue;
             }
             $pid = $row['person_id'];
-            $output[$pid][$data_key] = $row['data_value'];
+            // Check if data_value is valid JSON and we're outputting JSON format
+            if (get_http_var('output') == 'json') {
+                $data_value = api_decode_json($row['data_value']);
+            } else {
+                $data_value = $row['data_value'];
+            }
+            $output[$pid][$data_key] = $data_value;
             $time = strtotime($row['lastupdate']);
             if ($time > $last_mod) {
                 $last_mod = $time;
@@ -61,7 +67,11 @@ function _api_getMPsInfo_id($ids) {
                 if (!isset($output[$pid]['by_member_id'][$mid])) {
                     $output[$pid]['by_member_id'][$mid] = [];
                 }
-                $output[$pid]['by_member_id'][$mid][$data_key] = $row['data_value'];
+
+                // Check if data_value is valid JSON and we're outputting JSON
+                $data_value = api_decode_json($row['data_value']);
+
+                $output[$pid]['by_member_id'][$mid][$data_key] = $data_value;
                 $time = strtotime($row['lastupdate']);
                 if ($time > $last_mod) {
                     $last_mod = $time;

--- a/www/docs/api/api_getMPsInfo.php
+++ b/www/docs/api/api_getMPsInfo.php
@@ -38,7 +38,8 @@ function _api_getMPsInfo_id($ids) {
                 continue;
             }
             $pid = $row['person_id'];
-            $output[$pid][$data_key] = $row['data_value'];
+            $data_value = api_decode_value($row['data_value']);
+            $output[$pid][$data_key] = $data_value;
             $time = strtotime($row['lastupdate']);
             if ($time > $last_mod) {
                 $last_mod = $time;
@@ -61,7 +62,8 @@ function _api_getMPsInfo_id($ids) {
                 if (!isset($output[$pid]['by_member_id'][$mid])) {
                     $output[$pid]['by_member_id'][$mid] = [];
                 }
-                $output[$pid]['by_member_id'][$mid][$data_key] = $row['data_value'];
+
+                $output[$pid]['by_member_id'][$mid][$data_key] = api_decode_value($row['data_value']);
                 $time = strtotime($row['lastupdate']);
                 if ($time > $last_mod) {
                     $last_mod = $time;


### PR DESCRIPTION
We're storing more json values in the personinfo table - this stops double escaping these values when requested as an json export from the api by trying to decode it first.