### PR TITLE
Stop error on allowed length query

### DIFF
--- a/classes/AlertView/Standard.php
+++ b/classes/AlertView/Standard.php
@@ -472,7 +472,8 @@ class Standard extends \MySociety\TheyWorkForYou\AlertView {
             $errors['alertsearch'] = sprintf(gettext('That search appears to be invalid - %s - please check and try again.'), $se->error);
         }
 
-        if (strlen($text) > 255) {
+        // query can be up to 1000 - leaving some headroom
+        if (strlen($text) > 900) {
             $errors['alertsearch'] = gettext('That search is too long for our database; please split it up into multiple smaller alerts.');
         }
 


### PR DESCRIPTION
In principle we've allowed much longer queries since d7010246a4956ec088bcdb3ae169afbb557a339c

But we still had the error here which is my best candidate for where the errors are triggering in the alerts process (appearing after the related terms stage - which is a reasonable place for them to get longer).

Unless there's something I'm missing - it's safe to expand this. 

If we continue to get errors - need to have a go at getting the errors to at least surface in the right place. 