### PR TITLE
Update redis settings

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -41,6 +41,7 @@ jobs:
           REDIS_MASTER_SET: mymaster
           REDIS_MASTER_PASSWORD: password
           REDIS_SENTINEL_QUORUM: 1
+          ALLOW_EMPTY_PASSWORD: 'yes'
         ports:
           - 26379:26379
         options: >-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,10 +96,11 @@ services:
   sentinel:
     image: bitnamisecure/redis-sentinel
     environment:
-      REDIS_MASTER_HOST: redis
-      REDIS_MASTER_SET: mymaster
-      REDIS_MASTER_PASSWORD: password
-      REDIS_SENTINEL_QUORUM: 1
+          REDIS_MASTER_HOST: redis
+          REDIS_MASTER_SET: mymaster
+          REDIS_MASTER_PASSWORD: password
+          REDIS_SENTINEL_QUORUM: 1
+          ALLOW_EMPTY_PASSWORD: 'yes'
     ports:
       - 26379:26379
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     image: memcached:1.6-alpine
 
   redis:
-    image: bitnami/redis
+    image: bitnamisecure/redis
     ports:
       - 6379:6379
     environment:
@@ -94,7 +94,7 @@ services:
       retries: 5
 
   sentinel:
-    image: bitnami/redis-sentinel
+    image: bitnamisecure/redis-sentinel
     environment:
       REDIS_MASTER_HOST: redis
       REDIS_MASTER_SET: mymaster


### PR DESCRIPTION
Addressing a set of (it turns out unrelated) problems in docker and the test suite. 

- moved the docker to use the same bitnamisecure repo as the tests.
- for both added ALLOW_EMPTY_PASSWORD to let the sentinel start