### PR TITLE
Use Plaid Cymru's green for the party dot

### DIFF
--- a/www/docs/style/sass/pages/_search.scss
+++ b/www/docs/style/sass/pages/_search.scss
@@ -595,7 +595,7 @@ table.search-results-grouped {
   }
 
   &.plaid-cymru:before {
-    background-color: rgb(224, 134, 26);
+    background-color: rgb(0, 129, 66);
   }
 
   &.green:before {


### PR DESCRIPTION
Closes #2004.

Swaps the Plaid Cymru party dot from `rgb(224, 134, 26)` (orange) to `rgb(0, 129, 66)`, the party's official Pantone 348C green. That's what Parliament UK and the BBC use too.

@SarahmySociety noted the trade-off vs the Green Party already; the new shade is darker than the existing Green Party `rgb(106, 176, 35)` so they're still distinguishable next to each other.