### PR TITLE
Fix 'seperate' typos in two comments

### DIFF
--- a/classes/User.php
+++ b/classes/User.php
@@ -27,7 +27,7 @@ function calculateOptinValue($optin_service, $optin_stream, $optin_org) {
 }
 
 function extractOptinValues($value) {
-    // convert an integer into three seperate optin values ('Yes', 'No')
+    // convert an integer into three separate optin values ('Yes', 'No')
     return [
         'optin_service' => ($value & 1) ? "Yes" : "No",
         'optin_stream' => ($value & 2) ? "Yes" : "No",

--- a/classes/Utility/LibFilter.php
+++ b/classes/Utility/LibFilter.php
@@ -43,7 +43,7 @@ class LibFilter {
     ];
 
     #
-    # tags which must always have seperate opening and closing tags (e.g. "<b></b>")
+    # tags which must always have separate opening and closing tags (e.g. "<b></b>")
     #
 
     public $always_close = [


### PR DESCRIPTION
Caught these while skimming the source. Two unrelated comments, same misspelling.