### PR TITLE
Allow empty/missing categories list in regmem

### DIFF
--- a/classes/DataClass/Regmem/Person.php
+++ b/classes/DataClass/Regmem/Person.php
@@ -21,8 +21,14 @@ class Person extends BaseModel {
     public string $person_id;
     public string $person_name;
     public string $published_date;
-    public CategoryList $categories;
+    public ?CategoryList $categories = null;
 
+    public function getCategories(): CategoryList {
+        if ($this->categories === null) {
+            return new CategoryList();
+        }
+        return $this->categories;
+    }
 
     public function intId(): int {
         // extract the last part of the person_id, which is the integer id
@@ -32,7 +38,7 @@ class Person extends BaseModel {
 
     public function allEntryIds(): array {
         $entryIds = [];
-        foreach ($this->categories as $category) {
+        foreach ($this->getCategories() as $category) {
             foreach ($category->entries as $entry) {
                 $entryIds[] = $entry->id;
                 foreach ($entry->sub_entries as $subEntry) {
@@ -44,7 +50,7 @@ class Person extends BaseModel {
     }
 
     public function getCategoryFromId(string $categoryId): Category {
-        foreach ($this->categories as $category) {
+        foreach ($this->getCategories() as $category) {
             if ($category->category_id === $categoryId) {
                 return $category;
             }

--- a/www/docs/interests/category.php
+++ b/www/docs/interests/category.php
@@ -59,13 +59,13 @@ try {
 $categories = [];
 
 foreach ($register->persons as $person) {
-    foreach ($person->categories as $category) {
+    foreach ($person->getCategories() as $category) {
         if (!isset($categories[$category->category_id])) {
             $categories[$category->category_id] = $category->category_name;
         }
     }
     if ($selected_category_id) {
-        $person->categories->limitToCategoryIds([$selected_category_id]);
+        $person->getCategories()->limitToCategoryIds([$selected_category_id]);
     }
 }
 

--- a/www/includes/easyparliament/templates/html/interests/category.php
+++ b/www/includes/easyparliament/templates/html/interests/category.php
@@ -66,7 +66,7 @@
                 <?php } ; ?>
 
                     <?php foreach ($register->persons as $person) { ?>
-                        <?php foreach ($person->categories as $person_category) { ?>
+                        <?php foreach ($person->getCategories() as $person_category) { ?>
                         <?php if ($person_category->category_id != $selected_category_id || $person_category->only_null_entries()) {
                             continue;
                         }; ?> 

--- a/www/includes/easyparliament/templates/html/interests/highlighted_2024.php
+++ b/www/includes/easyparliament/templates/html/interests/highlighted_2024.php
@@ -47,7 +47,7 @@
                                     <th>MP's comment</th>
                                 </tr>
                     <?php foreach ($register->persons as $person) { ?>
-                        <?php foreach($person->categories as $category) { ?>
+                        <?php foreach($person->getCategories() as $category) { ?>
                             <?php if ($category->category_id != $category_id) { ?>
                                 <?php continue; ?>
                             <?php }; ?>

--- a/www/includes/easyparliament/templates/html/mp/_person_navigation.php
+++ b/www/includes/easyparliament/templates/html/mp/_person_navigation.php
@@ -137,7 +137,7 @@
                         <nav class="subpage-content-list js-accordion" aria-label="<?= $register->displayChamber() ?> list">
                             <h3 class="js-accordion-button"><?= $register->displayChamber() ?></h3>
                             <ul class="js-accordion-content">
-                                <?php foreach ($register->categories as $category): ?>
+                                <?php foreach ($register->getCategories() as $category): ?>
                                     <?php if ($category->only_null_entries()): ?>
                                         <?php continue; ?>
                                     <?php endif; ?>
@@ -161,7 +161,7 @@
                 <?php $election_registers = [$register_2024_enriched]; ?>
                 <?php if (!empty($election_registers)): ?>
                      <?php foreach ($election_registers as $register) { ?>
-                                <?php foreach ($register->categories as $category) { ?>
+                                <?php foreach ($register->getCategories() as $category) { ?>
                                     <?php if ($category->only_null_entries()) { ?>
                                         <?php continue; ?>
                                     <?php }; ?>

--- a/www/includes/easyparliament/templates/html/mp/election_register.php
+++ b/www/includes/easyparliament/templates/html/mp/election_register.php
@@ -80,14 +80,14 @@ function humInt(int $num): string {
 
 
 
-                        <?php if ($register->categories->isEmpty()) { ?>
+                        <?php if ($register->getCategories()->isEmpty()) { ?>
                             <div class="panel register">
                                 <p><?= ucfirst($full_name) ?> did not declare any relevant donations or gifts in the September 2024 register. </p>
                                 <p>This means they did not declare any donations above £1,500 in value, or any gifts above £300 in value.</p>
                             </div>
                         <?php }; ?>
 
-                        <?php foreach ($register->categories as $category) { ?>
+                        <?php foreach ($register->getCategories() as $category) { ?>
                             <div class="panel register">    
                             <h2 id="category-<?= $register->chamber . $category->category_id ?>"><?= $category->emoji() ?> <?= $category->category_name ?></h2>
 

--- a/www/includes/easyparliament/templates/html/mp/register.php
+++ b/www/includes/easyparliament/templates/html/mp/register.php
@@ -34,7 +34,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                                         <a href="#register-<?= $chamber ?>"><?= $register->displayChamber() ?></a>
                                         <span class="register-last-updated">(<?= gettext('Last updated:') ?> <?= $register->published_date ?>)</span>
                                         <ul class="register-submenu">
-                                            <?php foreach ($register->categories as $category) { ?>
+                                            <?php foreach ($register->getCategories() as $category) { ?>
                                                 <?php if ($category->only_null_entries()) {
                                                     continue;
                                                 }; ?>
@@ -80,7 +80,7 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
 
                         <?php include INCLUDESPATH . 'easyparliament/templates/html/register/_toggle_buttons.php'; ?>
 
-                        <?php foreach ($register->categories as $category) { ?>
+                        <?php foreach ($register->getCategories() as $category) { ?>
                             <?php if ($category->only_null_entries()) {
                                 continue;
                             }; ?>


### PR DESCRIPTION
Mismatch between the regmem json format and the PHP parser - we weren't allowing an empty categories list under a person (something to investigate in the data generator, but it's valid under the schema). 

This sets a null default and adds a new helper function to ensure there's always a list (even if empty). 