### PR TITLE
Group voting summaries by periods

### DIFF
--- a/classes/PolicyDistributionCollection.php
+++ b/classes/PolicyDistributionCollection.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Party Cohort Class
+ * Policy Distribution Collection Class
  *
  * @package TheyWorkForYou
  */
@@ -9,7 +9,7 @@
 namespace MySociety\TheyWorkForYou;
 
 /**
- * Policy DistributionCollection
+ * PolicyDistributionCollection
  * This brings together a set of a person's policy distributions for a given period and party.
  * It covers items in the same 'group' (health, social, etc)
  */
@@ -47,6 +47,35 @@ class PolicyDistributionCollection {
         $this->person_id = $person_id;
         $this->party_slug = $party_slug;
         $this->policy_pairs = $policy_pairs;
+    }
+
+    /**
+
+     * @return PolicyDistributionYearGroup[]
+     */
+    public function getPairsByRecencyBucket(int $bucket_size = 5, ?int $person_start_year = null, ?int $person_end_year = null): array {
+        // Votes can't be in the future, and shouldn't extend past when the
+        // person left office.
+        $current_year = (int) date('Y');
+        $cap_high = $person_end_year ? min($person_end_year, $current_year) : $current_year;
+
+        $buckets = [];
+        foreach ($this->policy_pairs as $pair) {
+            $year = $pair->member_distribution->end_year
+                ?: $pair->member_distribution->start_year;
+            $bucket_start_year = intdiv($year, $bucket_size) * $bucket_size;
+            $buckets[$bucket_start_year][] = $pair;
+        }
+        krsort($buckets); // most recent start year first
+
+        $result = [];
+        foreach ($buckets as $bucket_start_year => $pairs) {
+            shuffle($pairs); // keep random order within the bucket
+            $low = $person_start_year ? max($bucket_start_year, $person_start_year) : $bucket_start_year;
+            $high = min($bucket_start_year + $bucket_size - 1, $cap_high);
+            $result[] = new PolicyDistributionYearGroup($low, $high, $pairs);
+        }
+        return $result;
     }
 
     public function latestUpdate(array $latest_dates) {

--- a/classes/PolicyDistributionYearGroup.php
+++ b/classes/PolicyDistributionYearGroup.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Policy Distribution YearG roup
+ *
+ * @package TheyWorkForYou
+ */
+
+namespace MySociety\TheyWorkForYou;
+
+/**
+ * PolicyDistributionYearGroup
+ * A set of policy pairs that share a recency window (based on the year the
+ * member most recently voted on the policy). Used to add a time structure
+ * beneath each policy group in the all-time voting summary.
+ */
+
+class PolicyDistributionYearGroup {
+    public int $low_year;
+    public int $high_year;
+    /** @var PolicyDistributionPair[] */
+    public array $policy_pairs;
+
+    public function __construct(int $low_year, int $high_year, array $policy_pairs) {
+        $this->low_year = $low_year;
+        $this->high_year = $high_year;
+        $this->policy_pairs = $policy_pairs;
+    }
+
+    /**
+     * Time phrase describing the year group, designed to read after "Last voted on",
+     * e.g. "between 2015 and 2019" or "in 2024".
+     */
+    public function label(): string {
+        if ($this->low_year === $this->high_year) {
+            return "in {$this->high_year}";
+        } else {
+            return "between {$this->low_year} and {$this->high_year}";
+        }
+    }
+}

--- a/www/includes/easyparliament/templates/html/mp/votes.php
+++ b/www/includes/easyparliament/templates/html/mp/votes.php
@@ -151,15 +151,20 @@ include_once INCLUDESPATH . "easyparliament/templates/html/mp/header.php";
                                 How <?= $full_name ?> voted on <?= $segment->group_name ?>&nbsp;<small><a class="nav-anchor" href="<?= $member_url ?>/votes#<?= $segment->group_slug ?>">#</a></small>
                             </h2>
 
-                            <p>For votes held while they were in office:</p>
+                            <?php
+                            $person_start_year = !empty($entry_date) ? (int) $entry_date : null;
+                            $person_end_year = (!empty($leave_date) && (int) $leave_date !== 9999) ? (int) $leave_date : null;
+                            ?>
+                            <?php foreach ($segment->getPairsByRecencyBucket(5, $person_start_year, $person_end_year) as $bucket) { ?>
+                                <h3 class="vote-recency-heading">Last voted on <?= $bucket->label() ?></h3>
+                                <ul class="vote-descriptions">
+                                  <?php foreach ($bucket->policy_pairs as $policy_pair) {
 
-                            <ul class="vote-descriptions">
-                              <?php foreach ($segment->policy_pairs as $policy_pair) {
+                                      include '_vote_description.php';
 
-                                  include '_vote_description.php';
-
-                              } ?>
-                            </ul>
+                                  } ?>
+                                </ul>
+                            <?php } ?>
 
                             <p class="voting-information-provenance">
 


### PR DESCRIPTION
This PR adds a bit more time structure to the voting policies - the goal of this is to make recent votes easier to discover, give some structure to long running MPs, while reflecting that long ago votes can still be impactful today. 

- policies are grouped into five year periods (we don't have exact dates avalaible for start and end of policies, so can't sync exactly to parliaments). 
- start and end date displayed are adjusted depending on entry dates

Here's an example:

<img width="1604" height="1362" alt="image" src="https://github.com/user-attachments/assets/3004ea8b-81e6-4d64-981a-d50422555d29" />
