### PR TITLE
Changes donation heart from blue to red

### DIFF
--- a/www/docs/style/sass/pages/_home.scss
+++ b/www/docs/style/sass/pages/_home.scss
@@ -276,6 +276,10 @@ input.homepage-search__button {
                         vertical-align: middle;
                         font-size: $icon-size;
                     }
+
+                    &.fi-heart {
+                        color: #dc3545;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes: https://github.com/mysociety/theyworkforyou/issues/2011

Changes `quick-links__item .fi-heart` from blue to red(same as the current donation button).

<img width="1163" height="688" alt="Screenshot 2026-05-20 at 14 37 48" src="https://github.com/user-attachments/assets/fff8649c-7223-4c07-9703-7e06ac50b3cf" />
