### PR TITLE
Better start/end memberships

### DIFF
--- a/classes/AlertView/Standard.php
+++ b/classes/AlertView/Standard.php
@@ -563,7 +563,7 @@ class Standard extends \MySociety\TheyWorkForYou\AlertView {
             foreach ($this->data['member_constituencies'] as $pid) {
                 try {
                     $MEMBER = new \MySociety\TheyWorkForYou\Member(['person_id' => $pid]);
-                    $cons[] = [ 'member' => $MEMBER, 'constituency' => $MEMBER->constituency, 'rep_name' => $MEMBER->getMostRecentMembership()['rep_name'] ];
+                    $cons[] = [ 'member' => $MEMBER, 'constituency' => $MEMBER->constituency, 'rep_name' => $MEMBER->getMostRecentGroupedMembership()['rep_name'] ];
                 } catch (\MySociety\TheyWorkForYou\MemberException $e) {
                     // do nothing
                 }
@@ -581,7 +581,7 @@ class Standard extends \MySociety\TheyWorkForYou\AlertView {
                         $q = $db->query("SELECT person_id FROM member WHERE constituency = :constituency AND house = :house and left_reason = 'still_in_office'", [':constituency' => $constituency, ':house' => $house]);
                         foreach ($q as $row) {
                             $MEMBER = new \MySociety\TheyWorkForYou\Member(['person_id' => $row['person_id'], 'house' => $house]);
-                            $cons[] = [ 'member' => $MEMBER, 'constituency' => $constituency, 'rep_name' => $MEMBER->getMostRecentMembership()['rep_name'] ];
+                            $cons[] = [ 'member' => $MEMBER, 'constituency' => $constituency, 'rep_name' => $MEMBER->getMostRecentGroupedMembership()['rep_name'] ];
                         }
 
                     } else {

--- a/classes/Member.php
+++ b/classes/Member.php
@@ -21,42 +21,12 @@ class Member extends \MEMBER {
      */
 
     public function isDead() {
-
-        $left_house = $this->left_house();
-
-        if ($left_house) {
-
-            // This member has left a house, and might be dead. See if they are.
-
-            // Types of house to test for death.
-            $house_types = [
-                HOUSE_TYPE_COMMONS,
-                HOUSE_TYPE_LORDS,
-                HOUSE_TYPE_SCOTLAND,
-                HOUSE_TYPE_NI,
-                HOUSE_TYPE_WALES,
-                HOUSE_TYPE_LONDON_ASSEMBLY,
-            ];
-
-            foreach ($house_types as $house_type) {
-
-                if (in_array($house_type, $left_house) and
-                    $left_house[$house_type]['reason'] and
-                    $left_house[$house_type]['reason'] == 'Died'
-                ) {
-
-                    // This member has left a house because of death.
-                    return true;
-                }
-
+        foreach ($this->grouped_memberships as $house => $data) {
+            if ($data['end_reason'] == 'Died') { # XXX Doesn't work if translated
+                return true;
             }
-
         }
-
-        // If we get this far the member hasn't left a house due to death, and
-        // is presumably alive.
         return false;
-
     }
 
     public function cohortPartyComparisonDirection() {
@@ -172,15 +142,7 @@ class Member extends \MEMBER {
      */
 
     public function getEntryDate($house = HOUSE_TYPE_COMMONS) {
-        $date_entered = '';
-
-        $entered_house = $this->entered_house($house);
-
-        if ($entered_house) {
-            $date_entered = $entered_house['date'];
-        }
-
-        return $date_entered;
+        return $this->grouped_memberships[$house][0]['start_date'] ?? '';
     }
 
     /*
@@ -192,15 +154,7 @@ class Member extends \MEMBER {
      */
 
     public function getLeftDate($house = HOUSE_TYPE_COMMONS) {
-        $date_left = '';
-
-        $left_house = $this->left_house($house);
-
-        if ($left_house) {
-            $date_left = $left_house['date'];
-        }
-
-        return $date_left;
+        return $this->grouped_memberships[$house][0]['end_date'] ?? '';
     }
 
 
@@ -244,27 +198,11 @@ class Member extends \MEMBER {
 
     }
 
-    public function getMostRecentMembership() {
-        $departures = $this->left_house();
-
-        usort(
-            $departures,
-            function ($a, $b) {
-                if ($a['date'] == $b['date']) {
-                    return 0;
-                } elseif ($a['date'] < $b['date']) {
-                    return -1;
-                } else {
-                    return 1;
-                }
-            }
-        );
-
-        $latest_membership = array_slice($departures, -1)[0];
-        $latest_membership['current'] = ($latest_membership['date'] == '9999-12-31');
-        $latest_entrance = $this->entered_house($latest_membership['house']);
-        $latest_membership['start_date'] = $latest_entrance['date'];
-        $latest_membership['end_date'] = $latest_membership['date'];
+    public function getMostRecentGroupedMembership() {
+        $house = $this->house_disp;
+        $memberships = $this->grouped_memberships[$house];
+        $latest_membership = $memberships[0];
+        $latest_membership['current'] = ($latest_membership['end_date'] == '9999-12-31');
         $latest_membership['rep_name'] = $this->getRepNameForHouse($latest_membership['house']);
 
         return $latest_membership;

--- a/classes/Renderer/Header.php
+++ b/classes/Renderer/Header.php
@@ -279,7 +279,7 @@ class Header {
         if ($this_page == "alert") {
             if ($pid = get_http_var('pid')) {
                 $person = new \MySociety\TheyWorkForYou\Member(['person_id' => $pid]);
-                $membership = $person->getMostRecentMembership();
+                $membership = $person->getMostRecentGroupedMembership();
                 $parliament = $membership['house'];
                 if ($parliament == 'ni') {
                     $selected_top_link['text'] = 'Northern Ireland';

--- a/classes/User.php
+++ b/classes/User.php
@@ -349,9 +349,9 @@ class User {
         $mp_data['name'] = $member->full_name();
         $mp_data['party'] = $member->party();
         $mp_data['constituency'] = $member->constituency();
-        $left_house = $member->left_house();
+        $membership = $member->grouped_memberships[$mp_house][0];
         $mp_data['former'] = '';
-        if ($left_house[$mp_house]['date'] != '9999-12-31') {
+        if ($membership['end_date'] != '9999-12-31') {
             $mp_data['former'] = 'former';
         }
         $mp_data['postcode'] = $user->postcode();

--- a/www/docs/divisions/division.php
+++ b/www/docs/divisions/division.php
@@ -39,6 +39,7 @@ $data['main_vote_mp'] = $main_vote_mp;
 # We don't want a "Your MP" box on PBC votes
 if (isset($MEMBER) && $division_votes['house'] != 'pbc') {
     $mp_vote = $divisions->getDivisionResultsForMember($vote, $MEMBER->person_id());
+    $left_house = $MEMBER->left_house($division_votes['house_number']);
     if ($mp_vote) {
         $data['mp_vote'] = $mp_vote;
         $data['mp_vote']['with_majority'] = false;
@@ -48,7 +49,7 @@ if (isset($MEMBER) && $division_votes['house'] != 'pbc') {
     } else {
         if ($data['division']['date'] < $MEMBER->entered_house($division_votes['house_number'])['date']) {
             $data['before_mp'] = true;
-        } elseif ($data['division']['date'] > $MEMBER->left_house($division_votes['house_number'])['date']) {
+        } elseif ($data['division']['date'] > $left_house['date']) {
             $data['after_mp'] = true;
         }
     }
@@ -61,8 +62,7 @@ if (isset($MEMBER) && $division_votes['house'] != 'pbc') {
         'mp_url' => $MEMBER->url(),
         'image' => $MEMBER->image()['url'],
     ];
-    $left_house = $MEMBER->left_house();
-    if ($left_house[$division_votes['house_number']]['date'] != '9999-12-31') {
+    if ($left_house['date'] != '9999-12-31') {
         $mp_data['former'] = 'former';
     }
     $data['mp_data'] = $mp_data;

--- a/www/docs/mp/index.php
+++ b/www/docs/mp/index.php
@@ -323,7 +323,7 @@ $data['person_id'] = $MEMBER->person_id();
 $data['member_id'] = $MEMBER->member_id();
 
 $data['known_for'] = $known_for;
-$data['latest_membership'] = $MEMBER->getMostRecentMembership();
+$data['latest_membership'] = $MEMBER->getMostRecentGroupedMembership();
 
 $data['constituency'] = $MEMBER->constituency();
 $data['party'] = $MEMBER->party_text();
@@ -709,14 +709,13 @@ function person_error_page($message) {
  */
 
 function person_summary_description($MEMBER) {
-    $entered_house = $MEMBER->entered_house();
     $current_member = $MEMBER->current_member();
-    $left_house = $MEMBER->left_house();
+    $memberships = $MEMBER->grouped_memberships;
 
     if (in_array(HOUSE_TYPE_ROYAL, $MEMBER->houses())) {
         # Royal short-circuit
-        if (substr($entered_house[HOUSE_TYPE_ROYAL]['date'], 0, 4) == 1952) {
-            return '<strong>Acceded on ' . $entered_house[HOUSE_TYPE_ROYAL]['date_pretty']
+        if (substr($memberships[HOUSE_TYPE_ROYAL][0]['start_date'], 0, 4) == 1952) {
+            return '<strong>Acceded on ' . $memberships[HOUSE_TYPE_ROYAL][0]['start_date_pretty']
                 . '<br>Coronated on 2 June 1953</strong></li>';
         } else {
             return '';
@@ -724,12 +723,12 @@ function person_summary_description($MEMBER) {
     }
     $desc = '';
     foreach ($MEMBER->houses() as $house) {
-        if ($house == HOUSE_TYPE_COMMONS && isset($entered_house[HOUSE_TYPE_LORDS])) {
+        if ($house == HOUSE_TYPE_COMMONS && isset($memberships[HOUSE_TYPE_LORDS])) {
             # Same info is printed further down
             continue;
         }
 
-        $party = $left_house[$house]['party'];
+        $party = $memberships[$house][0]['party'];
         $party_br = '';
         if (preg_match('#^(.*?)\s*\((.*?)\)$#', $party, $m)) {
             $party_br = " ($m[2])";
@@ -750,6 +749,7 @@ function person_summary_description($MEMBER) {
                 $type = gettext('Member of the London Assembly');
             }
 
+            $const = $memberships[$house][0]['constituency'];
             if ($party == 'Speaker' || $party == 'Deputy Speaker') {
                 # XXX: Might go horribly wrong if something odd happens
                 if ($party == 'Deputy Speaker') {
@@ -759,14 +759,14 @@ function person_summary_description($MEMBER) {
                     $oparty = '';
                 }
                 if ($current_member[$house]) {
-                    $line = sprintf(gettext('%s, and %s %s for %s'), $pparty, $oparty, $type, $left_house[$house]['constituency']);
+                    $line = sprintf(gettext('%s, and %s %s for %s'), $pparty, $oparty, $type, $const);
                 } else {
-                    $line = sprintf(gettext('Former %s, and %s %s for %s'), $pparty, $oparty, $type, $left_house[$house]['constituency']);
+                    $line = sprintf(gettext('Former %s, and %s %s for %s'), $pparty, $oparty, $type, $const);
                 }
             } elseif ($current_member[$house]) {
-                $line = sprintf(gettext('%s %s %s for %s'), $pparty, $type, $party_br, $left_house[$house]['constituency']);
+                $line = sprintf(gettext('%s %s %s for %s'), $pparty, $type, $party_br, $const);
             } else {
-                $line = sprintf(gettext('Former %s %s %s for %s'), $pparty, $type, $party_br, $left_house[$house]['constituency']);
+                $line = sprintf(gettext('Former %s %s %s for %s'), $pparty, $type, $party_br, $const);
             }
         } elseif ($house == HOUSE_TYPE_LORDS && $party != 'Bishop') {
             if ($current_member[$house]) {

--- a/www/includes/easyparliament/member.php
+++ b/www/includes/easyparliament/member.php
@@ -20,6 +20,7 @@ class MEMBER {
     public $houses = [];
     public $entered_house = [];
     public $left_house = [];
+    public $grouped_memberships = [];
     public $extra_info = [];
     // Is this MP THEUSERS's MP?
     public $the_users_mp = false;
@@ -173,27 +174,38 @@ class MEMBER {
             $this->memberships[] = $row;
             $const = $row['constituency'] ? gettext($row['constituency']) : '';
             $party = $row['party'] ? gettext($row['party']) : '';
-            $entered_house = $row['entered_house'];
-            $left_house = $row['left_house'];
-            $entered_reason = $row['entered_reason'];
-            $left_reason = $row['left_reason'];
 
-            if (!isset($this->entered_house[$house]) || $entered_house < $this->entered_house[$house]['date']) {
+            $period = $this->membership_period_object($row);
+            if (!isset($this->grouped_memberships[$house])) {
+                $this->grouped_memberships[$house][] = $period;
+            } else {
+                $last = count($this->grouped_memberships[$house]) - 1;
+                $curr = $this->grouped_memberships[$house][$last];
+                $time_between = strtotime($curr['start_date']) - strtotime($period['end_date']);
+                if ($time_between < 86400 * 90) {
+                    $this->grouped_memberships[$house][$last]['start_date'] = $period['start_date'];
+                    $this->grouped_memberships[$house][$last]['start_date_pretty'] = $period['start_date_pretty'];
+                    $this->grouped_memberships[$house][$last]['start_reason'] = $period['start_reason'];
+                } else {
+                    $this->grouped_memberships[$house][] = $period;
+                }
+            }
+
+            if (!isset($this->entered_house[$house]) || $period['start_date'] < $this->entered_house[$house]['date']) {
                 $this->entered_house[$house] = [
-                    'date' => $entered_house,
-                    'date_pretty' => $this->entered_house_text($entered_house),
-                    'reason' => $this->entered_reason_text($entered_reason),
+                    'date' => $period['start_date'],
+                    'date_pretty' => $period['start_date_pretty'],
+                    'reason' => $period['start_reason'],
                     'house' => $house,
                 ];
             }
-
             if (!isset($this->left_house[$house])) {
                 $this->left_house[$house] = [
-                    'date' => $left_house,
-                    'date_pretty' => $this->left_house_text($left_house),
-                    'reason' => $this->left_reason_text($left_reason, $left_house, $house),
-                    'constituency' => $const,
-                    'party' => $this->party_text($party),
+                    'date' => $period['end_date'],
+                    'date_pretty' => $period['end_date_pretty'],
+                    'reason' => $period['end_reason'],
+                    'constituency' => $period['constituency'],
+                    'party' => $period['party'],
                     'house' => $house,
                 ];
             }
@@ -211,10 +223,10 @@ class MEMBER {
                 $this->person_id = $row['person_id'];
             }
 
-            if (($last_party && $party && $party != $last_party) || $left_reason == 'changed_party') {
+            if (($last_party && $party && $party != $last_party) || $period['end_reason'] == 'changed_party') {
                 $this->other_parties[] = [
                     'from' => $this->party_text($party),
-                    'date' => $left_house,
+                    'date' => $period['end_date'],
                 ];
             }
             $last_party = $party;
@@ -231,6 +243,22 @@ class MEMBER {
         // $this->load_extra_info();
 
         $this->set_users_mp();
+    }
+
+    private function membership_period_object($row) {
+        $const = $row['constituency'] ? gettext($row['constituency']) : '';
+        $party = $row['party'] ? gettext($row['party']) : '';
+        return [
+            'start_date' => $row['entered_house'],
+            'start_date_pretty' => $this->entered_house_text($row['entered_house']),
+            'start_reason' => $this->entered_reason_text($row['entered_reason']),
+            'end_date' => $row['left_house'],
+            'end_date_pretty' => $this->left_house_text($row['left_house']),
+            'end_reason' => $this->left_reason_text($row['left_reason'], $row['left_house'], $row['house']),
+            'constituency' => $const,
+            'party' => $this->party_text($party),
+            'house' => $row['house'],
+        ];
     }
 
     public function date_in_memberships($house, $date) {
@@ -668,10 +696,7 @@ class MEMBER {
         }
     }
 
-    public function entered_reason() {
-        return $this->entered_reason;
-    }
-    public function entered_reason_text($entered_reason) {
+    private function entered_reason_text($entered_reason) {
         if (isset($this->reasons()[$entered_reason])) {
             return $this->reasons()[$entered_reason];
         } else {
@@ -679,10 +704,7 @@ class MEMBER {
         }
     }
 
-    public function left_reason() {
-        return $this->left_reason;
-    }
-    public function left_reason_text($left_reason, $left_house, $house) {
+    private function left_reason_text($left_reason, $left_house, $house) {
         if (isset($this->reasons()[$left_reason])) {
             $left_reason = $this->reasons()[$left_reason];
             if (is_array($left_reason)) {
@@ -708,8 +730,8 @@ class MEMBER {
     public function current_member($house = 0) {
         $current = [];
         foreach (array_keys($this->houses_pretty()) as $h) {
-            $lh = $this->left_house($h);
-            $current[$h] = ($lh && $lh['date'] == '9999-12-31');
+            $lh = $this->grouped_memberships[$h][0] ?? null;
+            $current[$h] = ($lh && $lh['end_date'] == '9999-12-31');
         }
         if ($house) {
             return $current[$house];

--- a/www/includes/easyparliament/templates/html/alert/_mp_alert_form.php
+++ b/www/includes/easyparliament/templates/html/alert/_mp_alert_form.php
@@ -9,7 +9,7 @@
               <input type="hidden" name="email" value="<?= _htmlspecialchars($email) ?>">
               <input type="hidden" name="pid" value="<?= $constituency['member']->person_id() ?>">
               <input type="hidden" name="ignore_speaker_votes" value="<?= $ignore_speaker_votes ?>">
-              <?= $constituency['member']->full_name() ?> <?= _htmlspecialchars($constituency['member']->getMostRecentMembership()['rep_name']) ?>
+              <?= $constituency['member']->full_name() ?> <?= _htmlspecialchars($constituency['member']->getMostRecentGroupedMembership()['rep_name']) ?>
               (<?= _htmlspecialchars($constituency['constituency']) ?>)
               <input type="submit" class="button small" value="<?= gettext('Subscribe') ?>"></form>
           </li>

--- a/www/includes/easyparliament/templates/html/mp/_donation_banner.php
+++ b/www/includes/easyparliament/templates/html/mp/_donation_banner.php
@@ -6,7 +6,8 @@
 $current_page = isset($pagetype) && $pagetype ? $pagetype : 'profile';
 
 // Show banner to 20% of visitors - use a combination of IP, user agent, date, current page, and MP ID for daily rotation
-$user_identifier = $_SERVER['REMOTE_ADDR'] . $_SERVER['HTTP_USER_AGENT'] . date('Y-m-d') . $current_page . $person_id;
+$ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
+$user_identifier = $_SERVER['REMOTE_ADDR'] . $ua . date('Y-m-d') . $current_page . $person_id;
 $hash = crc32($user_identifier);
 $show_banner = ($hash % 100) < 20; // 20% chance
 $auto_expand = strtotime('2026-04-24') >= time(); // Automatically expand until 24 April 2026

--- a/www/includes/easyparliament/templates/html/search/person.php
+++ b/www/includes/easyparliament/templates/html/search/person.php
@@ -1,16 +1,26 @@
 <div class="search-result search-result--person">
     <img src="<?= $member->image()['url'] ?>" alt="">
     <h3 class="search-result__title"><a href="<?= $member->url() ?>"><?= $member->full_name() ?></a></h3>
-    <?php $latest_membership = $member->getMostRecentMembership(); ?>
-    <?php if ($latest_membership && $latest_membership['house'] != HOUSE_TYPE_ROYAL) { ?>
+<?php
+    $latest_membership = $member->getMostRecentGroupedMembership();
+    if ($latest_membership && $latest_membership['house'] != HOUSE_TYPE_ROYAL) { ?>
         <p class="search-result__description">
             <?= $latest_membership['current'] ? '' : 'Former' ?>
             <?= $latest_membership['party'] == 'Bishop' ? '' : $latest_membership['party'] ?>
             <?= $latest_membership['rep_name'] ?>
-            <?php if ($latest_membership['constituency']) { ?>
-                <?= sprintf(gettext('for %s'), $latest_membership['constituency']) ?>
-            <?php } ?>
-            (<?= format_date($latest_membership['start_date'], SHORTDATEFORMAT) ?> – <?= $latest_membership['current'] ? gettext('current') : format_date($latest_membership['end_date'], SHORTDATEFORMAT); ?>)
-        </p>
-    <?php } ?>
+            <?php if ($latest_membership['constituency']) {
+                printf(gettext('for %s'), $latest_membership['constituency']);
+            } ?>
+    (<?php
+        print $latest_membership['rep_name'] . ' ';
+        $out = [];
+        foreach ($member->grouped_memberships[$latest_membership['house']] as $mship) {
+            $out[] = sprintf('%s – %s', format_date($mship['start_date'], SHORTDATEFORMAT), $mship['end_date'] == '9999-12-31' ? gettext('current') : format_date($mship['end_date'], SHORTDATEFORMAT));
+        }
+        print join(', ', array_reverse($out));
+        ?>)
+    </p>
+<?php
+    }
+    ?>
 </div>


### PR DESCRIPTION
Use a new 'grouped memberships' (which joins together actual memberships if the ~~constituency is the same and~~ end/start dates are close enough) to cover distinct periods.
Use these in most places to allow better showing of 'current' start dates rather than only earliest start date.
Should fix Andy Burnham displaying as Labour MP for Makerfield ( 7 Jun 2001 – current) on search results page.

* Doesn't do anything with getEnterLeaveStrings which could be changed to loop through grouped_memberships and output all the relevant lines.
* ~~Makes things little bit worse (I guess) for everyone whose constituency changed in 2024 due to the boundary changes, because it now gives their start date as 2024 rather than when they actually started. But that does list the constituency name normally, so I guess is still accurate in that sense?~~