### PR TITLE
Fix link previews issues on social media platforms

### DIFF
--- a/www/docs/robots.txt
+++ b/www/docs/robots.txt
@@ -1,3 +1,35 @@
+# https://support.shareaholic.com/hc/en-us/articles/38798873799956-Social-Media-Content-Preview-Bots-to-Whitelist-in-Robots-txt
+# https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/
+
+User-agent: facebookexternalhit
+Disallow: /pwdata
+Disallow: /pwdata/scrapedxml
+Disallow: /pwdata/cmpages
+Disallow: /user
+Disallow: /vote
+
+User-agent: Twitterbot
+Disallow: /pwdata
+Disallow: /pwdata/scrapedxml
+Disallow: /pwdata/cmpages
+Disallow: /user
+Disallow: /vote
+
+User-agent: LinkedInBot
+Disallow: /pwdata
+Disallow: /pwdata/scrapedxml
+Disallow: /pwdata/cmpages
+Disallow: /user
+Disallow: /vote
+
+User-agent: Bluesky
+Disallow: /pwdata
+Disallow: /pwdata/scrapedxml
+Disallow: /pwdata/cmpages
+Disallow: /user
+Disallow: /vote
+
+# All other crawlers
 User-agent: *
 Disallow: /pwdata
 Disallow: /pwdata/scrapedxml

--- a/www/includes/easyparliament/templates/html/header.php
+++ b/www/includes/easyparliament/templates/html/header.php
@@ -32,7 +32,16 @@
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
   <?php } else { ?>
-    <meta property="og:image" content="https://<?= DOMAIN ?>/images/og/social_<?= $current_assembly ?? 'uk' ?>.png">
+    <?php
+      $og_image_assembly_map = [
+          'uk-commons' => 'uk',
+          'uk-lords' => 'uk',
+          'senedd' => 'wales',
+      ];
+      $og_assembly = $current_assembly ?? 'uk';
+      $og_image_suffix = $og_image_assembly_map[$og_assembly] ?? $og_assembly;
+    ?>
+    <meta property="og:image" content="https://<?= DOMAIN ?>/images/og/social_<?= $og_image_suffix ?>.png">
     <meta property="og:image:type" content="image/png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">


### PR DESCRIPTION
Fixes: https://github.com/mysociety/theyworkforyou/issues/2001

- This fixes errors for pages(`/senedd/`,`/peers,`, `/debates`) that were trying to use `social_senedd.png`, `social_uk-commons.png`, and `sociak_uk-lords.png`, none of those files existed. Instead it maps them to `social-wales` and `social-uk` respectively.
- Allow link preview for `/search` pages for Bluesky, Facebook, Linkedin and Twitter

