### PR TITLE
Alerts creation can handle OR in section

### DIFF
--- a/classes/AlertView/Standard.php
+++ b/classes/AlertView/Standard.php
@@ -745,22 +745,8 @@ class Standard extends \MySociety\TheyWorkForYou\AlertView {
      */
     private function setUserData() {
         if (!isset($this->data['criteria'])) {
-            $criteria = $this->data['keyword'];
-            if ($criteria) {
-                if (!$this->data['match_all']) {
-                    $has_or = strpos($criteria, ' OR ') !== false;
-                    $missing_braces = strpos($criteria, '(') === false;
-
-                    if ($has_or && $missing_braces) {
-                        $criteria = "($criteria)";
-                    }
-                }
-                if ($this->data['search_section']) {
-                    $criteria .= " section:" . $this->data['search_section'];
-                }
-                if ($this->data['pid']) {
-                    $criteria .= " speaker:" . $this->data['pid'];
-                }
+            $criteria = \MySociety\TheyWorkForYou\Utility\Alert::detailsToCriteria($this->data);
+            if ($this->data['keyword']) {
                 $this->data['search_results']  = $this->getRecentResults($criteria);
             }
 

--- a/classes/Utility/Alert.php
+++ b/classes/Utility/Alert.php
@@ -29,19 +29,33 @@ class Alert {
 
         return $section_map[$section];
     }
-    public static function detailsToCriteria($details) {
+
+    /**
+     * Build search criteria from the alert fields.
+     * @param array $details
+     */
+    public static function detailsToCriteria(array $details): string {
         $criteria = [];
+        $keyword = $details['keyword'] ?? '';
+        $section = $details['search_section'] ?? '';
+        $pid = $details['pid'] ?? false;
 
-        if (!empty($details['keyword'])) {
-            $criteria[] = $details['keyword'];
+        if ($keyword) {
+            // If the keyword contains " OR " and there's going to be additional filters applied
+            // wrap this in brackets so the filters are applied over the top
+            $section_or_person = $pid || $section;
+            if ($section_or_person && strpos($keyword, ' OR ') !== false) {
+                $keyword = '(' . $keyword . ')';
+            }
+            $criteria[] = $keyword;
         }
 
-        if (!empty($details['pid'])) {
-            $criteria[] = 'speaker:' . $details['pid'];
+        if ($pid) {
+            $criteria[] = 'speaker:' . $pid;
         }
 
-        if (!empty($details['search_section'])) {
-            $criteria[] = 'section:' . $details['search_section'];
+        if ($section) {
+            $criteria[] = 'section:' . $section;
         }
 
         $criteria = join(' ', $criteria);

--- a/tests/AlertCriteriaTest.php
+++ b/tests/AlertCriteriaTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use MySociety\TheyWorkForYou\Utility\Alert;
+
+class AlertCriteriaTest extends PHPUnit\Framework\TestCase {
+    /**
+     * @dataProvider criteriaProvider
+     */
+    public function testCriteria($details, $expected) {
+        $this->assertSame($expected, Alert::detailsToCriteria($details));
+    }
+
+    public function criteriaProvider() {
+        return [
+            [['keyword' => 'A OR B', 'search_section' => 'wales'], '(A OR B) section:wales'],
+            [['keyword' => 'A OR B', 'pid' => 123], '(A OR B) speaker:123'],
+            [['keyword' => 'A OR B', 'pid' => 123, 'search_section' => 'wales'], '(A OR B) speaker:123 section:wales'],
+            [['keyword' => '(A OR B) OR C', 'search_section' => 'wales'], '((A OR B) OR C) section:wales'],
+            [['keyword' => '(A OR B) -C', 'search_section' => 'wales'], '((A OR B) -C) section:wales'],
+            [['keyword' => 'A B', 'search_section' => 'wales'], 'A B section:wales'],
+            [['keyword' => 'A OR B'], 'A OR B'],
+            [['pid' => 123], 'speaker:123'],
+            [[], ''],
+        ];
+    }
+}


### PR DESCRIPTION
Currently the alerts creation process does not work when doing OR keywords and putting it in a section.

`a or b section:c` - effectively is `a OR (b section:C)`

We did have a function that fixed this by wrapping the keywords in brackets, but it was only applied as part of the preview interface. 

This PR moves it to the common conversion function (also simplifying some of the logic). 

Once live we'll need a script to adjust historical ones (have a candidate for this)