### PR TITLE
Carry PID across alerts steps

### DIFF
--- a/www/includes/easyparliament/templates/html/alert/_alert_step_review.php
+++ b/www/includes/easyparliament/templates/html/alert/_alert_step_review.php
@@ -11,6 +11,7 @@
                 <input type="hidden" name="keyword" value="<?= _htmlspecialchars($keyword) ?>">
                 <input type="hidden" name="exclusions" value="<?= _htmlspecialchars($exclusions) ?>">
                 <input type="hidden" name="representative" value="<?= _htmlspecialchars($representative) ?>">
+                <input type="hidden" name="pid" value="<?= _htmlspecialchars($pid) ?>">
                 <input type="hidden" name="search_section" value="<?= _htmlspecialchars($search_section) ?>">
                 <input type="hidden" name="email" id="email" value="<?= _htmlentities($email) ?>">
                 <input type="hidden" name="match_all" value="<?= $match_all ? 'on' : ''?>">

--- a/www/includes/easyparliament/templates/html/alert/_alert_step_vector.php
+++ b/www/includes/easyparliament/templates/html/alert/_alert_step_vector.php
@@ -8,6 +8,7 @@
                 <input type="hidden" name="keyword" value="<?= _htmlspecialchars($keyword) ?>">
                 <input type="hidden" name="exclusions" value="<?= _htmlspecialchars($exclusions) ?>">
                 <input type="hidden" name="representative" value="<?= _htmlspecialchars($representative) ?>">
+                <input type="hidden" name="pid" value="<?= _htmlspecialchars($pid) ?>">
                 <input type="hidden" name="search_section" value="<?= _htmlspecialchars($search_section) ?>">
                 <input type="hidden" name="email" id="email" value="<?= _htmlentities($email) ?>">
                 <input type="hidden" name="match_all" value="<?= $match_all ? 'on' : ''?>">


### PR DESCRIPTION
Ok, finally tracked down this error:

In the alerts page, enter a term and limit by an incomplete representative name that will match multiple valid options (e.g. "Chris").
You will then get a view that gives you a list of options to select from. Select an option.
This will take you to the related options page - but all navigation options will be broken - next and previous do not change the steps (the user is stuck there). This is not the case if you enter an exact match on representative. 

The reason for this is that selecting a representative passes a PID value back to the form process, but subsequent forms do not preserve the PID in a hidden field, meaning it just has access to the original incomplete representative name. This then triggers a multiple representatives error, and bounces back to the current step (add_vector_related) - but this doesn't have the right error handling (unlike the first step, which does). 

The solution is just to pass pid through as a hidden field - this means it keeps track of the selected representative and no errors are triggered. 
