### PR TITLE
speaker affiliations are often duplicated on TWFY

### DIFF
--- a/www/includes/easyparliament/templates/html/section/_section_content.php
+++ b/www/includes/easyparliament/templates/html/section/_section_content.php
@@ -137,7 +137,7 @@ foreach ($data['rows'] as $speech) { ?>
                   foreach ($speaker['office'] as $off) {
                       $desc[] = $off['pretty'];
                   }
-                  $speaker_position = join(', ', $desc);
+                  $speaker_position = join(', ', array_unique($desc));
               } else {
                   $speaker_position = _htmlentities($speaker['party']);
                   if ($speaker['house'] == 1


### PR DESCRIPTION
dedup affiliations of speakers

Doesn't fix it in the database, but that's not easy to find without state, so simply dedup at display